### PR TITLE
Allow init warning turnoff

### DIFF
--- a/src/Akka.Persistence.Linq2Db.Benchmark.DockerTests/Docker/Linq2Db/DockerLinq2DbPostgreSQLJournalPerfSpec.cs
+++ b/src/Akka.Persistence.Linq2Db.Benchmark.DockerTests/Docker/Linq2Db/DockerLinq2DbPostgreSQLJournalPerfSpec.cs
@@ -31,6 +31,7 @@ namespace Akka.Persistence.Linq2Db.BenchmarkTests.Docker.Linq2Db
                         use-clone-connection = true
                         tables.journal {{ 
                            auto-init = true
+                           warn-on-auto-init-fail = false
                            table-name = ""{2}"" 
                            }}
                     }}

--- a/src/Akka.Persistence.Linq2Db.Benchmark.DockerTests/Docker/Linq2Db/DockerLinq2DbSqlServerJournalPerfSpec.cs
+++ b/src/Akka.Persistence.Linq2Db.Benchmark.DockerTests/Docker/Linq2Db/DockerLinq2DbSqlServerJournalPerfSpec.cs
@@ -35,6 +35,7 @@ namespace Akka.Persistence.Linq2Db.BenchmarkTests.Docker.Linq2Db
                         use-clone-connection = true
                         tables.journal {{ 
                            auto-init = true
+                           warn-on-auto-init-fail = false
                            table-name = ""{2}"" 
                            }}
                     }}

--- a/src/Akka.Persistence.Linq2Db.Compatibility.DockerTests/SqlServer/SqlServerCompatibilitySpecConfig.cs
+++ b/src/Akka.Persistence.Linq2Db.Compatibility.DockerTests/SqlServer/SqlServerCompatibilitySpecConfig.cs
@@ -54,6 +54,7 @@ namespace Akka.Persistence.Linq2Db.CompatibilityTests.Docker.SqlServer
                         {{
                         snapshot {{ 
                            auto-init = true
+                           warn-on-auto-init-fail = false
                            table-name = ""{tablename}""    
                           }}
                         }}
@@ -94,6 +95,7 @@ namespace Akka.Persistence.Linq2Db.CompatibilityTests.Docker.SqlServer
                         table-compatibility-mode = ""sqlserver""
                         tables.journal {{ 
                            auto-init = true
+                           warn-on-auto-init-fail = false
                            table-name = ""{tablename}"" 
                            metadata-table-name = ""{metadatatablename}""
                            

--- a/src/Akka.Persistence.Linq2Db.Compatibility.Tests/Sqlite/SQLiteCompatibilitySpecConfig.cs
+++ b/src/Akka.Persistence.Linq2Db.Compatibility.Tests/Sqlite/SQLiteCompatibilitySpecConfig.cs
@@ -55,6 +55,7 @@ namespace Akka.Persistence.Linq2Db.CompatibilityTests
                         {{
                         snapshot {{ 
                            auto-init = true
+                           warn-on-auto-init-fail = false
                            table-name = ""{tablename}""    
                           }}
                         }}
@@ -94,6 +95,7 @@ namespace Akka.Persistence.Linq2Db.CompatibilityTests
                         table-compatibility-mode = ""sqlite""
                         tables.journal {{ 
                            auto-init = true
+                           warn-on-auto-init-fail = false
                            table-name = ""{tablename}"" 
                            metadata-table-name = ""{metadatatablename}""
                            

--- a/src/Akka.Persistence.Linq2Db.Journal.Query.Tests/SqliteAllEventsSpec.cs
+++ b/src/Akka.Persistence.Linq2Db.Journal.Query.Tests/SqliteAllEventsSpec.cs
@@ -36,6 +36,7 @@ namespace Akka.Persistence.Sqlite.Tests.Query
                      table-name = event_journal
                      metadata-table-name = journal_metadata
                      auto-init = true 
+                           warn-on-auto-init-fail = false
                    }} 
                 }}
                 connection-string = ""{connString}""
@@ -49,6 +50,7 @@ namespace Akka.Persistence.Sqlite.Tests.Query
                    journal {{
                    table-name = event_journal
                                    metadata-table-name = journal_metadata
+                           warn-on-auto-init-fail = false
                    }}
                 }}
             }}

--- a/src/Akka.Persistence.Linq2Db.Journal.Query.Tests/SqliteCurrentAllEventsSpec.cs
+++ b/src/Akka.Persistence.Linq2Db.Journal.Query.Tests/SqliteCurrentAllEventsSpec.cs
@@ -36,6 +36,7 @@ namespace Akka.Persistence.Sqlite.Tests.Query
                      table-name = event_journal
                      metadata-table-name = journal_metadata
                      auto-init = true 
+                           warn-on-auto-init-fail = false
                    }} 
                 }}
                 connection-string = ""{connString}""
@@ -49,6 +50,7 @@ namespace Akka.Persistence.Sqlite.Tests.Query
                    journal {{
                      table-name = event_journal
                      metadata-table-name = journal_metadata 
+                           warn-on-auto-init-fail = false
                    }} 
                 }}
             }}

--- a/src/Akka.Persistence.Linq2Db.Journal.Query.Tests/SqliteCurrentEventsByPersistenceIdSpec.cs
+++ b/src/Akka.Persistence.Linq2Db.Journal.Query.Tests/SqliteCurrentEventsByPersistenceIdSpec.cs
@@ -49,6 +49,7 @@ namespace Akka.Persistence.Sqlite.Tests.Query
                      table-name = event_journal
                      metadata-table-name = journal_metadata
                      auto-init = true 
+                           warn-on-auto-init-fail = false
                    }} 
                 }}
                 }}
@@ -66,6 +67,7 @@ namespace Akka.Persistence.Sqlite.Tests.Query
                          table-name = event_journal
                          metadata-table-name = journal_metadata
                          auto-init = true 
+                           warn-on-auto-init-fail = false
                        }} 
                     }}
                   }}

--- a/src/Akka.Persistence.Linq2Db.Journal.Query.Tests/SqliteCurrentEventsByTagSpec.cs
+++ b/src/Akka.Persistence.Linq2Db.Journal.Query.Tests/SqliteCurrentEventsByTagSpec.cs
@@ -51,6 +51,7 @@ namespace Akka.Persistence.Sqlite.Tests.Query
                 tables {{
                    journal {{
                      table-name = event_journal
+                           warn-on-auto-init-fail = false
                      metadata-table-name = journal_metadata
                      auto-init = true 
                    }} 
@@ -65,6 +66,7 @@ namespace Akka.Persistence.Sqlite.Tests.Query
                    journal {{
                      table-name = event_journal
                      metadata-table-name = journal_metadata
+                           warn-on-auto-init-fail = false
                    }} 
                 }}
             }}

--- a/src/Akka.Persistence.Linq2Db.Journal.Query.Tests/SqliteCurrentPersistenceIdsSpec.cs
+++ b/src/Akka.Persistence.Linq2Db.Journal.Query.Tests/SqliteCurrentPersistenceIdsSpec.cs
@@ -42,6 +42,7 @@ namespace Akka.Persistence.Sqlite.Tests.Query
                      table-name = event_journal
                      metadata-table-name = journal_metadata
                      auto-init = true 
+                           warn-on-auto-init-fail = false
                    }} 
                 }}
             }}
@@ -53,6 +54,7 @@ namespace Akka.Persistence.Sqlite.Tests.Query
                    journal {{
                      table-name = event_journal
                      metadata-table-name = journal_metadata 
+                           warn-on-auto-init-fail = false
                    }} 
                 }}
             }}

--- a/src/Akka.Persistence.Linq2Db.Journal.Query.Tests/SqliteEventsByPersistenceIdSpec.cs
+++ b/src/Akka.Persistence.Linq2Db.Journal.Query.Tests/SqliteEventsByPersistenceIdSpec.cs
@@ -40,6 +40,7 @@ namespace Akka.Persistence.Sqlite.Tests.Query
                      table-name = event_journal
                      metadata-table-name = journal_metadata
                      auto-init = true 
+                     warn-on-auto-init-fail = false
                    }} 
                 }}
             }}
@@ -51,6 +52,7 @@ namespace Akka.Persistence.Sqlite.Tests.Query
                    journal {{
                      table-name = event_journal
                      metadata-table-name = journal_metadata 
+                     warn-on-auto-init-fail = false
                    }} 
                 }}
             }}

--- a/src/Akka.Persistence.Linq2Db.Journal.Query.Tests/SqliteEventsByTagSpec.cs
+++ b/src/Akka.Persistence.Linq2Db.Journal.Query.Tests/SqliteEventsByTagSpec.cs
@@ -44,6 +44,7 @@ namespace Akka.Persistence.Sqlite.Tests.Query
                      table-name = event_journal
                      metadata-table-name = journal_metadata
                      auto-init = true 
+                     warn-on-auto-init-fail = false
                    }} 
                 }}
                 connection-string = ""{connString}""
@@ -57,6 +58,7 @@ namespace Akka.Persistence.Sqlite.Tests.Query
                    journal {{
                      table-name = event_journal
                      metadata-table-name = journal_metadata 
+                     warn-on-auto-init-fail = false
                    }} 
                 }}
             }}

--- a/src/Akka.Persistence.Linq2Db.Journal.Query.Tests/SqlitePersistenceIdsSpec.cs
+++ b/src/Akka.Persistence.Linq2Db.Journal.Query.Tests/SqlitePersistenceIdsSpec.cs
@@ -58,6 +58,7 @@ namespace Akka.Persistence.Sqlite.Tests.Query
                      table-name = event_journal
                      metadata-table-name = journal_metadata
                      auto-init = true 
+                     warn-on-auto-init-fail = false
                    }} 
                 }}
                     }}
@@ -81,6 +82,7 @@ namespace Akka.Persistence.Sqlite.Tests.Query
                    journal {{
                      table-name = event_journal
                      metadata-table-name = journal_metadata 
+                     warn-on-auto-init-fail = false
                    }} 
                 }}
                 write-plugin = ""akka.persistence.journal.linq2db""

--- a/src/Akka.Persistence.Sql.Linq2Db.DockerTests/Postgres/PostgreSQLJournalSpec.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db.DockerTests/Postgres/PostgreSQLJournalSpec.cs
@@ -34,6 +34,7 @@ namespace Akka.Persistence.Sql.Linq2Db.Tests.Docker.Postgres
                         use-clone-connection = true
                         tables.snapshot {{ 
                            auto-init = true
+                           warn-on-auto-init-fail = false
                            table-name = ""{2}"" 
                            }}
                     }}

--- a/src/Akka.Persistence.Sql.Linq2Db.DockerTests/Postgres/PostgreSQLJournalSpec.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db.DockerTests/Postgres/PostgreSQLJournalSpec.cs
@@ -92,6 +92,7 @@ namespace Akka.Persistence.Sql.Linq2Db.Tests.Docker.Postgres
                         use-clone-connection = true
                         tables.journal {{ 
                            auto-init = true
+                           warn-on-auto-init-fail = false
                            table-name = ""{2}"" 
                            }}
                     }}

--- a/src/Akka.Persistence.Sql.Linq2Db.DockerTests/Postgres/PostgreSQLJournalSpecConfig.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db.DockerTests/Postgres/PostgreSQLJournalSpecConfig.cs
@@ -18,7 +18,10 @@ plugin-dispatcher = ""akka.persistence.dispatchers.default-plugin-dispatcher""
 #connection-string = ""FullUri=file:test.db&cache=shared""
                         provider-name = ""{2}""
                         use-clone-connection = false
-                        tables.journal {{ auto-init = true }}
+                        tables.journal {{ 
+                           auto-init = true 
+                           warn-on-auto-init-fail = false
+                        }}
                     }}
                 }}
             }}

--- a/src/Akka.Persistence.Sql.Linq2Db.DockerTests/SqlServer/SQLServerJournalSpecConfig.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db.DockerTests/SqlServer/SQLServerJournalSpecConfig.cs
@@ -23,6 +23,7 @@ akka.persistence {{
                         #use-clone-connection = true
                         tables.journal {{ 
                            auto-init = true
+                           warn-on-auto-init-fail = false
                            table-name = ""{2}"" 
                            }}
                     }}
@@ -40,7 +41,7 @@ akka.persistence {{
     
     public static class SQLServerSnapshotSpecConfig
     {
-        public static string _journalBaseConfig = @"
+        public static string _snapshotBaseConfig = @"
 akka.persistence {{
                 publish-plugin-commands = on
                 snapshot-store {{
@@ -57,6 +58,7 @@ akka.persistence {{
                         #use-clone-connection = true
                         tables.snapshot {{ 
                            auto-init = true
+                           warn-on-auto-init-fail = false
                            table-name = ""{2}""
                            column-names {{
                            }} 
@@ -68,7 +70,7 @@ akka.persistence {{
         public static Configuration.Config Create(string connString, string tableName, int batchSize = 100, int parallelism = 2)
         {
             return ConfigurationFactory.ParseString(
-                string.Format(_journalBaseConfig,
+                string.Format(_snapshotBaseConfig,
                     typeof(Linq2DbSnapshotStore).AssemblyQualifiedName,
                     connString,tableName,batchSize, parallelism));
         }

--- a/src/Akka.Persistence.Sql.Linq2Db.Tests/Linq2DbJournalDefaultSpecConfig.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db.Tests/Linq2DbJournalDefaultSpecConfig.cs
@@ -16,6 +16,7 @@ akka.persistence.journal.linq2db{{
  tables{{
   journal{{
     auto-init = true
+    warn-on-auto-init-fail = false
     table-name = ""{journalTableName}""
     metadata-table-name = ""{metadatatablename}""
   }}
@@ -32,6 +33,7 @@ akka.persistence.journal.linq2db {{
  tables{{
   journal{{
     auto-init = true
+    warn-on-auto-init-fail = false
     table-name = ""{tablename}""
     metadata-table-name = ""{metadatatablename}""
   }}

--- a/src/Akka.Persistence.Sql.Linq2Db.Tests/Sqlite/SQLiteJournalSpecConfig.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db.Tests/Sqlite/SQLiteJournalSpecConfig.cs
@@ -21,7 +21,7 @@ plugin-dispatcher = ""akka.persistence.dispatchers.default-plugin-dispatcher""
                         provider-name = ""{2}""
                         parallelism = 1
                         max-row-by-row-size = 100
-                        tables.journal {{ 
+                        tables.snapshot {{ 
                           auto-init = true 
                           warn-on-auto-init-fail = false
                         }}

--- a/src/Akka.Persistence.Sql.Linq2Db.Tests/Sqlite/SQLiteJournalSpecConfig.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db.Tests/Sqlite/SQLiteJournalSpecConfig.cs
@@ -21,7 +21,10 @@ plugin-dispatcher = ""akka.persistence.dispatchers.default-plugin-dispatcher""
                         provider-name = ""{2}""
                         parallelism = 1
                         max-row-by-row-size = 100
-                        tables.journal {{ auto-init = true }}
+                        tables.journal {{ 
+                          auto-init = true 
+                          warn-on-auto-init-fail = false
+                        }}
                         use-clone-connection = ""{3}""
                     }}
                 }}
@@ -52,7 +55,10 @@ plugin-dispatcher = ""akka.persistence.dispatchers.default-plugin-dispatcher""
                         provider-name = ""{2}""
                         parallelism = 1
                         max-row-by-row-size = 100
-                        tables.journal {{ auto-init = true }}
+                        tables.journal {{ 
+                          auto-init = true
+                          warn-on-auto-init-fail = false 
+                        }}
                         use-clone-connection = ""{3}""
                     }}
                 }}

--- a/src/Akka.Persistence.Sql.Linq2Db/Config/JournalTableConfig.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db/Config/JournalTableConfig.cs
@@ -12,6 +12,7 @@ namespace Akka.Persistence.Sql.Linq2Db.Config
         public bool AutoInitialize { get; protected set; }
         public string MetadataTableName { get; protected set; }
         public MetadataTableColumnNames MetadataColumnNames { get; protected set; }
+        public bool WarnOnAutoInitializeFail { get; }
         public JournalTableConfig(Configuration.Config config)
         {
             
@@ -25,7 +26,12 @@ namespace Akka.Persistence.Sql.Linq2Db.Config
                 "journal_metadata");
             SchemaName = localcfg.GetString("schema-name", null);
             AutoInitialize = localcfg.GetBoolean("auto-init", false);
+            WarnOnAutoInitializeFail =
+                localcfg.GetBoolean("warn-on-auto-init-fail", true);
         }
+
+        
+
         protected bool Equals(JournalTableConfig other)
         {
             return Equals(ColumnNames, other.ColumnNames) &&
@@ -33,6 +39,7 @@ namespace Akka.Persistence.Sql.Linq2Db.Config
                    SchemaName == other.SchemaName &&
                    AutoInitialize == other.AutoInitialize &&
                    MetadataTableName == other.MetadataTableName &&
+                   WarnOnAutoInitializeFail == other.WarnOnAutoInitializeFail &&
                    Equals(MetadataColumnNames, other.MetadataColumnNames);
         }
 

--- a/src/Akka.Persistence.Sql.Linq2Db/Config/SnapshotTableConfiguration.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db/Config/SnapshotTableConfiguration.cs
@@ -17,7 +17,11 @@ namespace Akka.Persistence.Sql.Linq2Db.Config
             TableName = localcfg.GetString("table-name", "snapshot");
             SchemaName = localcfg.GetString("schema-name", null);
             AutoInitialize = localcfg.GetBoolean("auto-init", false);
+            WarnOnAutoInitializeFail =
+                localcfg.GetBoolean("warn-on-auto-init-fail", true);
         }
+
+        public bool WarnOnAutoInitializeFail { get; protected set; }
         public SnapshotTableColumnNames ColumnNames { get; protected set; }
         public string TableName { get; protected set; }
         public string SchemaName { get; protected set; }

--- a/src/Akka.Persistence.Sql.Linq2Db/Journal/DAO/ByteArrayJournalDao.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db/Journal/DAO/ByteArrayJournalDao.cs
@@ -32,7 +32,11 @@ namespace Akka.Persistence.Sql.Linq2Db.Journal.DAO
                 }
                 catch (Exception e)
                 {
-                    _logger.Warning(e,$"Could not Create Journal Table {_journalConfig.TableConfig.TableName} as requested by config.");
+                    if (_journalConfig.TableConfig.WarnOnAutoInitializeFail)
+                    {
+                        _logger.Warning(e,$"Could not Create Journal Table {_journalConfig.TableConfig.TableName} as requested by config.");    
+                    }
+                    
                 }
 
                 if (_journalConfig.DaoConfig.SqlCommonCompatibilityMode)
@@ -43,7 +47,10 @@ namespace Akka.Persistence.Sql.Linq2Db.Journal.DAO
                     }
                     catch (Exception e)
                     {
-                        _logger.Warning(e,$"Could not Create Journal Metadata Table {_journalConfig.TableConfig.TableName} as requested by config.");
+                        if (_journalConfig.TableConfig.WarnOnAutoInitializeFail)
+                        {
+                            _logger.Warning(e,$"Could not Create Journal Metadata Table {_journalConfig.TableConfig.TableName} as requested by config.");    
+                        }
                     }
                 }
             }

--- a/src/Akka.Persistence.Sql.Linq2Db/Snapshot/ByteArraySnapshotDao.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db/Snapshot/ByteArraySnapshotDao.cs
@@ -29,7 +29,10 @@ namespace Akka.Persistence.Sql.Linq2Db.Snapshot
                 }
                 catch (Exception e)
                 {
-                    _logger.Warning(e,$"Could not Create Snapshot Table {_snapshotConfig.TableConfig.TableName} as requested by config.");
+                    if (_snapshotConfig.TableConfig.WarnOnAutoInitializeFail)
+                    {
+                        _logger.Warning(e,$"Could not Create Snapshot Table {_snapshotConfig.TableConfig.TableName} as requested by config.");    
+                    }
                 }
             }
         }

--- a/src/Akka.Persistence.Sql.Linq2Db/persistence.conf
+++ b/src/Akka.Persistence.Sql.Linq2Db/persistence.conf
@@ -230,6 +230,12 @@
           #if delete-compatibility-mode is false, only journal table will be created.
           auto-init = true
 
+          #if true, a warning will be logged
+          #if auto-init of tables fails.
+          #set to false if you don't want this warning logged
+          #perhaps if running CI tests or similar.
+          warn-on-auto-init-fail = true
+
           table-name = "journal"
           metadata-table-name = "journal_metadata"
 

--- a/src/Akka.Persistence.Sql.Linq2Db/snapshot.conf
+++ b/src/Akka.Persistence.Sql.Linq2Db/snapshot.conf
@@ -31,6 +31,11 @@
                 table-name = "snapshot"
                 #if true, tables will attempt to be created.
                 auto-init = true
+                #if true, a warning will be logged
+                #if auto-init of tables fails.
+                #set to false if you don't want this warning logged
+                #perhaps if running CI tests or similar.
+                warn-on-auto-init-fail = true
                 column-names {
                   persistenceId = "persistence_id"
                   sequenceNumber = "sequence_number"


### PR DESCRIPTION
This allows the warnings that get logged when creating tables with `auto-init = true` to be suppressed. Will likely be useful for people running certain various integration tests as well as our own build pipeline.