### PR TITLE
Fix read journal, missing `_includeDeleted` checks

### DIFF
--- a/src/Akka.Persistence.Sql.Linq2Db.Tests/Settings/ReadJournalConfigSpec.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db.Tests/Settings/ReadJournalConfigSpec.cs
@@ -36,7 +36,7 @@ namespace Akka.Persistence.Sql.Linq2Db.Tests.Settings
             type.Should().Be(typeof(Linq2DbReadJournalProvider));
 
             query.GetString("write-plugin", "invalid").Should().BeNullOrEmpty();
-            query.GetBoolean("include-logically-deleted").Should().BeTrue();
+            query.GetBoolean("include-logically-deleted").Should().BeFalse();
             query.GetInt("max-buffer-size").Should().Be(500);
             query.GetTimeSpan("refresh-interval").Should().Be(1.Seconds());
             query.GetString("connection-string", "invalid").Should().BeNullOrEmpty();
@@ -241,7 +241,7 @@ namespace Akka.Persistence.Sql.Linq2Db.Tests.Settings
             journal.RefreshInterval.Should().Be(1.Seconds());
             journal.MaxBufferSize.Should().Be(500);
             journal.AddShutdownHook.Should().BeTrue();
-            journal.IncludeDeleted.Should().BeTrue();
+            journal.IncludeDeleted.Should().BeFalse();
 
             var pluginConfig = journal.PluginConfig;
             pluginConfig.TagSeparator.Should().Be(";");

--- a/src/Akka.Persistence.Sql.Linq2Db/Config/ReadJournalConfig.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db/Config/ReadJournalConfig.cs
@@ -16,7 +16,7 @@ namespace Akka.Persistence.Sql.Linq2Db.Config
             RefreshInterval = config.GetTimeSpan("refresh-interval", TimeSpan.FromSeconds(1));
             MaxBufferSize = config.GetInt("max-buffer-size", 500);
             AddShutdownHook = config.GetBoolean("add-shutdown-hook", true);
-            IncludeDeleted = config.GetBoolean("include-logically-deleted", true);
+            IncludeDeleted = config.GetBoolean("include-logically-deleted", false);
             DefaultSerializer = config.GetString("serializer");
         }
 

--- a/src/Akka.Persistence.Sql.Linq2Db/Journal/Linq2DbWriteJournal.cs
+++ b/src/Akka.Persistence.Sql.Linq2Db/Journal/Linq2DbWriteJournal.cs
@@ -79,11 +79,11 @@ namespace Akka.Persistence.Sql.Linq2Db.Journal
                         connection: new AkkaPersistenceDataConnectionFactory(_journalConfig),
                         journalConfig: _journalConfig, 
                         serializer: Context.System.Serialization, 
-                        logger: Context.GetLogger());
+                        logger: Logging.GetLogger(Context.System, typeof(ByteArrayJournalDao)));
                 }
                 catch (Exception e)
                 {
-                    Context.GetLogger().Error(e, "Error Initializing Journal!");
+                    _log.Error(e, "Error Initializing Journal!");
                     throw;
                 }
 
@@ -95,7 +95,7 @@ namespace Akka.Persistence.Sql.Linq2Db.Journal
                     }
                     catch (Exception e)
                     {
-                        Context.GetLogger().Warning(e, "Unable to Initialize Persistence Journal Table!");
+                        _log.Warning(e, "Unable to Initialize Persistence Journal Table!");
                     }
                 }
             }

--- a/src/Akka.Persistence.Sql.Linq2Db/persistence.conf
+++ b/src/Akka.Persistence.Sql.Linq2Db/persistence.conf
@@ -197,7 +197,7 @@
         #You should specify your proper linq2db journal plugin configuration path here.
         write-plugin = ""
 
-        include-logically-deleted = true # whether to include logical deletes in query results
+        include-logically-deleted = false # whether to include logical deletes in query results
 
         max-buffer-size = 500 # Number of events to buffer at a time.
         refresh-interval = 1s # interval for refreshing


### PR DESCRIPTION
Prerequisite for #117

Persistence query returned wrong number of events because it also includes soft deleted entries.