### PR TITLE
Fix pendingwrite clear on persistasync edge case

### DIFF
--- a/Akka.Persistence.Linq2Db.Benchmark.DockerComparisonTests/Akka.Persistence.Linq2Db.Benchmark.DockerComparisonTests.csproj
+++ b/Akka.Persistence.Linq2Db.Benchmark.DockerComparisonTests/Akka.Persistence.Linq2Db.Benchmark.DockerComparisonTests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <ServerGarbageCollection>false</ServerGarbageCollection>
+    </PropertyGroup>
+    
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="1.3.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\src\Akka.Persistence.Linq2Db.Benchmark.Tests\Akka.Persistence.Linq2Db.Benchmark.Tests.csproj" />
+      <ProjectReference Include="..\src\Akka.Persistence.Sql.Linq2Db.DockerTests\Akka.Persistence.Sql.Linq2Db.DockerTests.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Akka.Persistence.Linq2Db.Benchmark.DockerComparisonTests/PostgreSQLSpecsFixture.cs
+++ b/Akka.Persistence.Linq2Db.Benchmark.DockerComparisonTests/PostgreSQLSpecsFixture.cs
@@ -1,0 +1,11 @@
+﻿using Akka.Persistence.Sql.Linq2Db.Tests.Docker;
+using Akka.Persistence.Sql.Linq2Db.Tests.Docker.Docker;
+using Xunit;
+
+namespace Akka.Persistence.Linq2Db.BenchmarkTests.Docker.Linq2Db
+{
+    [CollectionDefinition("PostgreSQLSpec")]
+    public sealed class PostgreSQLSpecsFixture : ICollectionFixture<PostgreSQLFixture>
+    {
+    }
+}

--- a/Akka.Persistence.Linq2Db.Benchmark.DockerComparisonTests/SqlCommon/DockerBatchingSqlServerJournalPerfSpec.cs
+++ b/Akka.Persistence.Linq2Db.Benchmark.DockerComparisonTests/SqlCommon/DockerBatchingSqlServerJournalPerfSpec.cs
@@ -1,35 +1,34 @@
 ﻿using Akka.Configuration;
-using Akka.Persistence.Sql.Linq2Db.Tests.Docker;
+using Akka.Persistence.Linq2Db.BenchmarkTests;
 using Akka.Persistence.Sql.Linq2Db.Tests.Docker.Docker;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Akka.Persistence.Linq2Db.BenchmarkTests.Docker.SqlCommon
+namespace Akka.Persistence.Linq2Db.Benchmark.DockerComparisonTests.SqlCommon
 {
-    [Collection("PostgreSQLSpec")]
-    public class DockerPostgreSQLJournalPerfSpec : L2dbJournalPerfSpec
+    [Collection("SqlServerSpec")]
+    public class DockerBatchingSqlServerJournalPerfSpec : L2dbJournalPerfSpec
     {
-        public DockerPostgreSQLJournalPerfSpec(ITestOutputHelper output, PostgreSQLFixture fixture) : base(InitConfig(fixture),"sqlserverperfspec", output,40, TestConstants.DockerNumMessages)
+        public DockerBatchingSqlServerJournalPerfSpec(ITestOutputHelper output, SqlServerFixture fixture) : base(InitConfig(fixture),"sqlserverperfspec", output,40, TestConstants.DockerNumMessages)
         {
         }
-        public static Config InitConfig(PostgreSQLFixture fixture)
+        public static Config InitConfig(SqlServerFixture fixture)
         {
             //need to make sure db is created before the tests start
-            //DockerDbUtils.Initialize(fixture.ConnectionString);
+            DockerDbUtils.Initialize(fixture.ConnectionString);
             var specString = $@"
                     akka.persistence {{
                         publish-plugin-commands = on
                         journal {{
-                            plugin = ""akka.persistence.journal.postgresql""
-                            postgresql {{
-                                class = ""Akka.Persistence.PostgreSql.Journal.PostgreSqlJournal, Akka.Persistence.PostgreSql""
+                            plugin = ""akka.persistence.journal.sql-server""
+                            sql-server {{
+                                class = ""Akka.Persistence.SqlServer.Journal.BatchingSqlServerJournal, Akka.Persistence.SqlServer""
                                 #plugin-dispatcher = ""akka.actor.default-dispatcher""
                                 plugin-dispatcher = ""akka.persistence.dispatchers.default-plugin-dispatcher""
                                 table-name = EventJournal
-                                metadata-table-name = metadata
-                                schema-name = public
+                                schema-name = dbo
                                 auto-initialize = on
-                                connection-string = ""{fixture.ConnectionString}""
+                                connection-string = ""{DockerDbUtils.ConnectionString}""
                             }}
                         }}
                     }}";

--- a/Akka.Persistence.Linq2Db.Benchmark.DockerComparisonTests/SqlCommon/DockerPostgreSQLJournalPerfSpec.cs
+++ b/Akka.Persistence.Linq2Db.Benchmark.DockerComparisonTests/SqlCommon/DockerPostgreSQLJournalPerfSpec.cs
@@ -1,34 +1,35 @@
 ﻿using Akka.Configuration;
-using Akka.Persistence.Sql.Linq2Db.Tests.Docker;
+using Akka.Persistence.Linq2Db.BenchmarkTests;
 using Akka.Persistence.Sql.Linq2Db.Tests.Docker.Docker;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Akka.Persistence.Linq2Db.BenchmarkTests.Docker.SqlCommon
+namespace Akka.Persistence.Linq2Db.Benchmark.DockerComparisonTests.SqlCommon
 {
-    [Collection("SqlServerSpec")]
-    public class DockerBatchingSqlServerJournalPerfSpec : L2dbJournalPerfSpec
+    [Collection("PostgreSQLSpec")]
+    public class DockerPostgreSQLJournalPerfSpec : L2dbJournalPerfSpec
     {
-        public DockerBatchingSqlServerJournalPerfSpec(ITestOutputHelper output, SqlServerFixture fixture) : base(InitConfig(fixture),"sqlserverperfspec", output,40, TestConstants.DockerNumMessages)
+        public DockerPostgreSQLJournalPerfSpec(ITestOutputHelper output, PostgreSQLFixture fixture) : base(InitConfig(fixture),"sqlserverperfspec", output,40, TestConstants.DockerNumMessages)
         {
         }
-        public static Config InitConfig(SqlServerFixture fixture)
+        public static Config InitConfig(PostgreSQLFixture fixture)
         {
             //need to make sure db is created before the tests start
-            DockerDbUtils.Initialize(fixture.ConnectionString);
+            //DockerDbUtils.Initialize(fixture.ConnectionString);
             var specString = $@"
                     akka.persistence {{
                         publish-plugin-commands = on
                         journal {{
-                            plugin = ""akka.persistence.journal.sql-server""
-                            sql-server {{
-                                class = ""Akka.Persistence.SqlServer.Journal.BatchingSqlServerJournal, Akka.Persistence.SqlServer""
+                            plugin = ""akka.persistence.journal.postgresql""
+                            postgresql {{
+                                class = ""Akka.Persistence.PostgreSql.Journal.PostgreSqlJournal, Akka.Persistence.PostgreSql""
                                 #plugin-dispatcher = ""akka.actor.default-dispatcher""
                                 plugin-dispatcher = ""akka.persistence.dispatchers.default-plugin-dispatcher""
                                 table-name = EventJournal
-                                schema-name = dbo
+                                metadata-table-name = metadata
+                                schema-name = public
                                 auto-initialize = on
-                                connection-string = ""{DockerDbUtils.ConnectionString}""
+                                connection-string = ""{fixture.ConnectionString}""
                             }}
                         }}
                     }}";

--- a/Akka.Persistence.Linq2Db.Benchmark.DockerComparisonTests/SqlCommon/DockerSqlServerJournalPerfSpec.cs
+++ b/Akka.Persistence.Linq2Db.Benchmark.DockerComparisonTests/SqlCommon/DockerSqlServerJournalPerfSpec.cs
@@ -1,10 +1,10 @@
 ﻿using Akka.Configuration;
-using Akka.Persistence.Sql.Linq2Db.Tests.Docker;
+using Akka.Persistence.Linq2Db.BenchmarkTests;
 using Akka.Persistence.Sql.Linq2Db.Tests.Docker.Docker;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Akka.Persistence.Linq2Db.BenchmarkTests.Docker.SqlCommon
+namespace Akka.Persistence.Linq2Db.Benchmark.DockerComparisonTests.SqlCommon
 {
     [Collection("SqlServerSpec")]
     public class DockerSqlServerJournalPerfSpec : L2dbJournalPerfSpec

--- a/Akka.Persistence.Linq2Db.Benchmark.DockerComparisonTests/SqlServerSpecsFixture.cs
+++ b/Akka.Persistence.Linq2Db.Benchmark.DockerComparisonTests/SqlServerSpecsFixture.cs
@@ -1,0 +1,11 @@
+﻿using Akka.Persistence.Sql.Linq2Db.Tests.Docker;
+using Akka.Persistence.Sql.Linq2Db.Tests.Docker.Docker;
+using Xunit;
+
+namespace Akka.Persistence.Linq2Db.BenchmarkTests.Docker.Linq2Db
+{
+    [CollectionDefinition("SqlServerSpec")]
+    public sealed class SqlServerSpecsFixture : ICollectionFixture<SqlServerFixture>
+    {
+    }
+}

--- a/Akka.Persistence.Linq2Db.sln
+++ b/Akka.Persistence.Linq2Db.sln
@@ -31,7 +31,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_", "_", "{20C26B2D-59EA-42
 ProjectSection(SolutionItems) = preProject
 	src\common.props = src\common.props
 	README.md = README.md
+	RELEASE_NOTES.md = RELEASE_NOTES.md
 EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Persistence.Linq2Db.Benchmark.DockerComparisonTests", "Akka.Persistence.Linq2Db.Benchmark.DockerComparisonTests\Akka.Persistence.Linq2Db.Benchmark.DockerComparisonTests.csproj", "{170698FA-DA1E-40BC-896D-AFA67976C0EB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -71,6 +74,10 @@ Global
 		{095E392C-C439-4EBC-ABCB-6AA87FCBD9E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{095E392C-C439-4EBC-ABCB-6AA87FCBD9E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{095E392C-C439-4EBC-ABCB-6AA87FCBD9E9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{170698FA-DA1E-40BC-896D-AFA67976C0EB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{170698FA-DA1E-40BC-896D-AFA67976C0EB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{170698FA-DA1E-40BC-896D-AFA67976C0EB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{170698FA-DA1E-40BC-896D-AFA67976C0EB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Akka.Persistence.Linq2Db.Benchmark.DockerTests/Akka.Persistence.Linq2Db.Benchmark.DockerTests.csproj
+++ b/src/Akka.Persistence.Linq2Db.Benchmark.DockerTests/Akka.Persistence.Linq2Db.Benchmark.DockerTests.csproj
@@ -13,12 +13,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Akka" Version="1.4.19" />
-        <PackageReference Include="Akka.Persistence.PostgreSql" Version="1.4.17" />
-        <PackageReference Include="Akka.Persistence.Redis" Version="1.4.4" />
+        <PackageReference Include="Akka" Version="1.4.21" />
+        <PackageReference Include="Akka.Persistence.PostgreSql" Version="1.4.19" />
+        <PackageReference Include="Akka.Persistence.Redis" Version="1.4.20" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
         <PackageReference Include="redis-inside" Version="3.3.0" />
-        <PackageReference Include="StackExchange.Redis" Version="2.2.4" />
+        <PackageReference Include="StackExchange.Redis" Version="2.2.62" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
         <PackageReference Include="coverlet.collector" Version="1.2.0" />

--- a/src/Akka.Persistence.Linq2Db.Benchmark.DockerTests/Docker/Linq2Db/DockerLinq2DbSqlServerJournalPerfSpec.cs
+++ b/src/Akka.Persistence.Linq2Db.Benchmark.DockerTests/Docker/Linq2Db/DockerLinq2DbSqlServerJournalPerfSpec.cs
@@ -33,6 +33,7 @@ namespace Akka.Persistence.Linq2Db.BenchmarkTests.Docker.Linq2Db
 #connection-string = ""FullUri=file:test.db&cache=shared""
                         provider-name = """ + LinqToDB.ProviderName.SqlServer2017 + @"""
                         use-clone-connection = true
+                        #prefer-parameters-on-multirow-insert = true
                         tables.journal {{ 
                            auto-init = true
                            warn-on-auto-init-fail = false

--- a/src/Akka.Persistence.Linq2Db.Benchmark.Tests/Akka.Persistence.Linq2Db.Benchmark.Tests.csproj
+++ b/src/Akka.Persistence.Linq2Db.Benchmark.Tests/Akka.Persistence.Linq2Db.Benchmark.Tests.csproj
@@ -16,12 +16,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Akka" Version="1.4.19" />
-        <PackageReference Include="Akka.Persistence.PostgreSql" Version="1.4.17" />
-        <PackageReference Include="Akka.Persistence.Redis" Version="1.4.4" />
+        <PackageReference Include="Akka" Version="1.4.21" />
+        <PackageReference Include="Akka.Persistence.PostgreSql" Version="1.4.19" />
+        <PackageReference Include="Akka.Persistence.Redis" Version="1.4.20" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
         <PackageReference Include="redis-inside" Version="3.3.0" />
-        <PackageReference Include="StackExchange.Redis" Version="2.2.4" />
+        <PackageReference Include="StackExchange.Redis" Version="2.2.62" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
         <PackageReference Include="coverlet.collector" Version="1.2.0" />

--- a/src/Akka.Persistence.Linq2Db.Compatibility.DockerTests/Akka.Persistence.Linq2Db.Compatibility.DockerTests.csproj
+++ b/src/Akka.Persistence.Linq2Db.Compatibility.DockerTests/Akka.Persistence.Linq2Db.Compatibility.DockerTests.csproj
@@ -12,8 +12,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Akka" Version="1.4.19" />
-        <PackageReference Include="Akka.Persistence.PostgreSql" Version="1.4.17" />
+        <PackageReference Include="Akka" Version="1.4.21" />
+        <PackageReference Include="Akka.Persistence.PostgreSql" Version="1.4.19" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />

--- a/src/Akka.Persistence.Linq2Db.Compatibility.Tests/Akka.Persistence.Linq2Db.Compatibility.Tests.csproj
+++ b/src/Akka.Persistence.Linq2Db.Compatibility.Tests/Akka.Persistence.Linq2Db.Compatibility.Tests.csproj
@@ -9,8 +9,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Akka" Version="1.4.19" />
-        <PackageReference Include="Akka.Persistence.PostgreSql" Version="1.4.17" />
+        <PackageReference Include="Akka" Version="1.4.21" />
+        <PackageReference Include="Akka.Persistence.PostgreSql" Version="1.4.19" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />

--- a/src/Akka.Persistence.Linq2Db.Compatibility.Tests/SqlCommonSnapshotCompatibilitySpec.cs
+++ b/src/Akka.Persistence.Linq2Db.Compatibility.Tests/SqlCommonSnapshotCompatibilitySpec.cs
@@ -44,6 +44,7 @@ namespace Akka.Persistence.Linq2Db.CompatibilityTests
             Assert.True(persistRef.Ask<bool>(new ContainsEvent(){Guid = ourGuid}, TimeSpan.FromSeconds(5)).Result);
             await Task.Delay(TimeSpan.FromSeconds(2));
             await persistRef.GracefulStop(TimeSpan.FromSeconds(5));
+            await Task.Delay(TimeSpan.FromSeconds(2));
             persistRef =  sys1.ActorOf(Props.Create(() =>
                 new SnapshotCompatActor(NewSnapshot,
                     "p-1")), "test-snap-recover-1");
@@ -63,6 +64,7 @@ namespace Akka.Persistence.Linq2Db.CompatibilityTests
             Assert.True(persistRef.Ask<bool>(new ContainsEvent(){Guid = ourGuid}, TimeSpan.FromSeconds(5)).Result);
             await Task.Delay(TimeSpan.FromSeconds(2));
             await persistRef.GracefulStop(TimeSpan.FromSeconds(5));
+            await Task.Delay(TimeSpan.FromSeconds(2));
             persistRef =  sys1.ActorOf(Props.Create(() =>
                 new SnapshotCompatActor(NewSnapshot,
                     "p-2")), "test-snap-persist-1");
@@ -86,6 +88,7 @@ namespace Akka.Persistence.Linq2Db.CompatibilityTests
             Assert.True(persistRef.Ask<bool>(new ContainsEvent(){Guid = ourGuid}, TimeSpan.FromSeconds(5)).Result);
             await Task.Delay(TimeSpan.FromSeconds(2));
             await persistRef.GracefulStop(TimeSpan.FromSeconds(5));
+            await Task.Delay(TimeSpan.FromSeconds(2));
             persistRef = sys1.ActorOf(Props.Create(() =>
                 new SnapshotCompatActor(OldSnapshot,
                     "p-3")), "test-snap-recover-2");
@@ -105,6 +108,7 @@ namespace Akka.Persistence.Linq2Db.CompatibilityTests
             Assert.True(persistRef.Ask<bool>(new ContainsEvent(){Guid = ourGuid}, TimeSpan.FromSeconds(5)).Result);
             await Task.Delay(TimeSpan.FromSeconds(2));
             await persistRef.GracefulStop(TimeSpan.FromSeconds(5));
+            await Task.Delay(TimeSpan.FromSeconds(2));
             persistRef =  sys1.ActorOf(Props.Create(() =>
                 new SnapshotCompatActor(OldSnapshot,
                     "p-4")), "test-snap-persist-2");

--- a/src/Akka.Persistence.Linq2Db.Journal.Query.Tests/Akka.Persistence.Linq2Db.Journal.Query.Tests.csproj
+++ b/src/Akka.Persistence.Linq2Db.Journal.Query.Tests/Akka.Persistence.Linq2Db.Journal.Query.Tests.csproj
@@ -8,10 +8,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Akka" Version="1.4.19" />
-        <PackageReference Include="Akka.Persistence.Sqlite" Version="1.4.19" />
-        <PackageReference Include="Akka.Persistence.TCK" Version="1.4.19" />
-        <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.5" />
+        <PackageReference Include="Akka" Version="1.4.21" />
+        <PackageReference Include="Akka.Persistence.Sqlite" Version="1.4.21" />
+        <PackageReference Include="Akka.Persistence.TCK" Version="1.4.21" />
+        <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.7" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/src/Akka.Persistence.Sql.Linq2Db.DockerTests/Akka.Persistence.Sql.Linq2Db.DockerTests.csproj
+++ b/src/Akka.Persistence.Sql.Linq2Db.DockerTests/Akka.Persistence.Sql.Linq2Db.DockerTests.csproj
@@ -12,16 +12,16 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Akka" Version="1.4.19" />
-        <PackageReference Include="Akka.Persistence.Sqlite" Version="1.4.19" />
-        <PackageReference Include="Akka.Persistence.SqlServer" Version="1.4.16" />
-        <PackageReference Include="Akka.Persistence.TCK" Version="1.4.19" />
-        <PackageReference Include="Akka.Persistence.TestKit" Version="1.4.19" />
-        <PackageReference Include="Akka.Serialization.Hyperion" Version="1.4.19" />
+        <PackageReference Include="Akka" Version="1.4.21" />
+        <PackageReference Include="Akka.Persistence.Sqlite" Version="1.4.21" />
+        <PackageReference Include="Akka.Persistence.SqlServer" Version="1.4.18" />
+        <PackageReference Include="Akka.Persistence.TCK" Version="1.4.21" />
+        <PackageReference Include="Akka.Persistence.TestKit" Version="1.4.21" />
+        <PackageReference Include="Akka.Serialization.Hyperion" Version="1.4.21" />
         <PackageReference Include="Docker.DotNet" Version="3.125.4" />
         <PackageReference Include="Hyperion" Version="0.10.1" />
         <PackageReference Include="JetBrains.dotMemoryUnit" Version="3.1.20200127.214830" />
-        <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.5" />
+        <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.7" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
         <PackageReference Include="Npgsql" Version="4.1.4" />
         <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />

--- a/src/Akka.Persistence.Sql.Linq2Db.Tests/Akka.Persistence.Sql.Linq2Db.Tests.csproj
+++ b/src/Akka.Persistence.Sql.Linq2Db.Tests/Akka.Persistence.Sql.Linq2Db.Tests.csproj
@@ -11,16 +11,16 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Akka" Version="1.4.19" />
-        <PackageReference Include="Akka.Persistence.Sqlite" Version="1.4.19" />
-        <PackageReference Include="Akka.Persistence.SqlServer" Version="1.4.16" />
-        <PackageReference Include="Akka.Persistence.TCK" Version="1.4.19" />
-        <PackageReference Include="Akka.Persistence.TestKit" Version="1.4.19" />
-        <PackageReference Include="Akka.Serialization.Hyperion" Version="1.4.19" />
+        <PackageReference Include="Akka" Version="1.4.21" />
+        <PackageReference Include="Akka.Persistence.Sqlite" Version="1.4.21" />
+        <PackageReference Include="Akka.Persistence.SqlServer" Version="1.4.18" />
+        <PackageReference Include="Akka.Persistence.TCK" Version="1.4.21" />
+        <PackageReference Include="Akka.Persistence.TestKit" Version="1.4.21" />
+        <PackageReference Include="Akka.Serialization.Hyperion" Version="1.4.21" />
         <PackageReference Include="Docker.DotNet" Version="3.125.4" />
         <PackageReference Include="Hyperion" Version="0.10.1" />
         <PackageReference Include="JetBrains.dotMemoryUnit" Version="3.1.20200127.214830" />
-        <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.5" />
+        <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.7" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
         <PackageReference Include="Npgsql" Version="4.1.4" />
         <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />

--- a/src/Akka.Persistence.Sql.Linq2Db/Akka.Persistence.Sql.Linq2Db.csproj
+++ b/src/Akka.Persistence.Sql.Linq2Db/Akka.Persistence.Sql.Linq2Db.csproj
@@ -9,12 +9,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Akka" Version="1.4.19" />
-      <PackageReference Include="Akka.Persistence" Version="1.4.19" />
-      <PackageReference Include="Akka.Persistence.Query" Version="1.4.19" />
-      <PackageReference Include="Akka.Streams" Version="1.4.19" />
+      <PackageReference Include="Akka" Version="1.4.21" />
+      <PackageReference Include="Akka.Persistence" Version="1.4.21" />
+      <PackageReference Include="Akka.Persistence.Query" Version="1.4.21" />
+      <PackageReference Include="Akka.Streams" Version="1.4.21" />
       <PackageReference Include="LanguageExt.Core" Version="3.4.15" />
-      <PackageReference Include="linq2db" Version="3.4.0" />
+      <PackageReference Include="linq2db" Version="3.4.1" />
       <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.0" />
       <PackageReference Include="System.Linq.Async" Version="4.1.1" />
       <PackageReference Include="System.Reactive.Linq" Version="4.4.1" />

--- a/src/Akka.Persistence.Sql.Linq2Db/Journal/DAO/BaseByteArrayJournalDao.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db/Journal/DAO/BaseByteArrayJournalDao.cs
@@ -287,8 +287,7 @@ namespace Akka.Persistence.Sql.Linq2Db.Journal.DAO
                                     },
                                     jmd => new JournalMetaData()
                                     {
-                                        PersistenceId = persistenceId,
-                                        SequenceNumber = maxMarkedDeletion
+                                        
                                     },
                                     () => new JournalMetaData()
                                     {

--- a/src/Akka.Persistence.Sql.Linq2Db/Util/NoThrowAwaiter.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db/Util/NoThrowAwaiter.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+namespace Akka.Persistence.Sql.Linq2Db.Utility
+{
+    /// <summary>
+    /// An awaiter that never throws.
+    /// </summary>
+    internal struct NoThrowAwaiter : ICriticalNotifyCompletion
+    {
+        private readonly Task _task;
+        public NoThrowAwaiter(Task task) { _task = task; }
+        public NoThrowAwaiter GetAwaiter() => this;
+        public bool IsCompleted => _task.IsCompleted;
+        public void GetResult() { }
+        public void OnCompleted(Action continuation) => _task.GetAwaiter().OnCompleted(continuation);
+        public void UnsafeOnCompleted(Action continuation) => OnCompleted(continuation);
+    }
+}


### PR DESCRIPTION
- Fix PendingWrite potentially clearing before it should under multiple PersistAsync calls
- Fixup Delete code to be more sane/friendly to future DBs.
- Properly update Akka versions to 1.4.21
- Update Linq2db to 3.4.1