### PR TITLE
Fix inconsistent HOCON property naming and access, add MySql compat settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -351,3 +351,4 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+tools/

--- a/build.fsx
+++ b/build.fsx
@@ -95,7 +95,9 @@ Target "RunTests" (fun _ ->
     let projects = 
         match (isWindows) with 
         | true -> !! "./src/**/*.Tests.csproj"
+                  -- "./src/**/*.Benchmark.*.csproj"
         | _ -> !! "./src/**/*.Tests.csproj"
+               -- "./src/**/*.Benchmark.*.csproj"
                ++  "./src/**/*.DockerTests.csproj" // if you need to filter specs for Linux vs. Windows, do it here
 
     let runSingleProject project =

--- a/src/Akka.Persistence.Linq2Db.Benchmark.DockerTests/Docker/Linq2Db/DockerLinq2DbSqlServerJournalPerfSpec.cs
+++ b/src/Akka.Persistence.Linq2Db.Benchmark.DockerTests/Docker/Linq2Db/DockerLinq2DbSqlServerJournalPerfSpec.cs
@@ -19,44 +19,41 @@ namespace Akka.Persistence.Linq2Db.BenchmarkTests.Docker.Linq2Db
     [Collection("SqlServerSpec")]
     public class DockerLinq2DbSqlServerJournalPerfSpec : L2dbJournalPerfSpec
     {
-        public static string _journalBaseConfig = @"
-            akka.persistence {{
-                publish-plugin-commands = on
-                journal {{
-                    plugin = ""akka.persistence.journal.testspec""
-                    testspec {{
-                        class = ""{0}""
-                        #plugin-dispatcher = ""akka.actor.default-dispatcher""
-                        plugin-dispatcher = ""akka.persistence.dispatchers.default-plugin-dispatcher""
-                        parallelism = 2
-                        connection-string = ""{1}""
-#connection-string = ""FullUri=file:test.db&cache=shared""
-                        provider-name = """ + LinqToDB.ProviderName.SqlServer2017 + @"""
-                        use-clone-connection = true
-                        #prefer-parameters-on-multirow-insert = true
-                        tables.journal {{ 
-                           auto-init = true
-                           warn-on-auto-init-fail = false
-                           table-name = ""{2}"" 
-                           }}
-                    }}
-                }}
-            }}
-        ";
-        
-        public static Config Create(string connString)
+        private static Config Create(string connString)
         {
-            return ConfigurationFactory.ParseString(
-                string.Format(_journalBaseConfig,
-                    typeof(Linq2DbWriteJournal).AssemblyQualifiedName,
-                    connString,"testPerfTable"));
+            return ConfigurationFactory.ParseString($@"
+akka.persistence {{
+    publish-plugin-commands = on
+    journal {{
+        plugin = ""akka.persistence.journal.linq2db""
+        linq2db {{
+            class = ""{typeof(Linq2DbWriteJournal).AssemblyQualifiedName}""
+            #plugin-dispatcher = ""akka.actor.default-dispatcher""
+            plugin-dispatcher = ""akka.persistence.dispatchers.default-plugin-dispatcher""
+
+            connection-string = ""{connString}""
+            #connection-string = ""FullUri=file:test.db&cache=shared""
+            provider-name = ""{ProviderName.SqlServer2017}""
+            use-clone-connection = true
+            tables.journal {{ 
+                auto-init = true
+                warn-on-auto-init-fail = false
+                table-name = ""testPerfTable"" 
+            }}
+        }}
+    }}
+}}");
         }
+        
         public DockerLinq2DbSqlServerJournalPerfSpec(ITestOutputHelper output,
             SqlServerFixture fixture) : base(InitConfig(fixture),
             "sqlserverperf", output,40, eventsCount: TestConstants.DockerNumMessages)
         {
-            
-            var connFactory = new AkkaPersistenceDataConnectionFactory(new JournalConfig(Create(DockerDbUtils.ConnectionString).GetConfig("akka.persistence.journal.testspec")));
+            var extension = Linq2DbPersistence.Get(Sys);
+            var config = Create(DockerDbUtils.ConnectionString)
+                .WithFallback(extension.DefaultConfig)
+                .GetConfig("akka.persistence.journal.linq2db");
+            var connFactory = new AkkaPersistenceDataConnectionFactory(new JournalConfig(config));
             using (var conn = connFactory.GetConnection())
             {
                 try

--- a/src/Akka.Persistence.Linq2Db.Benchmark.Tests/Linq2Db/MSSQLiteLinq2DbJournalPerfSpec.cs
+++ b/src/Akka.Persistence.Linq2Db.Benchmark.Tests/Linq2Db/MSSQLiteLinq2DbJournalPerfSpec.cs
@@ -39,10 +39,14 @@ namespace Akka.Persistence.Linq2Db.BenchmarkTests.Local.Linq2Db
         public MSSQLiteLinq2DbJournalPerfSpec(ITestOutputHelper output)
             : base(SQLiteJournalSpecConfig.Create(connString, ProviderName.SQLiteMS), "SqliteJournalSpec", output,eventsCount: TestConstants.NumMessages)
         {
+            var extension = Linq2DbPersistence.Get(Sys);
+            
             heldSqliteConnection.Open();
             //InitWALForFileDb();
             var conf = new JournalConfig(
-                SQLiteJournalSpecConfig.Create(connString, ProviderName.SQLiteMS).GetConfig("akka.persistence.journal.testspec"));
+                SQLiteJournalSpecConfig.Create(connString, ProviderName.SQLiteMS)
+                    .WithFallback(extension.DefaultConfig)
+                    .GetConfig("akka.persistence.journal.linq2db"));
             
             var connFactory = new AkkaPersistenceDataConnectionFactory(conf);
             using (var conn = connFactory.GetConnection())

--- a/src/Akka.Persistence.Linq2Db.Compatibility.Tests/Sqlite/SQLiteSqlCommonJournalCompatibilitySpec.cs
+++ b/src/Akka.Persistence.Linq2Db.Compatibility.Tests/Sqlite/SQLiteSqlCommonJournalCompatibilitySpec.cs
@@ -10,9 +10,7 @@ namespace Akka.Persistence.Linq2Db.CompatibilityTests
     {
         private static AtomicCounter counter = new AtomicCounter(0);
         //private static string  connString = "FullUri=file:memdb"+counter.IncrementAndGet() +"?mode=memory&cache=shared";
-        private static string connString =
-            "Filename=file:memdb-journal-" + counter.IncrementAndGet() +
-            ".db;Mode=Memory;Cache=Shared";
+        private static string connString = $"Filename=file:memdb-journal-{counter.IncrementAndGet()}.db;Mode=Memory;Cache=Shared";
         private static SqliteConnection heldSqliteConnection =
             new SqliteConnection(connString);
         public SQLiteSqlCommonJournalCompatibilitySpec(ITestOutputHelper outputHelper) : base(outputHelper)
@@ -30,7 +28,7 @@ namespace Akka.Persistence.Linq2Db.CompatibilityTests
             "akka.persistence.journal.sqlite";
 
         protected override string NewJournal =>
-            "akka.persistence.journal.testspec";
+            "akka.persistence.journal.linq2db";
 
         protected override Configuration.Config Config =>
             SQLiteCompatibilitySpecConfig.InitJournalConfig("journal_compat",

--- a/src/Akka.Persistence.Linq2Db.Compatibility.Tests/Sqlite/SQLiteSqlCommonSnapshotCompatibilitySpec.cs
+++ b/src/Akka.Persistence.Linq2Db.Compatibility.Tests/Sqlite/SQLiteSqlCommonSnapshotCompatibilitySpec.cs
@@ -27,9 +27,8 @@ namespace Akka.Persistence.Linq2Db.CompatibilityTests
             GC.KeepAlive(heldSqliteConnection);
         }
 
-        protected override Config Config =>
-            SQLiteCompatibilitySpecConfig.InitSnapshotConfig("snapshot_compat",
-                connString);
+        protected override Config Config { get; } =
+            SQLiteCompatibilitySpecConfig.InitSnapshotConfig("snapshot_compat", connString);
 
         protected override string OldSnapshot =>
             "akka.persistence.snapshot-store.sqlite";

--- a/src/Akka.Persistence.Sql.Linq2Db.DockerTests/Postgres/PostgreSQLJournalSpec.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db.DockerTests/Postgres/PostgreSQLJournalSpec.cs
@@ -52,10 +52,13 @@ namespace Akka.Persistence.Sql.Linq2Db.Tests.Docker.Postgres
         public PostgreSQLSnapshotSpec(ITestOutputHelper outputHelper, PostgreSQLFixture fixture) :
             base(conf(fixture))
         {
+            var extension = Linq2DbPersistence.Get(Sys);
             DebuggingHelpers.SetupTraceDump(outputHelper);
             var connFactory = new AkkaPersistenceDataConnectionFactory(
                 new SnapshotConfig(
-                    conf(fixture).GetConfig("akka.persistence.snapshot-store.linq2db")));
+                    conf(fixture)
+                        .WithFallback(extension.DefaultConfig)
+                        .GetConfig("akka.persistence.snapshot-store.linq2db")));
             using (var conn = connFactory.GetConnection())
             {
                 

--- a/src/Akka.Persistence.Sql.Linq2Db.DockerTests/Postgres/PostgreSQLJournalSpecConfig.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db.DockerTests/Postgres/PostgreSQLJournalSpecConfig.cs
@@ -6,26 +6,24 @@ namespace Akka.Persistence.Sql.Linq2Db.Tests.Docker.Postgres
     public static class PostgreSQLJournalSpecConfig
     {
         public static string _journalBaseConfig = @"
-            akka.persistence {{
-                publish-plugin-commands = on
-                journal {{
-                    plugin = ""akka.persistence.journal.testspec""
-                    testspec {{
-                        class = ""{0}""
-                        #plugin-dispatcher = ""akka.actor.default-dispatcher""
-plugin-dispatcher = ""akka.persistence.dispatchers.default-plugin-dispatcher""
-                        connection-string = ""{1}""
-#connection-string = ""FullUri=file:test.db&cache=shared""
-                        provider-name = ""{2}""
-                        use-clone-connection = false
-                        tables.journal {{ 
-                           auto-init = true 
-                           warn-on-auto-init-fail = false
-                        }}
-                    }}
-                }}
+akka.persistence {{
+    publish-plugin-commands = on
+    journal {{
+        plugin = ""akka.persistence.journal.linq2db""
+        linq2db {{
+            class = ""{0}""
+            #plugin-dispatcher = ""akka.actor.default-dispatcher""
+            plugin-dispatcher = ""akka.persistence.dispatchers.default-plugin-dispatcher""
+            connection-string = ""{1}""
+            provider-name = ""{2}""
+            use-clone-connection = false
+            tables.journal {{ 
+                auto-init = true 
+                warn-on-auto-init-fail = false
             }}
-        ";
+        }}
+    }}
+}}";
         
         public static Configuration.Config Create(string connString, string providerName)
         {

--- a/src/Akka.Persistence.Sql.Linq2Db.DockerTests/SqlServer/SQLServerJournalCustomConfigSpec.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db.DockerTests/SqlServer/SQLServerJournalCustomConfigSpec.cs
@@ -29,7 +29,11 @@ namespace Akka.Persistence.Sql.Linq2Db.Tests.Docker.SqlServer
         public SQLServerJournalCustomConfigSpec(ITestOutputHelper outputHelper, SqlServerFixture fixture)
             : base(Initialize(fixture), "SQLServer-custom", outputHelper)
         {
-            var connFactory = new AkkaPersistenceDataConnectionFactory(new JournalConfig(conf.GetConfig("akka.persistence.journal.linq2db.customspec")));
+            var extension = Linq2DbPersistence.Get(Sys);
+            var connFactory = new AkkaPersistenceDataConnectionFactory(new JournalConfig(
+                conf
+                    .GetConfig("akka.persistence.journal.linq2db.customspec")
+                    .WithFallback(extension.DefaultJournalConfig)));
             using (var conn = connFactory.GetConnection())
             {
                 try

--- a/src/Akka.Persistence.Sql.Linq2Db.DockerTests/SqlServer/SQLServerJournalDefaultConfigSpec.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db.DockerTests/SqlServer/SQLServerJournalDefaultConfigSpec.cs
@@ -26,7 +26,11 @@ namespace Akka.Persistence.Sql.Linq2Db.Tests.Docker.SqlServer
         public SQLServerJournalDefaultConfigSpec(ITestOutputHelper outputHelper, SqlServerFixture fixture)
             : base(Initialize(fixture), "SQLServer-default", outputHelper)
         {
-            var connFactory = new AkkaPersistenceDataConnectionFactory(new JournalConfig(conf.GetConfig("akka.persistence.journal.linq2db")));
+            var extension = Linq2DbPersistence.Get(Sys);
+            var connFactory = new AkkaPersistenceDataConnectionFactory(new JournalConfig(
+                conf
+                    .WithFallback(extension.DefaultConfig)
+                    .GetConfig("akka.persistence.journal.linq2db")));
             using (var conn = connFactory.GetConnection())
             {
                 try

--- a/src/Akka.Persistence.Sql.Linq2Db.DockerTests/SqlServer/SQLServerJournalSpec.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db.DockerTests/SqlServer/SQLServerJournalSpec.cs
@@ -19,16 +19,20 @@ namespace Akka.Persistence.Sql.Linq2Db.Tests.Docker.SqlServer
         public static Configuration.Config Initialize(SqlServerFixture fixture)
         {
             DockerDbUtils.Initialize(fixture.ConnectionString);
-            return config;
+            return Config;
         }
 
-        private static Configuration.Config config =>
+        private static Configuration.Config Config =>
             SQLServerJournalSpecConfig.Create(DockerDbUtils.ConnectionString,
                 "journalSpec");
         public SQLServerJournalSpec(ITestOutputHelper outputHelper, SqlServerFixture fixture)
             : base(Initialize(fixture), "SQLServer", outputHelper)
         {
-            var connFactory = new AkkaPersistenceDataConnectionFactory(new JournalConfig(config.GetConfig("akka.persistence.journal.linq2db")));
+            var extension = Linq2DbPersistence.Get(Sys);
+            var config = Config
+                .WithFallback(extension.DefaultConfig)
+                .GetConfig("akka.persistence.journal.linq2db");
+            var connFactory = new AkkaPersistenceDataConnectionFactory(new JournalConfig(config));
             using (var conn = connFactory.GetConnection())
             {
                 try

--- a/src/Akka.Persistence.Sql.Linq2Db.DockerTests/SqlServer/SQLServerJournalSpecConfig.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db.DockerTests/SqlServer/SQLServerJournalSpecConfig.cs
@@ -8,28 +8,27 @@ namespace Akka.Persistence.Sql.Linq2Db.Tests.Docker.SqlServer
     {
         public static string _journalBaseConfig = @"
 akka.persistence {{
-                publish-plugin-commands = on
-                journal {{
-                    plugin = ""akka.persistence.journal.linq2db""
-                    linq2db {{
-                        class = ""{0}""
-                        plugin-dispatcher = ""akka.persistence.dispatchers.default-plugin-dispatcher""
-#plugin-dispatcher = ""akka.actor.default-dispatcher""
-                        connection-string = ""{1}""
-#connection-string = ""FullUri=file:test.db&cache=shared""
-                        provider-name = """ + LinqToDB.ProviderName.SqlServer2017 + @"""
-                        parallelism = {4}
-                        batch-size = {3}
-                        #use-clone-connection = true
-                        tables.journal {{ 
-                           auto-init = true
-                           warn-on-auto-init-fail = false
-                           table-name = ""{2}"" 
-                           }}
-                    }}
-                }}
+    publish-plugin-commands = on
+    journal {{
+        plugin = ""akka.persistence.journal.linq2db""
+        linq2db {{
+            class = ""{0}""
+            plugin-dispatcher = ""akka.persistence.dispatchers.default-plugin-dispatcher""
+            #plugin-dispatcher = ""akka.actor.default-dispatcher""
+            connection-string = ""{1}""
+            #connection-string = ""FullUri=file:test.db&cache=shared""
+            provider-name = """ + LinqToDB.ProviderName.SqlServer2017 + @"""
+            parallelism = {4}
+            batch-size = {3}
+            #use-clone-connection = true
+            tables.journal {{ 
+                auto-init = true
+                warn-on-auto-init-fail = false
+                table-name = ""{2}"" 
             }}
-        ";
+        }}
+    }}
+}}";
         public static Configuration.Config Create(string connString, string tableName, int batchSize = 100, int parallelism = 2)
         {
             return ConfigurationFactory.ParseString(
@@ -43,30 +42,29 @@ akka.persistence {{
     {
         public static string _snapshotBaseConfig = @"
 akka.persistence {{
-                publish-plugin-commands = on
-                snapshot-store {{
-                    plugin = ""akka.persistence.snapshot-store.linq2db""
-                    linq2db {{
-                        class = ""{0}""
-                        plugin-dispatcher = ""akka.persistence.dispatchers.default-plugin-dispatcher""
-#plugin-dispatcher = ""akka.actor.default-dispatcher""
-                        connection-string = ""{1}""
-#connection-string = ""FullUri=file:test.db&cache=shared""
-                        provider-name = """ + LinqToDB.ProviderName.SqlServer2017 + @"""
-                        parallelism = {4}
-                        batch-size = {3}
-                        #use-clone-connection = true
-                        tables.snapshot {{ 
-                           auto-init = true
-                           warn-on-auto-init-fail = false
-                           table-name = ""{2}""
-                           column-names {{
-                           }} 
-                           }}
-                    }}
-                }}
+    publish-plugin-commands = on
+    snapshot-store {{
+        plugin = ""akka.persistence.snapshot-store.linq2db""
+        linq2db {{
+            class = ""{0}""
+            plugin-dispatcher = ""akka.persistence.dispatchers.default-plugin-dispatcher""
+            #plugin-dispatcher = ""akka.actor.default-dispatcher""
+            connection-string = ""{1}""
+            #connection-string = ""FullUri=file:test.db&cache=shared""
+            provider-name = """ + LinqToDB.ProviderName.SqlServer2017 + @"""
+            parallelism = {4}
+            batch-size = {3}
+            #use-clone-connection = true
+            tables.snapshot {{ 
+                auto-init = true
+                warn-on-auto-init-fail = false
+                table-name = ""{2}""
+                column-names {{
+                }} 
             }}
-        ";
+        }}
+    }}
+}}";
         public static Configuration.Config Create(string connString, string tableName, int batchSize = 100, int parallelism = 2)
         {
             return ConfigurationFactory.ParseString(

--- a/src/Akka.Persistence.Sql.Linq2Db.DockerTests/SqlServer/SQLServerSnapshotSpec.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db.DockerTests/SqlServer/SQLServerSnapshotSpec.cs
@@ -24,9 +24,12 @@ namespace Akka.Persistence.Sql.Linq2Db.Tests.Docker.SqlServer
             base(Initialize(fixture))
         {
             DebuggingHelpers.SetupTraceDump(outputHelper);
+            var extension = Linq2DbPersistence.Get(Sys);
             var connFactory = new AkkaPersistenceDataConnectionFactory(
                 new SnapshotConfig(
-                    conf.GetConfig("akka.persistence.snapshot-store.linq2db")));
+                    conf
+                        .WithFallback(extension.DefaultConfig)
+                        .GetConfig("akka.persistence.snapshot-store.linq2db")));
             using (var conn = connFactory.GetConnection())
             {
                 

--- a/src/Akka.Persistence.Sql.Linq2Db.Tests/Linq2DbJournalDefaultSpecConfig.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db.Tests/Linq2DbJournalDefaultSpecConfig.cs
@@ -9,37 +9,36 @@ namespace Akka.Persistence.Sql.Linq2Db.Tests
             string journalTableName, string metadatatablename,
             string providername, string connectionstring) => $@"
 akka.persistence.journal.linq2db{{
-  {customJournalName} {{
-  class = ""Akka.Persistence.Sql.Linq2Db.Journal.Linq2DbWriteJournal, Akka.Persistence.Sql.Linq2Db""
-  provider-name = ""{providername}""
-    connection-string = ""{connectionstring}""
- tables{{
-  journal{{
-    auto-init = true
-    warn-on-auto-init-fail = false
-    table-name = ""{journalTableName}""
-    metadata-table-name = ""{metadatatablename}""
-  }}
- }}
-}}
+    {customJournalName} {{
+        class = ""Akka.Persistence.Sql.Linq2Db.Journal.Linq2DbWriteJournal, Akka.Persistence.Sql.Linq2Db""
+        provider-name = ""{providername}""
+        connection-string = ""{connectionstring}""
+        tables{{
+            journal{{
+                auto-init = true
+                warn-on-auto-init-fail = false
+                table-name = ""{journalTableName}""
+                metadata-table-name = ""{metadatatablename}""
+            }}
+        }}
+    }}
 }}";
         
         
         
         public static string _journalBaseConfig(string tablename, string metadatatablename, string providername, string connectionstring) => $@"
 akka.persistence.journal.linq2db {{
-  provider-name = ""{providername}""
+    provider-name = ""{providername}""
     connection-string = ""{connectionstring}""
- tables{{
-  journal{{
-    auto-init = true
-    warn-on-auto-init-fail = false
-    table-name = ""{tablename}""
-    metadata-table-name = ""{metadatatablename}""
-  }}
- }}
-}}
-";
+    tables {{
+        journal {{
+            auto-init = true
+            warn-on-auto-init-fail = false
+            table-name = ""{tablename}""
+            metadata-table-name = ""{metadatatablename}""
+        }}
+    }}
+}}";
 
         public static Configuration.Config GetCustomConfig(string configName,
             string journalTableName,
@@ -55,7 +54,7 @@ akka{{
       plugin = akka.persistence.journal.linq2db.{configName}
     }}      
   }}
-}}":"")).WithFallback(Linq2DbWriteJournal.DefaultConfiguration);
+}}":""));
         }
 
         public static Configuration.Config GetConfig(string tableName,
@@ -63,8 +62,7 @@ akka{{
         {
             return ConfigurationFactory
                 .ParseString(_journalBaseConfig(tableName, metadatatablename,
-                    providername, connectionString))
-                .WithFallback(Linq2DbWriteJournal.DefaultConfiguration);
+                    providername, connectionString));
         }
     }
 }

--- a/src/Akka.Persistence.Sql.Linq2Db.Tests/Settings/JournalConfigSpec.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db.Tests/Settings/JournalConfigSpec.cs
@@ -1,0 +1,266 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="JournalConfigSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using Akka.Configuration;
+using Akka.Persistence.Sql.Linq2Db.Config;
+using Akka.Persistence.Sql.Linq2Db.Journal;
+using Akka.Persistence.Sql.Linq2Db.Journal.DAO;
+using Akka.Persistence.Sql.Linq2Db.Query;
+using FluentAssertions;
+using LanguageExt.UnitsOfMeasure;
+using Xunit;
+
+namespace Akka.Persistence.Sql.Linq2Db.Tests.Settings
+{
+    public class JournalConfigSpec
+    {
+        private readonly Configuration.Config _defaultConfig;
+        
+        public JournalConfigSpec()
+        {
+            _defaultConfig = Linq2DbWriteJournal.DefaultConfiguration;
+        }
+
+        [Fact(DisplayName = "Default journal HOCON config should contain default values")]
+        public void DefaultJournalHoconConfigTest()
+        {
+            var journal = _defaultConfig.GetConfig("akka.persistence.journal.linq2db");
+            journal.Should().NotBeNull();
+            
+            var stringType = journal.GetString("class");
+            var type = Type.GetType(stringType);
+            type.Should().Be(typeof(Linq2DbWriteJournal));
+
+            journal.GetString("plugin-dispatcher").Should()
+                .Be("akka.persistence.dispatchers.default-plugin-dispatcher");
+            journal.GetString("connection-string", "invalid").Should().BeNullOrEmpty();
+            journal.GetString("provider-name", "invalid").Should().BeNullOrEmpty();
+            journal.GetBoolean("logical-delete").Should().BeFalse();
+            journal.GetBoolean("delete-compatibility-mode").Should().BeTrue();
+            journal.GetString("table-compatibility-mode", "invalid").Should().BeNullOrEmpty();
+            journal.GetInt("buffer-size").Should().Be(5000);
+            journal.GetInt("batch-size").Should().Be(100);
+            journal.GetInt("db-round-trip-max-batch-size").Should().Be(1000);
+            journal.GetBoolean("prefer-parameters-on-multirow-insert").Should().BeTrue();
+            journal.GetInt("replay-batch-size").Should().Be(1000);
+            journal.GetInt("parallelism").Should().Be(3);
+            journal.GetInt("max-row-by-row-size").Should().Be(100);
+            journal.GetBoolean("use-clone-connection").Should().BeFalse();
+            journal.GetString("materializer-dispatcher", "invalid").Should().Be("akka.actor.default-dispatcher");
+            journal.GetString("serializer", "invalid").Should().BeNullOrEmpty();
+            journal.GetString("tag-separator", "invalid").Should().Be(",");
+            journal.GetString("dao", "invalid").Should()
+                .Be("Akka.Persistence.Sql.Linq2Db.Journal.DAO.ByteArrayJournalDao, Akka.Persistence.Sql.Linq2Db");
+
+            var journalTable = journal.GetConfig("tables.journal");
+            journalTable.Should().NotBeNull();
+            journalTable.GetBoolean("auto-init").Should().BeTrue();
+            journalTable.GetBoolean("warn-on-auto-init-fail").Should().BeTrue();
+            journalTable.GetString("table-name", "invalid").Should().Be("journal");
+            journalTable.GetString("metadata-table-name", "invalid").Should().Be("journal_metadata");
+            journalTable.GetString("schema-name", "invalid").Should().BeNullOrEmpty();
+        }
+        
+        [Fact(DisplayName = "Default journal config should contain default values")]
+        public void DefaultJournalConfigTest()
+        {
+            var journalHocon = _defaultConfig.GetConfig("akka.persistence.journal.linq2db");
+            journalHocon.Should().NotBeNull();
+
+            var journal = new JournalConfig(journalHocon);
+            // assert default values
+            AssertDefaultJournalConfig(journal);
+            
+            var tableConfig = journal.TableConfig;
+
+            // assert default journal column names
+            var journalColumns = tableConfig.ColumnNames;
+            journalColumns.Ordering.Should().Be("ordering");
+            journalColumns.Deleted.Should().Be("deleted");
+            journalColumns.PersistenceId.Should().Be("persistence_id");
+            journalColumns.SequenceNumber.Should().Be("sequence_number");
+            journalColumns.Created.Should().Be("created");
+            journalColumns.Tags.Should().Be("tags");
+            journalColumns.Message.Should().Be("message");
+            journalColumns.Identitifer.Should().Be("identifier");
+            journalColumns.Manifest.Should().Be("manifest");
+            
+            // assert default metadata column names
+            var metaColumns = tableConfig.MetadataColumnNames;
+            metaColumns.PersistenceId.Should().Be("persistenceId");
+            metaColumns.SequenceNumber.Should().Be("sequenceNr");
+        }
+
+        [Fact(DisplayName = "Journal config with SqlServer compat should contain correct SqlServer column names")]
+        public void SqlServerJournalConfigTest()
+        {
+            var journalHocon = ConfigurationFactory
+                .ParseString("akka.persistence.journal.linq2db.table-compatibility-mode = sqlserver")
+                .WithFallback(_defaultConfig)
+                .GetConfig("akka.persistence.journal.linq2db");
+            journalHocon.Should().NotBeNull();
+            
+            var journal = new JournalConfig(journalHocon);
+            // assert default values
+            AssertDefaultJournalConfig(journal);
+            
+            var tableConfig = journal.TableConfig;
+
+            // assert default journal column names
+            var journalColumns = tableConfig.ColumnNames;
+            journalColumns.Ordering.Should().Be("Ordering");
+            journalColumns.Deleted.Should().Be("IsDeleted");
+            journalColumns.PersistenceId.Should().Be("PersistenceId");
+            journalColumns.SequenceNumber.Should().Be("SequenceNr");
+            journalColumns.Created.Should().Be("Timestamp");
+            journalColumns.Tags.Should().Be("Tags");
+            journalColumns.Message.Should().Be("Payload");
+            journalColumns.Identitifer.Should().Be("SerializerId");
+            journalColumns.Manifest.Should().Be("Manifest");
+            
+            // assert default metadata column names
+            var metaColumns = tableConfig.MetadataColumnNames;
+            metaColumns.PersistenceId.Should().Be("persistenceId");
+            metaColumns.SequenceNumber.Should().Be("sequenceNr");
+        }
+
+        [Fact(DisplayName = "Journal config with Sqlite compat should contain correct SqlServer column names")]
+        public void SqliteJournalConfigTest()
+        {
+            var journalHocon = ConfigurationFactory
+                .ParseString("akka.persistence.journal.linq2db.table-compatibility-mode = sqlite")
+                .WithFallback(_defaultConfig)
+                .GetConfig("akka.persistence.journal.linq2db");
+            journalHocon.Should().NotBeNull();
+            
+            var journal = new JournalConfig(journalHocon);
+            // assert default values
+            AssertDefaultJournalConfig(journal);
+            
+            var tableConfig = journal.TableConfig;
+
+            // assert default journal column names
+            var journalColumns = tableConfig.ColumnNames;
+            journalColumns.Ordering.Should().Be("ordering");
+            journalColumns.Deleted.Should().Be("is_deleted");
+            journalColumns.PersistenceId.Should().Be("persistence_id");
+            journalColumns.SequenceNumber.Should().Be("sequence_nr");
+            journalColumns.Created.Should().Be("timestamp");
+            journalColumns.Tags.Should().Be("tags");
+            journalColumns.Message.Should().Be("payload");
+            journalColumns.Identitifer.Should().Be("serializer_id");
+            journalColumns.Manifest.Should().Be("manifest");
+            
+            // assert default metadata column names
+            var metaColumns = tableConfig.MetadataColumnNames;
+            metaColumns.PersistenceId.Should().Be("persistence_id");
+            metaColumns.SequenceNumber.Should().Be("sequence_nr");
+        }
+
+        [Fact(DisplayName = "Journal config with PostgreSql compat should contain correct SqlServer column names")]
+        public void PostgreSqlJournalConfigTest()
+        {
+            var journalHocon = ConfigurationFactory
+                .ParseString("akka.persistence.journal.linq2db.table-compatibility-mode = postgres")
+                .WithFallback(_defaultConfig)
+                .GetConfig("akka.persistence.journal.linq2db");
+            journalHocon.Should().NotBeNull();
+            
+            var journal = new JournalConfig(journalHocon);
+            // assert default values
+            AssertDefaultJournalConfig(journal);
+            
+            var tableConfig = journal.TableConfig;
+
+            // assert default journal column names
+            var journalColumns = tableConfig.ColumnNames;
+            journalColumns.Ordering.Should().Be("ordering");
+            journalColumns.Deleted.Should().Be("is_deleted");
+            journalColumns.PersistenceId.Should().Be("persistence_id");
+            journalColumns.SequenceNumber.Should().Be("sequence_nr");
+            journalColumns.Created.Should().Be("created_at");
+            journalColumns.Tags.Should().Be("tags");
+            journalColumns.Message.Should().Be("payload");
+            journalColumns.Identitifer.Should().Be("serializer_id");
+            journalColumns.Manifest.Should().Be("manifest");
+            
+            // assert default metadata column names
+            var metaColumns = tableConfig.MetadataColumnNames;
+            metaColumns.PersistenceId.Should().Be("persistence_id");
+            metaColumns.SequenceNumber.Should().Be("sequence_nr");
+        }
+
+        [Fact(DisplayName = "Journal config with MySql compat should contain correct SqlServer column names")]
+        public void MySqlJournalConfigTest()
+        {
+            var journalHocon = ConfigurationFactory
+                .ParseString("akka.persistence.journal.linq2db.table-compatibility-mode = mysql")
+                .WithFallback(_defaultConfig)
+                .GetConfig("akka.persistence.journal.linq2db");
+            journalHocon.Should().NotBeNull();
+            
+            var journal = new JournalConfig(journalHocon);
+            // assert default values
+            AssertDefaultJournalConfig(journal);
+            
+            var tableConfig = journal.TableConfig;
+
+            // assert default journal column names
+            var journalColumns = tableConfig.ColumnNames;
+            journalColumns.Ordering.Should().Be("ordering");
+            journalColumns.Deleted.Should().Be("is_deleted");
+            journalColumns.PersistenceId.Should().Be("persistence_id");
+            journalColumns.SequenceNumber.Should().Be("sequence_nr");
+            journalColumns.Created.Should().Be("created_at");
+            journalColumns.Tags.Should().Be("tags");
+            journalColumns.Message.Should().Be("payload");
+            journalColumns.Identitifer.Should().Be("serializer_id");
+            journalColumns.Manifest.Should().Be("manifest");
+            
+            // assert default metadata column names
+            var metaColumns = tableConfig.MetadataColumnNames;
+            metaColumns.PersistenceId.Should().Be("persistence_id");
+            metaColumns.SequenceNumber.Should().Be("sequence_nr");
+        }
+
+        private static void AssertDefaultJournalConfig(JournalConfig journal)
+        {
+            journal.ConnectionString.Should().BeNullOrEmpty();
+            journal.MaterializerDispatcher.Should().Be("akka.actor.default-dispatcher");
+            journal.ProviderName.Should().BeNullOrEmpty();
+            journal.UseSharedDb.Should().BeNullOrEmpty();
+            journal.UseCloneConnection.Should().BeFalse();
+            journal.DefaultSerializer.Should().BeNullOrEmpty();
+
+            var pluginConfig = journal.PluginConfig;
+            pluginConfig.TagSeparator.Should().Be(",");
+            var daoType = Type.GetType(pluginConfig.Dao);
+            daoType.Should().Be(typeof(ByteArrayJournalDao));
+
+            var daoConfig = journal.DaoConfig;
+            daoConfig.BufferSize.Should().Be(5000);
+            daoConfig.BatchSize.Should().Be(100);
+            daoConfig.DbRoundTripBatchSize.Should().Be(1000);
+            daoConfig.PreferParametersOnMultiRowInsert.Should().BeTrue();
+            daoConfig.ReplayBatchSize.Should().Be(1000);
+            daoConfig.Parallelism.Should().Be(3);
+            daoConfig.LogicalDelete.Should().BeFalse();
+            daoConfig.MaxRowByRowSize.Should().Be(100);
+            daoConfig.SqlCommonCompatibilityMode.Should().BeTrue();
+            
+            var tableConfig = journal.TableConfig;
+            tableConfig.AutoInitialize.Should().BeTrue();
+            tableConfig.TableName.Should().Be("journal");
+            tableConfig.MetadataTableName.Should().Be("journal_metadata");
+            tableConfig.SchemaName.Should().BeNullOrEmpty();
+            tableConfig.WarnOnAutoInitializeFail.Should().BeTrue();
+        }
+        
+
+    }
+}

--- a/src/Akka.Persistence.Sql.Linq2Db.Tests/Settings/ReadJournalConfigSpec.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db.Tests/Settings/ReadJournalConfigSpec.cs
@@ -1,0 +1,271 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="ReadJournalConfigSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using Akka.Configuration;
+using Akka.Persistence.Sql.Linq2Db.Config;
+using Akka.Persistence.Sql.Linq2Db.Journal;
+using Akka.Persistence.Sql.Linq2Db.Journal.DAO;
+using Akka.Persistence.Sql.Linq2Db.Query;
+using FluentAssertions;
+using LanguageExt.UnitsOfMeasure;
+using Xunit;
+
+namespace Akka.Persistence.Sql.Linq2Db.Tests.Settings
+{
+    public class ReadJournalConfigSpec
+    {
+        private readonly Configuration.Config _defaultConfig;
+        
+        public ReadJournalConfigSpec()
+        {
+            _defaultConfig = Linq2DbWriteJournal.DefaultConfiguration;
+        }
+
+        [Fact(DisplayName = "Default journal query HOCON config should contain default values")]
+        public void DefaultJournalQueryHoconConfigTest()
+        {
+            var query = _defaultConfig.GetConfig("akka.persistence.query.journal.linq2db");
+            query.Should().NotBeNull();
+            
+            var stringType = query.GetString("class");
+            var type = Type.GetType(stringType);
+            type.Should().Be(typeof(Linq2DbReadJournalProvider));
+
+            query.GetString("write-plugin", "invalid").Should().BeNullOrEmpty();
+            query.GetBoolean("include-logically-deleted").Should().BeTrue();
+            query.GetInt("max-buffer-size").Should().Be(500);
+            query.GetTimeSpan("refresh-interval").Should().Be(1.Seconds());
+            query.GetString("connection-string", "invalid").Should().BeNullOrEmpty();
+            query.GetString("provider-name", "invalid").Should().BeNullOrEmpty();
+            query.GetBoolean("logical-delete").Should().BeFalse();
+            query.GetBoolean("delete-compatibility-mode").Should().BeTrue();
+            query.GetString("table-compatibility-mode", "invalid").Should().BeNullOrEmpty();
+            query.GetInt("buffer-size").Should().Be(5000);
+            query.GetInt("batch-size").Should().Be(100);
+            query.GetInt("replay-batch-size").Should().Be(1000);
+            query.GetInt("parallelism").Should().Be(3);
+            query.GetInt("max-row-by-row-size").Should().Be(100);
+            query.GetBoolean("use-clone-connection").Should().BeFalse();
+            query.GetString("tag-separator", "invalid").Should().Be(",");
+            query.GetString("dao", "invalid").Should()
+                .Be("Akka.Persistence.Sql.Linq2Db.Journal.DAO.ByteArrayJournalDao, Akka.Persistence.Sql.Linq2Db");
+
+            var retrieval = query.GetConfig("journal-sequence-retrieval");
+            retrieval.Should().NotBeNull();
+            retrieval.GetInt("batch-size").Should().Be(10000);
+            retrieval.GetInt("max-tries").Should().Be(10);
+            retrieval.GetTimeSpan("query-delay").Should().Be(1.Seconds());
+            retrieval.GetTimeSpan("max-backoff-query-delay").Should().Be(1.Minutes());
+            retrieval.GetTimeSpan("ask-timeout").Should().Be(1.Seconds());
+            
+            var journalTable = query.GetConfig("tables.journal");
+            journalTable.Should().NotBeNull();
+            journalTable.GetBoolean("auto-init").Should().BeTrue();
+            journalTable.GetBoolean("warn-on-auto-init-fail").Should().BeTrue();
+            journalTable.GetString("table-name", "invalid").Should().Be("journal");
+            journalTable.GetString("metadata-table-name", "invalid").Should().Be("journal_metadata");
+            journalTable.GetString("schema-name", "invalid").Should().BeNullOrEmpty();
+        }
+        
+        [Fact(DisplayName = "Default journal query config should contain default values")]
+        public void DefaultReadJournalConfigTest()
+        {
+            var journalHocon = _defaultConfig.GetConfig("akka.persistence.query.journal.linq2db");
+            journalHocon.Should().NotBeNull();
+
+            var journal = new ReadJournalConfig(journalHocon);
+            // assert default values
+            AssertDefaultQueryConfig(journal);
+            
+            var tableConfig = journal.TableConfig;
+
+            // assert default journal column names
+            var journalColumns = tableConfig.ColumnNames;
+            journalColumns.Ordering.Should().Be("ordering");
+            journalColumns.Deleted.Should().Be("deleted");
+            journalColumns.PersistenceId.Should().Be("persistence_id");
+            journalColumns.SequenceNumber.Should().Be("sequence_number");
+            journalColumns.Created.Should().Be("created");
+            journalColumns.Tags.Should().Be("tags");
+            journalColumns.Message.Should().Be("message");
+            journalColumns.Identitifer.Should().Be("identifier");
+            journalColumns.Manifest.Should().Be("manifest");
+            
+            // assert default metadata column names
+            var metaColumns = tableConfig.MetadataColumnNames;
+            metaColumns.PersistenceId.Should().Be("persistenceId");
+            metaColumns.SequenceNumber.Should().Be("sequenceNr");
+        }
+
+        [Fact(DisplayName = "Journal config with SqlServer compat should contain correct SqlServer column names")]
+        public void SqlServerJournalConfigTest()
+        {
+            var journalHocon = ConfigurationFactory
+                .ParseString("akka.persistence.query.journal.linq2db.table-compatibility-mode = sqlserver")
+                .WithFallback(_defaultConfig)
+                .GetConfig("akka.persistence.query.journal.linq2db");
+            journalHocon.Should().NotBeNull();
+            
+            var journal = new ReadJournalConfig(journalHocon);
+            // assert default values
+            AssertDefaultQueryConfig(journal);
+            
+            var tableConfig = journal.TableConfig;
+
+            // assert default journal column names
+            var journalColumns = tableConfig.ColumnNames;
+            journalColumns.Ordering.Should().Be("Ordering");
+            journalColumns.Deleted.Should().Be("IsDeleted");
+            journalColumns.PersistenceId.Should().Be("PersistenceId");
+            journalColumns.SequenceNumber.Should().Be("SequenceNr");
+            journalColumns.Created.Should().Be("Timestamp");
+            journalColumns.Tags.Should().Be("Tags");
+            journalColumns.Message.Should().Be("Payload");
+            journalColumns.Identitifer.Should().Be("SerializerId");
+            journalColumns.Manifest.Should().Be("Manifest");
+            
+            // assert default metadata column names
+            var metaColumns = tableConfig.MetadataColumnNames;
+            metaColumns.PersistenceId.Should().Be("persistenceId");
+            metaColumns.SequenceNumber.Should().Be("sequenceNr");
+        }
+
+        [Fact(DisplayName = "Journal config with Sqlite compat should contain correct SqlServer column names")]
+        public void SqliteJournalConfigTest()
+        {
+            var journalHocon = ConfigurationFactory
+                .ParseString("akka.persistence.query.journal.linq2db.table-compatibility-mode = sqlite")
+                .WithFallback(_defaultConfig)
+                .GetConfig("akka.persistence.query.journal.linq2db");
+            journalHocon.Should().NotBeNull();
+            
+            var journal = new ReadJournalConfig(journalHocon);
+            // assert default values
+            AssertDefaultQueryConfig(journal);
+            
+            var tableConfig = journal.TableConfig;
+
+            // assert default journal column names
+            var journalColumns = tableConfig.ColumnNames;
+            journalColumns.Ordering.Should().Be("ordering");
+            journalColumns.Deleted.Should().Be("is_deleted");
+            journalColumns.PersistenceId.Should().Be("persistence_id");
+            journalColumns.SequenceNumber.Should().Be("sequence_nr");
+            journalColumns.Created.Should().Be("timestamp");
+            journalColumns.Tags.Should().Be("tags");
+            journalColumns.Message.Should().Be("payload");
+            journalColumns.Identitifer.Should().Be("serializer_id");
+            journalColumns.Manifest.Should().Be("manifest");
+            
+            // assert default metadata column names
+            var metaColumns = tableConfig.MetadataColumnNames;
+            metaColumns.PersistenceId.Should().Be("persistence_id");
+            metaColumns.SequenceNumber.Should().Be("sequence_nr");
+        }
+
+        [Fact(DisplayName = "Journal config with PostgreSql compat should contain correct SqlServer column names")]
+        public void PostgreSqlJournalConfigTest()
+        {
+            var journalHocon = ConfigurationFactory
+                .ParseString("akka.persistence.query.journal.linq2db.table-compatibility-mode = postgres")
+                .WithFallback(_defaultConfig)
+                .GetConfig("akka.persistence.query.journal.linq2db");
+            journalHocon.Should().NotBeNull();
+            
+            var journal = new ReadJournalConfig(journalHocon);
+            // assert default values
+            AssertDefaultQueryConfig(journal);
+            
+            var tableConfig = journal.TableConfig;
+
+            // assert default journal column names
+            var journalColumns = tableConfig.ColumnNames;
+            journalColumns.Ordering.Should().Be("ordering");
+            journalColumns.Deleted.Should().Be("is_deleted");
+            journalColumns.PersistenceId.Should().Be("persistence_id");
+            journalColumns.SequenceNumber.Should().Be("sequence_nr");
+            journalColumns.Created.Should().Be("created_at");
+            journalColumns.Tags.Should().Be("tags");
+            journalColumns.Message.Should().Be("payload");
+            journalColumns.Identitifer.Should().Be("serializer_id");
+            journalColumns.Manifest.Should().Be("manifest");
+            
+            // assert default metadata column names
+            var metaColumns = tableConfig.MetadataColumnNames;
+            metaColumns.PersistenceId.Should().Be("persistence_id");
+            metaColumns.SequenceNumber.Should().Be("sequence_nr");
+        }
+
+        [Fact(DisplayName = "Journal config with MySql compat should contain correct SqlServer column names")]
+        public void MySqlJournalConfigTest()
+        {
+            var journalHocon = ConfigurationFactory
+                .ParseString("akka.persistence.query.journal.linq2db.table-compatibility-mode = mysql")
+                .WithFallback(_defaultConfig)
+                .GetConfig("akka.persistence.query.journal.linq2db");
+            journalHocon.Should().NotBeNull();
+            
+            var journal = new ReadJournalConfig(journalHocon);
+            // assert default values
+            AssertDefaultQueryConfig(journal);
+            
+            var tableConfig = journal.TableConfig;
+
+            // assert default journal column names
+            var journalColumns = tableConfig.ColumnNames;
+            journalColumns.Ordering.Should().Be("ordering");
+            journalColumns.Deleted.Should().Be("is_deleted");
+            journalColumns.PersistenceId.Should().Be("persistence_id");
+            journalColumns.SequenceNumber.Should().Be("sequence_nr");
+            journalColumns.Created.Should().Be("created_at");
+            journalColumns.Tags.Should().Be("tags");
+            journalColumns.Message.Should().Be("payload");
+            journalColumns.Identitifer.Should().Be("serializer_id");
+            journalColumns.Manifest.Should().Be("manifest");
+            
+            // assert default metadata column names
+            var metaColumns = tableConfig.MetadataColumnNames;
+            metaColumns.PersistenceId.Should().Be("persistence_id");
+            metaColumns.SequenceNumber.Should().Be("sequence_nr");
+        }
+
+        private static void AssertDefaultQueryConfig(ReadJournalConfig journal)
+        {
+            journal.ConnectionString.Should().BeNullOrEmpty();
+            journal.ProviderName.Should().BeNullOrEmpty();
+            journal.UseCloneConnection.Should().BeFalse();
+            journal.RefreshInterval.Should().Be(1.Seconds());
+            journal.MaxBufferSize.Should().Be(500);
+            journal.AddShutdownHook.Should().BeTrue();
+            journal.IncludeDeleted.Should().BeTrue();
+
+            var pluginConfig = journal.PluginConfig;
+            pluginConfig.TagSeparator.Should().Be(",");
+            var daoType = Type.GetType(pluginConfig.Dao);
+            daoType.Should().Be(typeof(ByteArrayJournalDao));
+
+            var daoConfig = journal.DaoConfig;
+            daoConfig.BufferSize.Should().Be(5000);
+            daoConfig.BatchSize.Should().Be(100);
+            // daoConfig.DbRoundTripBatchSize.Should().Be(1000); // Not used in query config
+            // daoConfig.PreferParametersOnMultiRowInsert.Should().BeTrue(); // Not used in query config
+            daoConfig.ReplayBatchSize.Should().Be(1000);
+            daoConfig.Parallelism.Should().Be(3);
+            daoConfig.LogicalDelete.Should().BeFalse();
+            daoConfig.MaxRowByRowSize.Should().Be(100);
+            daoConfig.SqlCommonCompatibilityMode.Should().BeTrue();
+            
+            var tableConfig = journal.TableConfig;
+            tableConfig.AutoInitialize.Should().BeTrue();
+            tableConfig.TableName.Should().Be("journal");
+            tableConfig.MetadataTableName.Should().Be("journal_metadata");
+            tableConfig.SchemaName.Should().BeNullOrEmpty();
+            tableConfig.WarnOnAutoInitializeFail.Should().BeTrue();
+        }
+    }
+}

--- a/src/Akka.Persistence.Sql.Linq2Db.Tests/Settings/SnapshotConfigSpec.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db.Tests/Settings/SnapshotConfigSpec.cs
@@ -1,0 +1,200 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="SnapshotConfigSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using Akka.Configuration;
+using Akka.Persistence.Sql.Linq2Db.Config;
+using Akka.Persistence.Sql.Linq2Db.Journal.DAO;
+using Akka.Persistence.Sql.Linq2Db.Snapshot;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Persistence.Sql.Linq2Db.Tests.Settings
+{
+    public class SnapshotConfigSpec
+    {
+        private readonly Configuration.Config _defaultConfig;
+        
+        public SnapshotConfigSpec()
+        {
+            _defaultConfig = Linq2DbSnapshotStore.DefaultConfiguration;
+        }
+
+        [Fact(DisplayName = "Default snapshot HOCON config should contain default values")]
+        public void DefaultJournalHoconConfigTest()
+        {
+            var snapshot = _defaultConfig.GetConfig("akka.persistence.snapshot-store.linq2db");
+            snapshot.Should().NotBeNull();
+            
+            var stringType = snapshot.GetString("class");
+            var type = Type.GetType(stringType);
+            type.Should().Be(typeof(Linq2DbSnapshotStore));
+
+            snapshot.GetString("plugin-dispatcher").Should()
+                .Be("akka.persistence.dispatchers.default-plugin-dispatcher");
+            snapshot.GetString("connection-string", "invalid").Should().BeNullOrEmpty();
+            snapshot.GetString("provider-name", "invalid").Should().BeNullOrEmpty();
+            snapshot.GetBoolean("use-clone-connection").Should().BeFalse();
+            snapshot.GetString("table-compatibility-mode", "invalid").Should().BeNullOrEmpty();
+            snapshot.GetString("serializer", "invalid").Should().BeNullOrEmpty();
+            snapshot.GetString("dao", "invalid").Should()
+                .Be("Akka.Persistence.Sql.Linq2Db.Journal.DAO.ByteArrayJournalDao, Akka.Persistence.Sql.Linq2Db");
+            
+            var snapshotTable = snapshot.GetConfig("tables.snapshot");
+            snapshotTable.Should().NotBeNull();
+            snapshotTable.GetBoolean("auto-init").Should().BeTrue();
+            snapshotTable.GetBoolean("warn-on-auto-init-fail").Should().BeTrue();
+            snapshotTable.GetString("table-name", "invalid").Should().Be("snapshot");
+            snapshotTable.GetString("schema-name", "invalid").Should().BeNullOrEmpty();
+        }
+        
+        [Fact(DisplayName = "Default snapshot config should contain default values")]
+        public void DefaultSnapshotConfigTest()
+        {
+            var snapshotHocon = _defaultConfig.GetConfig("akka.persistence.snapshot-store.linq2db");
+            snapshotHocon.Should().NotBeNull();
+
+            var snapshot = new SnapshotConfig(snapshotHocon);
+            // assert default values
+            AssertDefaultSnapshotConfig(snapshot);
+            
+            var tableConfig = snapshot.TableConfig;
+
+            // assert default snapshot column names
+            var snapshotColumns = tableConfig.ColumnNames;
+            snapshotColumns.PersistenceId.Should().Be("persistence_id");
+            snapshotColumns.SequenceNumber.Should().Be("sequence_number");
+            snapshotColumns.Created.Should().Be("created");
+            snapshotColumns.Snapshot.Should().Be("snapshot");
+            snapshotColumns.Manifest.Should().Be("manifest");
+            snapshotColumns.SerializerId.Should().Be("serializer_id");
+        }
+
+        [Fact(DisplayName = "Snapshot config with SqlServer compat should contain correct SqlServer column names")]
+        public void SqlServerSnapshotConfigTest()
+        {
+            var snapshotHocon = ConfigurationFactory
+                .ParseString("akka.persistence.snapshot-store.linq2db.table-compatibility-mode = sqlserver")
+                .WithFallback(_defaultConfig)
+                .GetConfig("akka.persistence.snapshot-store.linq2db");
+            snapshotHocon.Should().NotBeNull();
+
+            var snapshot = new SnapshotConfig(snapshotHocon);
+            // assert default values
+            AssertDefaultSnapshotConfig(snapshot);
+            
+            var tableConfig = snapshot.TableConfig;
+
+            // assert default snapshot column names
+            var snapshotColumns = tableConfig.ColumnNames;
+            snapshotColumns.PersistenceId.Should().Be("PersistenceId");
+            snapshotColumns.SequenceNumber.Should().Be("SequenceNr");
+            snapshotColumns.Created.Should().Be("Timestamp");
+            snapshotColumns.Snapshot.Should().Be("Snapshot");
+            snapshotColumns.Manifest.Should().Be("Manifest");
+            snapshotColumns.SerializerId.Should().Be("SerializerId");
+        }
+
+        [Fact(DisplayName = "Snapshot config with Sqlite compat should contain correct SqlServer column names")]
+        public void SqliteSnapshotConfigTest()
+        {
+            var snapshotHocon = ConfigurationFactory
+                .ParseString("akka.persistence.snapshot-store.linq2db.table-compatibility-mode = sqlite")
+                .WithFallback(_defaultConfig)
+                .GetConfig("akka.persistence.snapshot-store.linq2db");
+            snapshotHocon.Should().NotBeNull();
+
+            var snapshot = new SnapshotConfig(snapshotHocon);
+            // assert default values
+            AssertDefaultSnapshotConfig(snapshot);
+            
+            var tableConfig = snapshot.TableConfig;
+
+            // assert default snapshot column names
+            var snapshotColumns = tableConfig.ColumnNames;
+            snapshotColumns.PersistenceId.Should().Be("persistence_id");
+            snapshotColumns.SequenceNumber.Should().Be("sequence_nr");
+            snapshotColumns.Created.Should().Be("created_at");
+            snapshotColumns.Snapshot.Should().Be("payload");
+            snapshotColumns.Manifest.Should().Be("manifest");
+            snapshotColumns.SerializerId.Should().Be("serializer_id");
+        }
+
+        [Fact(DisplayName = "Snapshot config with PostgreSql compat should contain correct SqlServer column names")]
+        public void PostgreSqlSnapshotConfigTest()
+        {
+            var snapshotHocon = ConfigurationFactory
+                .ParseString("akka.persistence.snapshot-store.linq2db.table-compatibility-mode = postgres")
+                .WithFallback(_defaultConfig)
+                .GetConfig("akka.persistence.snapshot-store.linq2db");
+            snapshotHocon.Should().NotBeNull();
+
+            var snapshot = new SnapshotConfig(snapshotHocon);
+            // assert default values
+            AssertDefaultSnapshotConfig(snapshot);
+            
+            var tableConfig = snapshot.TableConfig;
+
+            // assert default snapshot column names
+            var snapshotColumns = tableConfig.ColumnNames;
+            snapshotColumns.PersistenceId.Should().Be("persistence_id");
+            snapshotColumns.SequenceNumber.Should().Be("sequence_nr");
+            snapshotColumns.Created.Should().Be("created_at");
+            snapshotColumns.Snapshot.Should().Be("payload");
+            snapshotColumns.Manifest.Should().Be("manifest");
+            snapshotColumns.SerializerId.Should().Be("serializer_id");
+        }
+
+        [Fact(DisplayName = "Snapshot config with MySql compat should contain correct SqlServer column names")]
+        public void MySqlSnapshotConfigTest()
+        {
+            var snapshotHocon = ConfigurationFactory
+                .ParseString("akka.persistence.snapshot-store.linq2db.table-compatibility-mode = mysql")
+                .WithFallback(_defaultConfig)
+                .GetConfig("akka.persistence.snapshot-store.linq2db");
+            snapshotHocon.Should().NotBeNull();
+
+            var snapshot = new SnapshotConfig(snapshotHocon);
+            // assert default values
+            AssertDefaultSnapshotConfig(snapshot);
+            
+            var tableConfig = snapshot.TableConfig;
+
+            // assert default snapshot column names
+            var snapshotColumns = tableConfig.ColumnNames;
+            snapshotColumns.PersistenceId.Should().Be("persistence_id");
+            snapshotColumns.SequenceNumber.Should().Be("sequence_nr");
+            snapshotColumns.Created.Should().Be("created_at");
+            snapshotColumns.Snapshot.Should().Be("snapshot");
+            snapshotColumns.Manifest.Should().Be("manifest");
+            snapshotColumns.SerializerId.Should().Be("serializer_id");
+        }
+
+        private static void AssertDefaultSnapshotConfig(SnapshotConfig snapshot)
+        {
+            snapshot.ConnectionString.Should().BeNullOrEmpty();
+            snapshot.ProviderName.Should().BeNullOrEmpty();
+            snapshot.UseCloneConnection.Should().BeFalse();
+            snapshot.DefaultSerializer.Should().BeNullOrEmpty();
+            snapshot.UseSharedDb.Should().BeNullOrEmpty();
+            
+            var pluginConfig = snapshot.PluginConfig;
+            var daoType = Type.GetType(pluginConfig.Dao);
+            daoType.Should().Be(typeof(ByteArrayJournalDao));
+
+            var daoConfig = snapshot.IDaoConfig;
+            daoConfig.SqlCommonCompatibilityMode.Should().BeFalse();
+            daoConfig.Parallelism.Should().Be(0); // this is not set
+            
+            var tableConfig = snapshot.TableConfig;
+            tableConfig.AutoInitialize.Should().BeTrue();
+            tableConfig.TableName.Should().Be("snapshot");
+            tableConfig.SchemaName.Should().BeNullOrEmpty();
+            tableConfig.WarnOnAutoInitializeFail.Should().BeTrue();
+        }
+    }
+}

--- a/src/Akka.Persistence.Sql.Linq2Db.Tests/Sqlite/SQLiteJournalSpecConfig.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db.Tests/Sqlite/SQLiteJournalSpecConfig.cs
@@ -8,72 +8,62 @@ namespace Akka.Persistence.Sql.Linq2Db.Tests
     public static class SQLiteSnapshotSpecConfig
     {
         public static string _journalBaseConfig = @"
-            akka.persistence {{
-                publish-plugin-commands = on
-                snapshot-store {{
-                    plugin = ""akka.persistence.snapshot-store.testspec""
-                    testspec {{
-                        class = ""{0}""
-                        #plugin-dispatcher = ""akka.actor.default-dispatcher""
-plugin-dispatcher = ""akka.persistence.dispatchers.default-plugin-dispatcher""
-                        connection-string = ""{1}""
-#connection-string = ""FullUri=file:test.db&cache=shared""
-                        provider-name = ""{2}""
-                        parallelism = 1
-                        max-row-by-row-size = 100
-                        tables.snapshot {{ 
-                          auto-init = true 
-                          warn-on-auto-init-fail = false
-                        }}
-                        use-clone-connection = ""{3}""
-                    }}
-                }}
-            }}
+            
         ";
         
         public static Configuration.Config Create(string connString, string providerName)
         {
-            return ConfigurationFactory.ParseString(
-                string.Format(_journalBaseConfig,
-                    typeof(Linq2DbSnapshotStore).AssemblyQualifiedName,
-                    connString, providerName, (providerName == ProviderName.SQLiteMS).ToString().ToLower()));
+            return ConfigurationFactory.ParseString($@"
+akka.persistence {{
+    publish-plugin-commands = on
+    snapshot-store {{
+        plugin = ""akka.persistence.snapshot-store.testspec""
+        testspec {{
+            class = ""{typeof(Linq2DbSnapshotStore).AssemblyQualifiedName}""
+            #plugin-dispatcher = ""akka.actor.default-dispatcher""
+            plugin-dispatcher = ""akka.persistence.dispatchers.default-plugin-dispatcher""
+            connection-string = ""{connString}""
+            #connection-string = ""FullUri=file:test.db&cache=shared""
+            provider-name = ""{providerName}""
+            parallelism = 1
+            max-row-by-row-size = 100
+            tables.snapshot {{ 
+                auto-init = true 
+                warn-on-auto-init-fail = false
+            }}
+            use-clone-connection = {(providerName == ProviderName.SQLiteMS ? "on" : "off")}
+        }}
+    }}
+}}");
         }
     }
     public static class SQLiteJournalSpecConfig
     {
-        public static string _journalBaseConfig = @"
-            akka.persistence {{
-                publish-plugin-commands = on
-                journal {{
-                    plugin = ""akka.persistence.journal.testspec""
-                    testspec {{
-                        class = ""{0}""
-                        #plugin-dispatcher = ""akka.actor.default-dispatcher""
-plugin-dispatcher = ""akka.persistence.dispatchers.default-plugin-dispatcher""
-                        connection-string = ""{1}""
-#connection-string = ""FullUri=file:test.db&cache=shared""
-                        provider-name = ""{2}""
-                        parallelism = 1
-                        max-row-by-row-size = 100
-                        delete-compatibility-mode = ""{4}""
-                        tables.journal {{ 
-                          auto-init = true
-                          warn-on-auto-init-fail = false 
-                        }}
-                        use-clone-connection = ""{3}""
-                    }}
-                }}
-            }}
-        ";
-        
         public static Configuration.Config Create(string connString, string providerName, bool nativeMode = false)
         {
-            return ConfigurationFactory.ParseString(
-                string.Format(_journalBaseConfig,
-                    typeof(Linq2DbWriteJournal).AssemblyQualifiedName,
-                    connString, providerName,
-                    (providerName == ProviderName.SQLiteMS).ToString()
-                    .ToLower(), (nativeMode == false).ToString().ToLower()));
+            return ConfigurationFactory.ParseString($@"
+akka.persistence {{
+    publish-plugin-commands = on
+    journal {{
+        plugin = ""akka.persistence.journal.linq2db""
+        linq2db {{
+            class = ""{typeof(Linq2DbWriteJournal).AssemblyQualifiedName}""
+            #plugin-dispatcher = ""akka.actor.default-dispatcher""
+            plugin-dispatcher = ""akka.persistence.dispatchers.default-plugin-dispatcher""
+            connection-string = ""{connString}""
+            #connection-string = ""FullUri=file:test.db&cache=shared""
+            provider-name = ""{providerName}""
+            parallelism = 1
+            max-row-by-row-size = 100
+            delete-compatibility-mode = {(nativeMode == false ? "on" : "off")}
+            tables.journal {{ 
+                auto-init = true
+                warn-on-auto-init-fail = false 
+            }}
+            use-clone-connection = {(providerName == ProviderName.SQLiteMS ? "on" : "off")}
+        }}
+    }}
+}}");
         }
     }
 }

--- a/src/Akka.Persistence.Sql.Linq2Db/Akka.Persistence.Sql.Linq2Db.csproj
+++ b/src/Akka.Persistence.Sql.Linq2Db/Akka.Persistence.Sql.Linq2Db.csproj
@@ -21,10 +21,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <Folder Include="Journal\Config" />
-    </ItemGroup>
-
-    <ItemGroup>
         <None Remove="persistence.conf" />
         <EmbeddedResource Include="persistence.conf">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/src/Akka.Persistence.Sql.Linq2Db/Config/JournalConfig.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db/Config/JournalConfig.cs
@@ -8,9 +8,6 @@ namespace Akka.Persistence.Sql.Linq2Db.Config
     {
         public JournalConfig(Configuration.Config config)
         {
-            config =
-                config.SafeWithFallback(
-                    Linq2DbWriteJournal.DefaultConfiguration);
             MaterializerDispatcher = config.GetString("materializer-dispatcher","akka.actor.default-dispatcher");
             ConnectionString = config.GetString("connection-string");
             ProviderName = config.GetString("provider-name");
@@ -21,7 +18,7 @@ namespace Akka.Persistence.Sql.Linq2Db.Config
             UseSharedDb = string.IsNullOrWhiteSpace(dbConf) ? null : dbConf;
             UseCloneConnection =
                 config.GetBoolean("use-clone-connection", false);
-            
+            DefaultSerializer = config.GetString("serializer", null);
         }
         
         public string MaterializerDispatcher { get; protected set; }

--- a/src/Akka.Persistence.Sql.Linq2Db/Config/JournalPluginConfig.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db/Config/JournalPluginConfig.cs
@@ -6,7 +6,7 @@
         {
             TagSeparator = config.GetString("tag-separator", ",");
             //TODO: FILL IN SANELY
-            Dao = config.GetString("dao", "Akka.Persistence.Sql.Linq2Db.Journal.DAO.ByteArrayJournalDao ;Akka.Persistence.Sql.Linq2Db.Journal");
+            Dao = config.GetString("dao", "Akka.Persistence.Sql.Linq2Db.Journal.DAO.ByteArrayJournalDao, Akka.Persistence.Sql.Linq2Db");
         }
         public string TagSeparator { get; protected set; }
         public string Dao { get; protected set; }

--- a/src/Akka.Persistence.Sql.Linq2Db/Config/JournalTableColumnNames.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db/Config/JournalTableColumnNames.cs
@@ -22,6 +22,9 @@ namespace Akka.Persistence.Sql.Linq2Db.Config
                 case "postgres":
                     colString = "postgres-compat-column-names";
                     break;
+                case "mysql":
+                    colString = "mysql-compat-column-names";
+                    break;
                 default:
                     colString = "column-names";
                     break;
@@ -32,7 +35,7 @@ namespace Akka.Persistence.Sql.Linq2Db.Config
                     ConfigurationFactory.ParseString(FallBack).GetConfig($"tables.journal.{colString}"));
             Ordering =       cfg.GetString("ordering","ordering");
             Deleted =        cfg.GetString("deleted","deleted");
-            PersistenceId =  cfg.GetString("PersistenceId", "persistence_id");
+            PersistenceId =  cfg.GetString("persistenceId", "persistence_id");
             SequenceNumber = cfg.GetString("sequenceNumber", "sequence_number");
             Created =        cfg.GetString("created", "created");
             Tags =           cfg.GetString("tags", "tags");
@@ -83,44 +86,64 @@ namespace Akka.Persistence.Sql.Linq2Db.Config
             hashCode.Add(Manifest);
             return hashCode.ToHashCode();
         }
-        public static readonly string FallBack = @"tables.journal
-  { 
+        public static readonly string FallBack = @"
+tables.journal { 
     sqlserver-compat-column-names {
-          ""ordering"" = ""ordering""
-        ""deleted"" = ""isdeleted""
-        ""PersistenceId"" = ""PersistenceId""
-        ""sequenceNumber"" = ""sequenceNr""
-        ""created"" = ""Timestamp""
-        ""tags"" = ""tags""
-        ""message"" = ""payload""
-        ""identifier"" = ""serializerid""
-        ""manifest"" = ""manifest""
+        ordering = Ordering
+        deleted = IsDeleted
+        persistenceId = PersistenceId
+        sequenceNumber = SequenceNr
+        created = Timestamp
+        tags = Tags
+        message = Payload
+        identifier = SerializerId
+        manifest = Manifest
     }
     sqlite-compat-column-names {
-    ""ordering"" = ""ordering""
-    ""deleted"" = ""is_deleted""
-    ""PersistenceId"" = ""persistence_Id""
-    ""sequenceNumber"" = ""sequence_nr""
-    ""created"" = ""Timestamp""
-    ""tags"" = ""tags""
-    ""message"" = ""payload""
-    ""identifier"" = ""serializer_id""
-    ""manifest"" = ""manifest""
+        ordering = ordering
+        deleted = is_deleted
+        persistenceId = persistence_id
+        sequenceNumber = sequence_nr
+        created = timestamp
+        tags = tags
+        message = payload
+        identifier = serializer_id
+        manifest = manifest
     }
-postgres-compat-column-names {
-          ""ordering"" = ""ordering""
-        ""deleted"" = ""is_deleted""
-        ""PersistenceId"" = ""persistence_id""
-        ""sequenceNumber"" = ""sequence_nr""
-        ""created"" = ""created_at""
-        ""tags"" = ""tags""
-        ""message"" = ""payload""
-        ""identifier"" = ""serializer_id""
-        ""manifest"" = ""manifest""
+    postgres-compat-column-names {
+        ordering = ordering
+        deleted = is_deleted
+        persistenceId = persistence_id
+        sequenceNumber = sequence_nr
+        created = created_at
+        tags = tags
+        message = payload
+        identifier = serializer_id
+        manifest = manifest
     }
- column-names
- { 
- }
+    mysql-compat-column-names {
+        ordering = ordering
+        deleted = is_deleted
+        persistenceId = persistence_id
+        sequenceNumber = sequence_nr
+        created = created_at
+        tags = tags
+        message = payload
+        identifier = serializer_id
+        manifest = manifest
+    }
+    column-names
+    {
+        ordering = ordering
+        deleted = deleted
+        persistenceId = persistence_id
+        sequenceNumber = sequence_number
+        created = created
+        tags = tags
+        message = message
+        identifier = identifier
+        manifest = manifest
+    }
 }";
     }
 }

--- a/src/Akka.Persistence.Sql.Linq2Db/Config/JournalTableColumnNames.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db/Config/JournalTableColumnNames.cs
@@ -30,9 +30,7 @@ namespace Akka.Persistence.Sql.Linq2Db.Config
                     break;
             }
             
-            var cfg = config
-                .GetConfig($"tables.journal.{colString}").SafeWithFallback(
-                    ConfigurationFactory.ParseString(FallBack).GetConfig($"tables.journal.{colString}"));
+            var cfg = config.GetConfig($"tables.journal.{colString}");
             Ordering =       cfg.GetString("ordering","ordering");
             Deleted =        cfg.GetString("deleted","deleted");
             PersistenceId =  cfg.GetString("persistenceId", "persistence_id");
@@ -86,64 +84,5 @@ namespace Akka.Persistence.Sql.Linq2Db.Config
             hashCode.Add(Manifest);
             return hashCode.ToHashCode();
         }
-        public static readonly string FallBack = @"
-tables.journal { 
-    sqlserver-compat-column-names {
-        ordering = Ordering
-        deleted = IsDeleted
-        persistenceId = PersistenceId
-        sequenceNumber = SequenceNr
-        created = Timestamp
-        tags = Tags
-        message = Payload
-        identifier = SerializerId
-        manifest = Manifest
-    }
-    sqlite-compat-column-names {
-        ordering = ordering
-        deleted = is_deleted
-        persistenceId = persistence_id
-        sequenceNumber = sequence_nr
-        created = timestamp
-        tags = tags
-        message = payload
-        identifier = serializer_id
-        manifest = manifest
-    }
-    postgres-compat-column-names {
-        ordering = ordering
-        deleted = is_deleted
-        persistenceId = persistence_id
-        sequenceNumber = sequence_nr
-        created = created_at
-        tags = tags
-        message = payload
-        identifier = serializer_id
-        manifest = manifest
-    }
-    mysql-compat-column-names {
-        ordering = ordering
-        deleted = is_deleted
-        persistenceId = persistence_id
-        sequenceNumber = sequence_nr
-        created = created_at
-        tags = tags
-        message = payload
-        identifier = serializer_id
-        manifest = manifest
-    }
-    column-names
-    {
-        ordering = ordering
-        deleted = deleted
-        persistenceId = persistence_id
-        sequenceNumber = sequence_number
-        created = created
-        tags = tags
-        message = message
-        identifier = identifier
-        manifest = manifest
-    }
-}";
     }
 }

--- a/src/Akka.Persistence.Sql.Linq2Db/Config/MetadataTableColumnNames.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db/Config/MetadataTableColumnNames.cs
@@ -23,6 +23,9 @@ namespace Akka.Persistence.Sql.Linq2Db.Config
                 case "postgres":
                     colString = "postgres-compat-metadata-column-names";
                     break;
+                case "mysql":
+                    colString = "mysql-compat-metadata-column-names";
+                    break;
                 default:
                     colString = "metadata-column-names";
                     break;
@@ -31,7 +34,7 @@ namespace Akka.Persistence.Sql.Linq2Db.Config
                 .GetConfig($"tables.journal.{colString}").SafeWithFallback(
                     ConfigurationFactory.ParseString(FallBack).GetConfig($"tables.journal.{colString}"));
             //var cfg =  config.GetConfig("tables.journal.metadata-column-names").SafeWithFallback(ConfigurationFactory.ParseString(FallBack).GetConfig("tables.journal.metadata-column-names"));
-            PersistenceId =  cfg.GetString("PersistenceId", "PersistenceId");
+            PersistenceId =  cfg.GetString("persistenceId", "PersistenceId");
             SequenceNumber = cfg.GetString("sequenceNumber", "sequenceNr");
         }
         protected bool Equals(MetadataTableColumnNames other)
@@ -54,22 +57,27 @@ namespace Akka.Persistence.Sql.Linq2Db.Config
 
         
         
-        public static readonly string FallBack = @"tables.journal{
+        public static readonly string FallBack = @"
+tables.journal {
     metadata-column-names {
-        ""PersistenceId"" = ""PersistenceId""
-        ""sequenceNumber"" = ""sequenceNr""
+        persistenceId = persistenceId
+        sequenceNumber = sequenceNr
     }
     sqlserver-compat-metadata-column-names {
-        ""PersistenceId"" = ""PersistenceId""
-        ""sequenceNumber"" = ""sequenceNr""
+        persistenceId = PersistenceId
+        sequenceNumber = SequenceNr
     }
     sqlite-compat-metadata-column-names {
-        ""PersistenceId"" = ""persistence_Id""
-        ""sequenceNumber"" = ""sequence_nr""
+        persistenceId = persistence_Id
+        sequenceNumber = sequence_nr
     }
     postgres-compat-metadata-column-names {
-        ""PersistenceId"" = ""persistence_id""
-        ""sequenceNumber"" = ""sequence_nr""
+        persistenceId = persistence_id
+        sequenceNumber = sequence_nr
+    }
+    mysql-compat-metadata-column-names {
+        persistenceId = persistence_id
+        sequenceNumber = sequence_nr
     }
 }";
     }

--- a/src/Akka.Persistence.Sql.Linq2Db/Config/MetadataTableColumnNames.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db/Config/MetadataTableColumnNames.cs
@@ -31,9 +31,7 @@ namespace Akka.Persistence.Sql.Linq2Db.Config
                     break;
             }
             var cfg = config
-                .GetConfig($"tables.journal.{colString}").SafeWithFallback(
-                    ConfigurationFactory.ParseString(FallBack).GetConfig($"tables.journal.{colString}"));
-            //var cfg =  config.GetConfig("tables.journal.metadata-column-names").SafeWithFallback(ConfigurationFactory.ParseString(FallBack).GetConfig("tables.journal.metadata-column-names"));
+                .GetConfig($"tables.journal.{colString}");
             PersistenceId =  cfg.GetString("persistenceId", "PersistenceId");
             SequenceNumber = cfg.GetString("sequenceNumber", "sequenceNr");
         }
@@ -54,31 +52,5 @@ namespace Akka.Persistence.Sql.Linq2Db.Config
         {
             return HashCode.Combine(PersistenceId, SequenceNumber);
         }
-
-        
-        
-        public static readonly string FallBack = @"
-tables.journal {
-    metadata-column-names {
-        persistenceId = persistenceId
-        sequenceNumber = sequenceNr
-    }
-    sqlserver-compat-metadata-column-names {
-        persistenceId = PersistenceId
-        sequenceNumber = SequenceNr
-    }
-    sqlite-compat-metadata-column-names {
-        persistenceId = persistence_Id
-        sequenceNumber = sequence_nr
-    }
-    postgres-compat-metadata-column-names {
-        persistenceId = persistence_id
-        sequenceNumber = sequence_nr
-    }
-    mysql-compat-metadata-column-names {
-        persistenceId = persistence_id
-        sequenceNumber = sequence_nr
-    }
-}";
     }
 }

--- a/src/Akka.Persistence.Sql.Linq2Db/Config/ReadJournalPluginConfig.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db/Config/ReadJournalPluginConfig.cs
@@ -5,9 +5,7 @@
         public ReadJournalPluginConfig(Configuration.Config config)
         {
             TagSeparator = config.GetString("tag-separator", ",");
-            Dao = config.GetString("dao",
-                "akka.persistence.sql.linq2db.dao.bytea.readjournal.bytearrayreadjournaldao");
-            
+            Dao = config.GetString("dao", "Akka.Persistence.Sql.Linq2Db.Journal.DAO.ByteArrayJournalDao, Akka.Persistence.Sql.Linq2Db");
         }
 
         public string Dao { get; set; }

--- a/src/Akka.Persistence.Sql.Linq2Db/Config/SnapshotConfig.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db/Config/SnapshotConfig.cs
@@ -16,9 +16,6 @@ namespace Akka.Persistence.Sql.Linq2Db.Config
     {
         public SnapshotConfig(Configuration.Config config)
         {
-            config =
-                config.SafeWithFallback(Linq2DbSnapshotStore
-                    .DefaultConfiguration.GetConfig("akka.persistence.snapshot-store.linq2db"));
             TableConfig = new SnapshotTableConfiguration(config);
             PluginConfig = new SnapshotPluginConfig(config);
             var dbConf = config.GetString(ConfigKeys.useSharedDb);

--- a/src/Akka.Persistence.Sql.Linq2Db/Config/SnapshotPluginConfig.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db/Config/SnapshotPluginConfig.cs
@@ -4,8 +4,7 @@
     {
         public SnapshotPluginConfig(Configuration.Config config)
         {
-            Dao = config.GetString("dao",
-                "akka.persistence.sql.linq2db.dao.bytea.snapshot.bytearraysnapshotdao");
+            Dao = config.GetString("dao", "Akka.Persistence.Sql.Linq2Db.Journal.DAO.ByteArrayJournalDao, Akka.Persistence.Sql.Linq2Db");
         }
 
         public string Dao { get; protected set; }

--- a/src/Akka.Persistence.Sql.Linq2Db/Config/SnapshotTableColumnNames.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db/Config/SnapshotTableColumnNames.cs
@@ -28,8 +28,7 @@ namespace Akka.Persistence.Sql.Linq2Db.Config
                     break;
             }
             var cfg = config
-                .GetConfig($"tables.snapshot.{colString}").SafeWithFallback(
-                    ConfigurationFactory.ParseString(FallBack).GetConfig($"tables.snapshot.{colString}"));
+                .GetConfig($"tables.snapshot.{colString}");
 
             PersistenceId = cfg.GetString("persistenceId", "persistence_id");
             SequenceNumber = cfg.GetString("sequenceNumber", "sequence_number");
@@ -49,48 +48,5 @@ namespace Akka.Persistence.Sql.Linq2Db.Config
             return HashCode.Combine(PersistenceId, SequenceNumber, Created,
                 Snapshot, Manifest, SerializerId);
         }
-
-        private static readonly string FallBack = @"
-column-names {
-    persistenceId = persistence_id
-    sequenceNumber = sequence_number
-    created = created
-    snapshot = snapshot
-    manifest = manifest
-    serializerId = serializer_id
-}
-sql-server-compat-column-names {
-    persistenceId = PersistenceId
-    sequenceNumber = SequenceNr
-    created = Timestamp
-    snapshot = Snapshot
-    manifest = Manifest
-    serializerId = SerializerId
-}
-sqlite-compat-column-names {
-    persistenceId = persistence_id
-    sequenceNumber = sequence_nr
-    created = created_at
-    snapshot = payload
-    manifest = manifest
-    serializerId = serializer_id
-}
-postgres-compat-column-names {
-    persistenceId: persistence_id,
-    sequenceNumber: sequence_nr,
-    created: created_at,
-    snapshot: payload,
-    manifest: manifest,
-    serializerId: serializer_id,
-}
-mysql-compat-column-names {
-    persistenceId: persistence_id,
-    sequenceNumber: sequence_nr,
-    created: created_at,
-    snapshot: snapshot,
-    manifest: manifest,
-    serializerId: serializer_id,
-}
-";
     }
 }

--- a/src/Akka.Persistence.Sql.Linq2Db/Config/SnapshotTableColumnNames.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db/Config/SnapshotTableColumnNames.cs
@@ -20,6 +20,9 @@ namespace Akka.Persistence.Sql.Linq2Db.Config
                 case "postgres":
                     colString = "postgres-compat-column-names";
                     break;
+                case "mysql":
+                    colString = "mysql-compat-column-names";
+                    break;
                 default:
                     colString = "column-names";
                     break;
@@ -47,30 +50,47 @@ namespace Akka.Persistence.Sql.Linq2Db.Config
                 Snapshot, Manifest, SerializerId);
         }
 
-        private static readonly string FallBack =
-            @"sql-server-compat-column-names {
-                  persistenceId = ""PersistenceId""
-                  sequenceNumber = ""sequencenr""
-                  created = ""timestamp""
-                  snapshot = ""snapshot""
-                  manifest = ""manifest""
-                  serializerId = ""serializerid""
-                }
+        private static readonly string FallBack = @"
+column-names {
+    persistenceId = persistence_id
+    sequenceNumber = sequence_number
+    created = created
+    snapshot = snapshot
+    manifest = manifest
+    serializerId = serializer_id
+}
+sql-server-compat-column-names {
+    persistenceId = PersistenceId
+    sequenceNumber = SequenceNr
+    created = Timestamp
+    snapshot = Snapshot
+    manifest = Manifest
+    serializerId = SerializerId
+}
 sqlite-compat-column-names {
-                  persistenceId = ""persistence_id""
-                  sequenceNumber = ""sequence_nr""
-                  snapshot = ""payload""
-                  manifest = ""manifest""
-                  created = ""created_at""
-                  serializerId = ""serializer_id""
-                }
+    persistenceId = persistence_id
+    sequenceNumber = sequence_nr
+    created = created_at
+    snapshot = payload
+    manifest = manifest
+    serializerId = serializer_id
+}
 postgres-compat-column-names {
-                  persistenceId: ""persistence_id"",
-                  sequenceNumber: ""sequence_nr"",
-                  snapshot: ""payload"",
-                  manifest: ""manifest"",
-                  created: ""created_at"",
-                  serializerId: ""serializer_id"",
-                }";
+    persistenceId: persistence_id,
+    sequenceNumber: sequence_nr,
+    created: created_at,
+    snapshot: payload,
+    manifest: manifest,
+    serializerId: serializer_id,
+}
+mysql-compat-column-names {
+    persistenceId: persistence_id,
+    sequenceNumber: sequence_nr,
+    created: created_at,
+    snapshot: snapshot,
+    manifest: manifest,
+    serializerId: serializer_id,
+}
+";
     }
 }

--- a/src/Akka.Persistence.Sql.Linq2Db/Extension.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db/Extension.cs
@@ -9,51 +9,52 @@ using Akka.Configuration;
 using Akka.Persistence.Sql.Linq2Db.Journal;
 using Akka.Persistence.Sql.Linq2Db.Snapshot;
 
-namespace Akka.Persistence.Sql.Linq2Db;
-
-public sealed class Linq2DbPersistence : IExtension
+namespace Akka.Persistence.Sql.Linq2Db
 {
-    public const string JournalConfigPath = "akka.persistence.journal.linq2db";
-    public const string SnapshotStoreConfigPath = "akka.persistence.snapshot-store.linq2db";
-    
-    /// <summary>
-    /// Returns a default configuration for akka persistence Linq2Db-based journals and snapshot stores.
-    /// </summary>
-    /// <returns></returns>
-    public static Configuration.Config DefaultConfiguration()
+    public sealed class Linq2DbPersistence : IExtension
     {
-        var journalConfig =  ConfigurationFactory.FromResource<Linq2DbWriteJournal>("Akka.Persistence.Sql.Linq2Db.persistence.conf");
-        var snapshotConfig = ConfigurationFactory.FromResource<Linq2DbSnapshotStore>("Akka.Persistence.Sql.Linq2Db.snapshot.conf");
+        public const string JournalConfigPath = "akka.persistence.journal.linq2db";
+        public const string SnapshotStoreConfigPath = "akka.persistence.snapshot-store.linq2db";
+    
+        /// <summary>
+        /// Returns a default configuration for akka persistence Linq2Db-based journals and snapshot stores.
+        /// </summary>
+        /// <returns></returns>
+        public static Configuration.Config DefaultConfiguration()
+        {
+            var journalConfig =  ConfigurationFactory.FromResource<Linq2DbWriteJournal>("Akka.Persistence.Sql.Linq2Db.persistence.conf");
+            var snapshotConfig = ConfigurationFactory.FromResource<Linq2DbSnapshotStore>("Akka.Persistence.Sql.Linq2Db.snapshot.conf");
         
-        return journalConfig.WithFallback(snapshotConfig);
+            return journalConfig.WithFallback(snapshotConfig);
+        }    
+    
+        public readonly Configuration.Config DefaultJournalConfig;
+        public readonly Configuration.Config DefaultSnapshotConfig;
+        public readonly Configuration.Config DefaultConfig;
+
+        public Linq2DbPersistence(ExtendedActorSystem system)
+        {
+            DefaultConfig = DefaultConfiguration();
+            system.Settings.InjectTopLevelFallback(DefaultConfig);
+
+            DefaultJournalConfig = DefaultConfig.GetConfig(JournalConfigPath);
+            DefaultSnapshotConfig = DefaultConfig.GetConfig(SnapshotStoreConfigPath);
+        }
+    
+        public static Linq2DbPersistence Get(ActorSystem system)
+        {
+            return system.WithExtension<Linq2DbPersistence, Linq2DbPersistenceProvider>();
+        }
+    }
+
+    /// <summary>
+    ///     Singleton class used to setup Linq2Db for akka persistence plugin.
+    /// </summary>
+    public sealed class Linq2DbPersistenceProvider : ExtensionIdProvider<Linq2DbPersistence>
+    {
+        public override Linq2DbPersistence CreateExtension(ExtendedActorSystem system)
+        {
+            return new Linq2DbPersistence(system);
+        }
     }    
-    
-    public readonly Configuration.Config DefaultJournalConfig;
-    public readonly Configuration.Config DefaultSnapshotConfig;
-    public readonly Configuration.Config DefaultConfig;
-
-    public Linq2DbPersistence(ExtendedActorSystem system)
-    {
-        DefaultConfig = DefaultConfiguration();
-        system.Settings.InjectTopLevelFallback(DefaultConfig);
-
-        DefaultJournalConfig = DefaultConfig.GetConfig(JournalConfigPath);
-        DefaultSnapshotConfig = DefaultConfig.GetConfig(SnapshotStoreConfigPath);
-    }
-    
-    public static Linq2DbPersistence Get(ActorSystem system)
-    {
-        return system.WithExtension<Linq2DbPersistence, Linq2DbPersistenceProvider>();
-    }
-}
-
-/// <summary>
-///     Singleton class used to setup Linq2Db for akka persistence plugin.
-/// </summary>
-public sealed class Linq2DbPersistenceProvider : ExtensionIdProvider<Linq2DbPersistence>
-{
-    public override Linq2DbPersistence CreateExtension(ExtendedActorSystem system)
-    {
-        return new Linq2DbPersistence(system);
-    }
 }

--- a/src/Akka.Persistence.Sql.Linq2Db/Extension.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db/Extension.cs
@@ -1,0 +1,59 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="Extension.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Persistence.Sql.Linq2Db.Journal;
+using Akka.Persistence.Sql.Linq2Db.Snapshot;
+
+namespace Akka.Persistence.Sql.Linq2Db;
+
+public sealed class Linq2DbPersistence : IExtension
+{
+    public const string JournalConfigPath = "akka.persistence.journal.linq2db";
+    public const string SnapshotStoreConfigPath = "akka.persistence.snapshot-store.linq2db";
+    
+    /// <summary>
+    /// Returns a default configuration for akka persistence Linq2Db-based journals and snapshot stores.
+    /// </summary>
+    /// <returns></returns>
+    public static Configuration.Config DefaultConfiguration()
+    {
+        var journalConfig =  ConfigurationFactory.FromResource<Linq2DbWriteJournal>("Akka.Persistence.Sql.Linq2Db.persistence.conf");
+        var snapshotConfig = ConfigurationFactory.FromResource<Linq2DbSnapshotStore>("Akka.Persistence.Sql.Linq2Db.snapshot.conf");
+        
+        return journalConfig.WithFallback(snapshotConfig);
+    }    
+    
+    public readonly Configuration.Config DefaultJournalConfig;
+    public readonly Configuration.Config DefaultSnapshotConfig;
+    public readonly Configuration.Config DefaultConfig;
+
+    public Linq2DbPersistence(ExtendedActorSystem system)
+    {
+        DefaultConfig = DefaultConfiguration();
+        system.Settings.InjectTopLevelFallback(DefaultConfig);
+
+        DefaultJournalConfig = DefaultConfig.GetConfig(JournalConfigPath);
+        DefaultSnapshotConfig = DefaultConfig.GetConfig(SnapshotStoreConfigPath);
+    }
+    
+    public static Linq2DbPersistence Get(ActorSystem system)
+    {
+        return system.WithExtension<Linq2DbPersistence, Linq2DbPersistenceProvider>();
+    }
+}
+
+/// <summary>
+///     Singleton class used to setup Linq2Db for akka persistence plugin.
+/// </summary>
+public sealed class Linq2DbPersistenceProvider : ExtensionIdProvider<Linq2DbPersistence>
+{
+    public override Linq2DbPersistence CreateExtension(ExtendedActorSystem system)
+    {
+        return new Linq2DbPersistence(system);
+    }
+}

--- a/src/Akka.Persistence.Sql.Linq2Db/Journal/Linq2DbWriteJournal.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db/Journal/Linq2DbWriteJournal.cs
@@ -47,17 +47,21 @@ namespace Akka.Persistence.Sql.Linq2Db.Journal
 
     public class Linq2DbWriteJournal : AsyncWriteJournal
     {
+        [Obsolete(message: "Use Linq2DbPersistence.Get(ActorSystem).DefaultConfig instead")]
         public static Configuration.Config DefaultConfiguration =>
             ConfigurationFactory.FromResource<Linq2DbWriteJournal>(
                 "Akka.Persistence.Sql.Linq2Db.persistence.conf");
         
+        public readonly Linq2DbPersistence Extension = Linq2DbPersistence.Get(Context.System);
+        
         private ActorMaterializer _mat;
         private JournalConfig _journalConfig;
         private ByteArrayJournalDao _journal;
-        public Linq2DbWriteJournal(Configuration.Config config)
+        public Linq2DbWriteJournal(Configuration.Config journalConfig)
         {
             try
             {
+                var config = journalConfig.WithFallback(Extension.DefaultJournalConfig);
                 _journalConfig = new JournalConfig(config);
                 _mat = Materializer.CreateSystemMaterializer((ExtendedActorSystem)Context.System,
                     ActorMaterializerSettings.Create(Context.System)

--- a/src/Akka.Persistence.Sql.Linq2Db/Journal/Linq2DbWriteJournal.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db/Journal/Linq2DbWriteJournal.cs
@@ -48,9 +48,8 @@ namespace Akka.Persistence.Sql.Linq2Db.Journal
     public class Linq2DbWriteJournal : AsyncWriteJournal
     {
         [Obsolete(message: "Use Linq2DbPersistence.Get(ActorSystem).DefaultConfig instead")]
-        public static Configuration.Config DefaultConfiguration =>
-            ConfigurationFactory.FromResource<Linq2DbWriteJournal>(
-                "Akka.Persistence.Sql.Linq2Db.persistence.conf");
+        public static readonly Configuration.Config DefaultConfiguration =
+            ConfigurationFactory.FromResource<Linq2DbWriteJournal>("Akka.Persistence.Sql.Linq2Db.persistence.conf");
         
         public readonly Linq2DbPersistence Extension = Linq2DbPersistence.Get(Context.System);
         

--- a/src/Akka.Persistence.Sql.Linq2Db/Query/Linq2DbReadJournal.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db/Query/Linq2DbReadJournal.cs
@@ -9,6 +9,7 @@ using Akka.Persistence.Journal;
 using Akka.Persistence.Query;
 using Akka.Persistence.Sql.Linq2Db.Config;
 using Akka.Persistence.Sql.Linq2Db.Db;
+using Akka.Persistence.Sql.Linq2Db.Journal;
 using Akka.Persistence.Sql.Linq2Db.Journal.DAO;
 using Akka.Persistence.Sql.Linq2Db.Journal.Types;
 using Akka.Persistence.Sql.Linq2Db.Query.Dao;
@@ -35,9 +36,8 @@ namespace Akka.Persistence.Sql.Linq2Db.Query
             get { return "akka.persistence.query.journal.linq2db"; }
         }
 
-        public static Configuration.Config DefaultConfiguration =>
-            ConfigurationFactory.FromResource<Linq2DbReadJournal>(
-                "Akka.Persistence.Sql.Linq2Db.persistence.conf");
+        [Obsolete(message: "Use Linq2DbPersistence.Get(ActorSystem).DefaultConfig instead")]
+        public static readonly Configuration.Config DefaultConfiguration = Linq2DbWriteJournal.DefaultConfiguration;
 
         private IActorRef journalSequenceActor;
         private ActorMaterializer _mat;

--- a/src/Akka.Persistence.Sql.Linq2Db/Snapshot/Linq2DbSnapshotStore.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db/Snapshot/Linq2DbSnapshotStore.cs
@@ -15,14 +15,20 @@ namespace Akka.Persistence.Sql.Linq2Db.Snapshot
 {
     public class Linq2DbSnapshotStore : SnapshotStore
     {
+        [Obsolete(message: "Use Linq2DbPersistence.Get(ActorSystem).DefaultConfig instead")]
         public static Configuration.Config DefaultConfiguration =>
             ConfigurationFactory.FromResource<Linq2DbSnapshotStore>(
                 "Akka.Persistence.Sql.Linq2Db.snapshot.conf");
+        
+        public readonly Linq2DbPersistence Extension = Linq2DbPersistence.Get(Context.System);
+        
         private SnapshotConfig _snapshotConfig;
         private ByteArraySnapshotDao _dao;
 
-        public Linq2DbSnapshotStore(Configuration.Config config)
+        public Linq2DbSnapshotStore(Configuration.Config snapshotConfig)
         {
+            var config = snapshotConfig.WithFallback(Extension.DefaultSnapshotConfig);
+            
             _snapshotConfig = new SnapshotConfig(config);
             _dao = new ByteArraySnapshotDao(
                 new AkkaPersistenceDataConnectionFactory(_snapshotConfig),

--- a/src/Akka.Persistence.Sql.Linq2Db/Snapshot/Linq2DbSnapshotStore.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db/Snapshot/Linq2DbSnapshotStore.cs
@@ -16,9 +16,8 @@ namespace Akka.Persistence.Sql.Linq2Db.Snapshot
     public class Linq2DbSnapshotStore : SnapshotStore
     {
         [Obsolete(message: "Use Linq2DbPersistence.Get(ActorSystem).DefaultConfig instead")]
-        public static Configuration.Config DefaultConfiguration =>
-            ConfigurationFactory.FromResource<Linq2DbSnapshotStore>(
-                "Akka.Persistence.Sql.Linq2Db.snapshot.conf");
+        public static readonly Configuration.Config DefaultConfiguration =
+            ConfigurationFactory.FromResource<Linq2DbSnapshotStore>("Akka.Persistence.Sql.Linq2Db.snapshot.conf");
         
         public readonly Linq2DbPersistence Extension = Linq2DbPersistence.Get(Context.System);
         

--- a/src/Akka.Persistence.Sql.Linq2Db/persistence.conf
+++ b/src/Akka.Persistence.Sql.Linq2Db/persistence.conf
@@ -23,8 +23,9 @@
       # note that there is a performance penalty for using this.
       delete-compatibility-mode = true
 
-      # If "sqlite", "sqlserver", or "postgres", default column names are compatible with
-      # Akka.Persistence.Sql Default Column names.                       
+      # if set to "sqlite", "sqlserver", "mysql", or "postgres",
+      # Column names will be compatible with Akka.Persistence.Sql
+      # You still must set your table name!
       table-compatibility-mode = null
 
       #If more entries than this are pending, writes will be rejected.
@@ -96,67 +97,80 @@
         #If you want to specify a schema for your tables, you can do so here.
         schema-name = null
 
-
-
         column-names {
-          "ordering" = "ordering"
-          "deleted" = "deleted"
-          "persistenceId" = "persistence_id"
-          "sequenceNumber" = "sequence_number"
-          "created" = "created"
-          "tags" = "tags"
-          "message" = "message"
-          "identifier" = "identifier"
-          "manifest" = "manifest"
+          ordering = ordering
+          deleted = deleted
+          persistenceId = persistence_id
+          sequenceNumber = sequence_number
+          created = created
+          tags = tags
+          message = message
+          identifier = identifier
+          manifest = manifest
         }
         sqlserver-compat-column-names {
-          "ordering" = "ordering"
-          "deleted" = "isdeleted"
-          "persistenceId" = "persistenceId"
-          "sequenceNumber" = "sequenceNr"
-          "created" = "Timestamp"
-          "tags" = "tags"
-          "message" = "payload"
-          "identifier" = "serializerid"
-          "manifest" = "manifest"
+          ordering = Ordering
+          deleted = IsDeleted
+          persistenceId = PersistenceId
+          sequenceNumber = SequenceNr
+          created = Timestamp
+          tags = Tags
+          message = Payload
+          identifier = SerializerId
+          manifest = Manifest
         }
         sqlite-compat-column-names {
-          "ordering" = "ordering"
-          "deleted" = "is_deleted"
-          "persistenceId" = "persistence_Id"
-          "sequenceNumber" = "sequence_nr"
-          "created" = "Timestamp"
-          "tags" = "tags"
-          "message" = "payload"
-          "identifier" = "serializer_id"
-          "manifest" = "manifest"
+          ordering = ordering
+          deleted = is_deleted
+          persistenceId = persistence_id
+          sequenceNumber = sequence_nr
+          created = timestamp
+          tags = tags
+          message = payload
+          identifier = serializer_id
+          manifest = manifest
         }
         postgres-compat-column-names {
-          "ordering" = "ordering"
-          "deleted" = "is_deleted"
-          "persistenceId" = "persistence_id"
-          "sequenceNumber" = "sequence_nr"
-          "created" = "created_at"
-          "tags" = "tags"
-          "message" = "payload"
-          "identifier" = "serializer_id"
-          "manifest" = "manifest"
+          ordering = ordering
+          deleted = is_deleted
+          persistenceId = persistence_id
+          sequenceNumber = sequence_nr
+          created = created_at
+          tags = tags
+          message = payload
+          identifier = serializer_id
+          manifest = manifest
+        }
+        mysql-compat-column-names {
+          ordering = ordering
+          deleted = is_deleted
+          persistenceId = persistence_id
+          sequenceNumber = sequence_nr
+          created = created_at
+          tags = tags
+          message = payload
+          identifier = serializer_id
+          manifest = manifest
         }
         metadata-column-names {
-          "persistenceId" = "persistenceId"
-          "sequenceNumber" = "sequenceNr"
+          persistenceId = persistenceId
+          sequenceNumber = sequenceNr
         }
         sqlserver-compat-metadata-column-names {
-          "persistenceId" = "persistenceId"
-          "sequenceNumber" = "sequenceNr"
+          persistenceId = persistenceId
+          sequenceNumber = sequenceNr
         }
         sqlite-compat-metadata-column-names {
-          "persistenceId" = "persistence_Id"
-          "sequenceNumber" = "sequence_nr"
+          persistenceId = persistence_Id
+          sequenceNumber = sequence_nr
         }
         postgres-compat-metadata-column-names {
-          "persistenceId" = "persistence_id"
-          "sequenceNumber" = "sequence_nr"
+          persistenceId = persistence_id
+          sequenceNumber = sequence_nr
+        }
+        mysql-compat-metadata-column-names {
+          persistenceId = persistence_id
+          sequenceNumber = sequence_nr
         }
       }
     }
@@ -200,8 +214,9 @@
         # If true, journal_metadata is created
         delete-compatibility-mode = true
 
-        # If "sqlite" or "sqlserver", default column names are compatible with
-        # Akka.Persistence.Sql Default Column names.                       
+        # if set to "sqlite", "sqlserver", "mysql", or "postgres",
+        # Column names will be compatible with Akka.Persistence.Sql
+        # You still must set your table name!
         table-compatibility-mode = null
 
         #If more entries than this are pending, writes will be rejected.
@@ -258,66 +273,80 @@
           #If you want to specify a schema for your tables, you can do so here.
           schema-name = null
 
-
           column-names {
-            "ordering" = "ordering"
-            "deleted" = "deleted"
-            "persistenceId" = "persistence_id"
-            "sequenceNumber" = "sequence_number"
-            "created" = "created"
-            "tags" = "tags"
-            "message" = "message"
-            "identifier" = "identifier"
-            "manifest" = "manifest"
+            ordering = ordering
+            deleted = deleted
+            persistenceId = persistence_id
+            sequenceNumber = sequence_number
+            created = created
+            tags = tags
+            message = message
+            identifier = identifier
+            manifest = manifest
           }
           sqlserver-compat-column-names {
-            "ordering" = "ordering"
-            "deleted" = "isdeleted"
-            "persistenceId" = "persistenceId"
-            "sequenceNumber" = "sequenceNr"
-            "created" = "Timestamp"
-            "tags" = "tags"
-            "message" = "payload"
-            "identifier" = "serializerid"
-            "manifest" = "manifest"
+            ordering = Ordering
+            deleted = IsDeleted
+            persistenceId = PersistenceId
+            sequenceNumber = SequenceNr
+            created = Timestamp
+            tags = Tags
+            message = Payload
+            identifier = SerializerId
+            manifest = Manifest
           }
           sqlite-compat-column-names {
-            "ordering" = "ordering"
-            "deleted" = "is_deleted"
-            "persistenceId" = "persistence_Id"
-            "sequenceNumber" = "sequence_nr"
-            "created" = "Timestamp"
-            "tags" = "tags"
-            "message" = "payload"
-            "identifier" = "serializer_id"
-            "manifest" = "manifest"
+            ordering = ordering
+            deleted = is_deleted
+            persistenceId = persistence_id
+            sequenceNumber = sequence_nr
+            created = timestamp
+            tags = tags
+            message = payload
+            identifier = serializer_id
+            manifest = manifest
           }
           postgres-compat-column-names {
-            "ordering" = "ordering"
-            "deleted" = "is_deleted"
-            "persistenceId" = "persistence_id"
-            "sequenceNumber" = "sequence_nr"
-            "created" = "created_at"
-            "tags" = "tags"
-            "message" = "payload"
-            "identifier" = "serializer_id"
-            "manifest" = "manifest"
+            ordering = ordering
+            deleted = is_deleted
+            persistenceId = persistence_id
+            sequenceNumber = sequence_nr
+            created = created_at
+            tags = tags
+            message = payload
+            identifier = serializer_id
+            manifest = manifest
+          }
+          mysql-compat-column-names {
+            ordering = ordering
+            deleted = is_deleted
+            persistenceId = persistence_id
+            sequenceNumber = sequence_nr
+            created = created_at
+            tags = tags
+            message = payload
+            identifier = serializer_id
+            manifest = manifest
           }
           metadata-column-names {
-            "persistenceId" = "persistenceId"
-            "sequenceNumber" = "sequenceNr"
+            persistenceId = persistenceId
+            sequenceNumber = sequenceNr
           }
           sqlserver-compat-metadata-column-names {
-            "persistenceId" = "persistenceId"
-            "sequenceNumber" = "sequenceNr"
+            persistenceId = persistenceId
+            sequenceNumber = sequenceNr
           }
           sqlite-compat-metadata-column-names {
-            "persistenceId" = "persistence_Id"
-            "sequenceNumber" = "sequence_nr"
+            persistenceId = persistence_Id
+            sequenceNumber = sequence_nr
           }
           postgres-compat-metadata-column-names {
-            "persistenceId" = "persistence_id"
-            "sequenceNumber" = "sequence_nr"
+            persistenceId = persistence_id
+            sequenceNumber = sequence_nr
+          }
+          mysql-compat-metadata-column-names {
+            persistenceId = persistence_id
+            sequenceNumber = sequence_nr
           }
         }
       }

--- a/src/Akka.Persistence.Sql.Linq2Db/persistence.conf
+++ b/src/Akka.Persistence.Sql.Linq2Db/persistence.conf
@@ -1,6 +1,5 @@
 ﻿akka.persistence {
   journal {
-    plugin = "akka.persistence.journal.linq2db"
     linq2db {
       class = "Akka.Persistence.Sql.Linq2Db.Journal.Linq2DbWriteJournal, Akka.Persistence.Sql.Linq2Db"
       plugin-dispatcher = "akka.persistence.dispatchers.default-plugin-dispatcher"
@@ -85,11 +84,26 @@
       # You may wish to provide a dedicated dispatcher instead
       materializer-dispatcher = "akka.actor.default-dispatcher"
       
+      tag-separator = ","
+      
+      dao = "Akka.Persistence.Sql.Linq2Db.Journal.DAO.ByteArrayJournalDao, Akka.Persistence.Sql.Linq2Db"
+      
+      # Default serializer used as manifest serializer when applicable and payload serializer when 
+      # no specific binding overrides are specified.
+      # If set to null, the default `System.Object` serializer is used.
+      serializer = null
+      
       tables.journal {
-
+        
         #if delete-compatibility-mode is true, both tables are created
         #if delete-compatibility-mode is false, only journal table will be created.
         auto-init = true
+
+        #if true, a warning will be logged
+        #if auto-init of tables fails.
+        #set to false if you don't want this warning logged
+        #perhaps if running CI tests or similar.
+        warn-on-auto-init-fail = true
 
         table-name = "journal"
         metadata-table-name = "journal_metadata"
@@ -161,7 +175,7 @@
           sequenceNumber = sequenceNr
         }
         sqlite-compat-metadata-column-names {
-          persistenceId = persistence_Id
+          persistenceId = persistence_id
           sequenceNumber = sequence_nr
         }
         postgres-compat-metadata-column-names {
@@ -255,100 +269,11 @@
         #This setting will go away once https://github.com/linq2db/linq2db/issues/2466 is resolved
         use-clone-connection = false
 
-        tables.journal {
-
-          #if delete-compatibility-mode is true, both tables are created
-          #if delete-compatibility-mode is false, only journal table will be created.
-          auto-init = true
-
-          #if true, a warning will be logged
-          #if auto-init of tables fails.
-          #set to false if you don't want this warning logged
-          #perhaps if running CI tests or similar.
-          warn-on-auto-init-fail = true
-
-          table-name = "journal"
-          metadata-table-name = "journal_metadata"
-
-          #If you want to specify a schema for your tables, you can do so here.
-          schema-name = null
-
-          column-names {
-            ordering = ordering
-            deleted = deleted
-            persistenceId = persistence_id
-            sequenceNumber = sequence_number
-            created = created
-            tags = tags
-            message = message
-            identifier = identifier
-            manifest = manifest
-          }
-          sqlserver-compat-column-names {
-            ordering = Ordering
-            deleted = IsDeleted
-            persistenceId = PersistenceId
-            sequenceNumber = SequenceNr
-            created = Timestamp
-            tags = Tags
-            message = Payload
-            identifier = SerializerId
-            manifest = Manifest
-          }
-          sqlite-compat-column-names {
-            ordering = ordering
-            deleted = is_deleted
-            persistenceId = persistence_id
-            sequenceNumber = sequence_nr
-            created = timestamp
-            tags = tags
-            message = payload
-            identifier = serializer_id
-            manifest = manifest
-          }
-          postgres-compat-column-names {
-            ordering = ordering
-            deleted = is_deleted
-            persistenceId = persistence_id
-            sequenceNumber = sequence_nr
-            created = created_at
-            tags = tags
-            message = payload
-            identifier = serializer_id
-            manifest = manifest
-          }
-          mysql-compat-column-names {
-            ordering = ordering
-            deleted = is_deleted
-            persistenceId = persistence_id
-            sequenceNumber = sequence_nr
-            created = created_at
-            tags = tags
-            message = payload
-            identifier = serializer_id
-            manifest = manifest
-          }
-          metadata-column-names {
-            persistenceId = persistenceId
-            sequenceNumber = sequenceNr
-          }
-          sqlserver-compat-metadata-column-names {
-            persistenceId = persistenceId
-            sequenceNumber = sequenceNr
-          }
-          sqlite-compat-metadata-column-names {
-            persistenceId = persistence_Id
-            sequenceNumber = sequence_nr
-          }
-          postgres-compat-metadata-column-names {
-            persistenceId = persistence_id
-            sequenceNumber = sequence_nr
-          }
-          mysql-compat-metadata-column-names {
-            persistenceId = persistence_id
-            sequenceNumber = sequence_nr
-          }
-        }
+        tag-separator = ","
+      
+        dao = "Akka.Persistence.Sql.Linq2Db.Journal.DAO.ByteArrayJournalDao, Akka.Persistence.Sql.Linq2Db"
+      
+        tables.journal = ${akka.persistence.journal.linq2db.tables.journal}
       }
     }
   }

--- a/src/Akka.Persistence.Sql.Linq2Db/snapshot.conf
+++ b/src/Akka.Persistence.Sql.Linq2Db/snapshot.conf
@@ -1,6 +1,5 @@
 ﻿akka.persistence {
   snapshot-store {
-    plugin = "akka.persistence.snapshot-store.linq2db"
     linq2db {
       class = "Akka.Persistence.Sql.Linq2Db.Snapshot.Linq2DbSnapshotStore, Akka.Persistence.Sql.Linq2Db"
       plugin-dispatcher = "akka.persistence.dispatchers.default-plugin-dispatcher"
@@ -21,7 +20,17 @@
       # if set to "sqlite", "sqlserver", "mysql", or "postgres",
       # Column names will be compatible with Akka.Persistence.Sql
       # You still must set your table name!
-      table-compatibility-mode = false
+      table-compatibility-mode = null
+      
+      # Default serializer used as manifest serializer when applicable and payload serializer when 
+      # no specific binding overrides are specified.
+      # If set to null, the default `System.Object` serializer is used.
+      serializer = null
+      
+      dao = "Akka.Persistence.Sql.Linq2Db.Journal.DAO.ByteArrayJournalDao, Akka.Persistence.Sql.Linq2Db"
+      
+      compatibility-mode = false
+      
       tables.snapshot {
         schema-name = null
         
@@ -46,11 +55,11 @@
         }
         sql-server-compat-column-names {
           persistenceId = PersistenceId
-          sequenceNumber = sequencenr
-          created = timestamp
-          snapshot = snapshot
-          manifest = manifest
-          serializerId = serializerid
+          sequenceNumber = SequenceNr
+          created = Timestamp
+          snapshot = Snapshot
+          manifest = Manifest
+          serializerId = SerializerId
         }
         sqlite-compat-column-names {
           persistenceId = persistence_id,

--- a/src/Akka.Persistence.Sql.Linq2Db/snapshot.conf
+++ b/src/Akka.Persistence.Sql.Linq2Db/snapshot.conf
@@ -1,73 +1,82 @@
 ﻿akka.persistence {
-  snapshot-store
-    {
-      plugin = "akka.persistence.snapshot-store.linq2db"
-      linq2db {
-        class = "Akka.Persistence.Sql.Linq2Db.Snapshot.Linq2DbSnapshotStore, Akka.Persistence.Sql.Linq2Db"
-        plugin-dispatcher = "akka.persistence.dispatchers.default-plugin-dispatcher"
-        connection-string = ""
-        
-        # Provider name is required.
-        # Refer to LinqToDb.ProviderName for values
-        # Always use a specific version if possible
-        # To avoid provider detection performance penalty
-        # Don't worry if your DB is newer than what is listed;
-        # Just pick the newest one (if yours is still newer)
-        provider-name = ""
+  snapshot-store {
+    plugin = "akka.persistence.snapshot-store.linq2db"
+    linq2db {
+      class = "Akka.Persistence.Sql.Linq2Db.Snapshot.Linq2DbSnapshotStore, Akka.Persistence.Sql.Linq2Db"
+      plugin-dispatcher = "akka.persistence.dispatchers.default-plugin-dispatcher"
+      connection-string = ""
+      
+      # Provider name is required.
+      # Refer to LinqToDb.ProviderName for values
+      # Always use a specific version if possible
+      # To avoid provider detection performance penalty
+      # Don't worry if your DB is newer than what is listed;
+      # Just pick the newest one (if yours is still newer)
+      provider-name = ""
 
-        #Only set to TRUE if unit tests pass with the connection string you intend to use!
-        #This setting will go away once https://github.com/linq2db/linq2db/issues/2466 is resolved
-        use-clone-connection = false
+      #Only set to TRUE if unit tests pass with the connection string you intend to use!
+      #This setting will go away once https://github.com/linq2db/linq2db/issues/2466 is resolved
+      use-clone-connection = false
+      
+      # if set to "sqlite", "sqlserver", "mysql", or "postgres",
+      # Column names will be compatible with Akka.Persistence.Sql
+      # You still must set your table name!
+      table-compatibility-mode = false
+      tables.snapshot {
+        schema-name = null
         
-        # if set to "sqlite", "sqlserver", or "postgres",
-        # Column names will be compatible with Akka.Persistence.Sql
-        # You still must set your table name!
-        table-compatibility-mode = false
-        tables.
-            snapshot
-              {
-                schema-name = null
-                table-name = "snapshot"
-                #if true, tables will attempt to be created.
-                auto-init = true
-                #if true, a warning will be logged
-                #if auto-init of tables fails.
-                #set to false if you don't want this warning logged
-                #perhaps if running CI tests or similar.
-                warn-on-auto-init-fail = true
-                column-names {
-                  persistenceId = "persistence_id"
-                  sequenceNumber = "sequence_number"
-                  created = "created"
-                  snapshot = "snapshot"
-                  manifest = "manifest"
-                  serializerId = "serializer_id"
-                }
-                sql-server-compat-column-names {
-                  persistenceId = "PersistenceId"
-                  sequenceNumber = "sequencenr"
-                  created = "timestamp"
-                  snapshot = "snapshot"
-                  manifest = "manifest"
-                  serializerId = "serializerid"
-                }
-                sqlite-compat-column-names {
-                  persistenceId: "persistence_id",
-                  sequenceNumber: "sequence_nr",
-                  snapshot: "payload",
-                  manifest: "manifest",
-                  created: "created_at",
-                  serializerId: "serializer_id",
-                }
-                postgres-compat-column-names {
-                  persistenceId: "persistence_id",
-                  sequenceNumber: "sequence_nr",
-                  snapshot: "payload",
-                  manifest: "manifest",
-                  created: "created_at",
-                  serializerId: "serializer_id",
-                }
-              }
+        table-name = "snapshot"
+        
+        #if true, tables will attempt to be created.
+        auto-init = true
+        
+        #if true, a warning will be logged
+        #if auto-init of tables fails.
+        #set to false if you don't want this warning logged
+        #perhaps if running CI tests or similar.
+        warn-on-auto-init-fail = true
+        
+        column-names {
+          persistenceId = persistence_id
+          sequenceNumber = sequence_number
+          created = created
+          snapshot = snapshot
+          manifest = manifest
+          serializerId = serializer_id
+        }
+        sql-server-compat-column-names {
+          persistenceId = PersistenceId
+          sequenceNumber = sequencenr
+          created = timestamp
+          snapshot = snapshot
+          manifest = manifest
+          serializerId = serializerid
+        }
+        sqlite-compat-column-names {
+          persistenceId = persistence_id,
+          sequenceNumber = sequence_nr,
+          snapshot = payload,
+          manifest = manifest,
+          created = created_at,
+          serializerId = serializer_id,
+        }
+        postgres-compat-column-names {
+          persistenceId = persistence_id,
+          sequenceNumber = sequence_nr,
+          snapshot = payload,
+          manifest = manifest,
+          created = created_at,
+          serializerId = serializer_id,
+        }
+        mysql-compat-column-names {
+          persistenceId = persistence_id,
+          sequenceNumber = sequence_nr,
+          snapshot = snapshot,
+          manifest = manifest,
+          created = created_at,
+          serializerId = serializer_id,
+        }
       }
     }
+  }
 }


### PR DESCRIPTION
## Changes

- The `persistenceId` property are named `PersistenceId` in one file but named `persistenceId` in another.
- Wrong property name were used when reading the HOCON settings
- Simplify HOCON by removing unnesscessary double quotes
- Add MySql compatibility settings
- Move default HOCON config loading from journal and snapshot plugin to Linq2DbPersistence class that extends IExtension