### PR TITLE
Refactor compatibility unit tests to use TestKit

### DIFF
--- a/src/Akka.Persistence.Linq2Db.Compatibility.Tests/SqlCommonSnapshotCompatibilitySpec.cs
+++ b/src/Akka.Persistence.Linq2Db.Compatibility.Tests/SqlCommonSnapshotCompatibilitySpec.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Event;
+using Akka.TestKit;
 using Akka.TestKit.Xunit2.Internals;
 using FluentAssertions;
 using LanguageExt.UnitsOfMeasure;
@@ -10,7 +11,7 @@ using Xunit.Abstractions;
 
 namespace Akka.Persistence.Linq2Db.CompatibilityTests
 {
-    public abstract class SqlCommonSnapshotCompatibilitySpec
+    public abstract class SqlCommonSnapshotCompatibilitySpec: IAsyncLifetime
     {
         protected abstract Configuration.Config Config { get; }
         public SqlCommonSnapshotCompatibilitySpec(ITestOutputHelper outputHelper)
@@ -18,129 +19,128 @@ namespace Akka.Persistence.Linq2Db.CompatibilityTests
             Output = outputHelper;
         }
 
-        protected void InitializeLogger(ActorSystem system)
-        {
-            if (Output != null)
-            {
-                var extSystem = (ExtendedActorSystem)system;
-                var logger = extSystem.SystemActorOf(Props.Create(() => new TestOutputLogger(Output)), "log-test");
-                logger.Tell(new InitializeLogger(system.EventStream));
-            }
-        }
-        
-        public ITestOutputHelper Output { get; }
+        protected ITestOutputHelper Output { get; }
         protected abstract string OldSnapshot { get; }
         protected abstract string NewSnapshot { get; }
+        protected ActorSystem Sys { get; private set;  }
+        protected Akka.TestKit.Xunit2.TestKit TestKit { get; private set; }
+        protected TestProbe Probe { get; private set; }
+        
+        public Task InitializeAsync()
+        {
+            Sys = ActorSystem.Create("test-sys", Config);
+            TestKit = new Akka.TestKit.Xunit2.TestKit(Sys, Output);
+            Probe = TestKit.CreateTestProbe();
+            return Task.CompletedTask;
+        }
+
+        public async Task DisposeAsync()
+        {
+            await Sys.Terminate();
+        }
         
         [Fact]
-        public async Task Can_Recover_SqlCommon_Snapshot()
+        public void Can_Recover_SqlCommon_Snapshot()
         {
-            var sys1 = ActorSystem.Create("first", Config);
-            InitializeLogger(sys1);
-            
-            var persistRef = sys1.ActorOf(Props.Create(() =>
+            var persistRef = Sys.ActorOf(Props.Create(() =>
                 new SnapshotCompatActor(OldSnapshot, "p-1")), "test-snap-recover-1");
             var ourGuid = Guid.NewGuid();
+
+            Probe.Send(persistRef, new SomeEvent { EventName = "rec-test", Guid = ourGuid, Number = 1 });
+            Probe.ExpectMsg(true);
+            Probe.Send(persistRef, new ContainsEvent { Guid = ourGuid });
+            Probe.ExpectMsg(true, 5.Seconds());
+
+            Probe.Watch(persistRef);
+            persistRef.Tell(PoisonPill.Instance);
+            Probe.ExpectTerminated(persistRef);
+            Probe.Unwatch(persistRef);
             
-            (await persistRef.Ask<bool>(new SomeEvent { EventName = "rec-test", Guid = ourGuid, Number = 1 }))
-                .Should().BeTrue();
-            (await persistRef.Ask<bool>(new ContainsEvent { Guid = ourGuid }, TimeSpan.FromSeconds(5)))
-                .Should().BeTrue();
-            
-            (await persistRef.GracefulStop(10.Seconds())).Should().BeTrue();
-            // Intentionally being called twice to make sure that the actor state inside the user guardian has been cleared 
-            (await persistRef.GracefulStop(10.Seconds())).Should().BeTrue();
-            
-            persistRef =  sys1.ActorOf(Props.Create(() =>
+            persistRef = Sys.ActorOf(Props.Create(() =>
                 new SnapshotCompatActor(NewSnapshot, "p-1")), "test-snap-recover-1");
-            (await persistRef.Ask<bool>(new ContainsEvent { Guid = ourGuid }, TimeSpan.FromSeconds(5)))
-                .Should().BeTrue();
-        }
-        [Fact]
-        public async Task Can_Persist_SqlCommon_Snapshot()
-        {
-            var sys1 = ActorSystem.Create("first", Config);
-            InitializeLogger(sys1);
-            
-            var persistRef = sys1.ActorOf(Props.Create(() =>
-                new SnapshotCompatActor(OldSnapshot, "p-2")), "test-snap-persist-1");
-            var ourGuid = Guid.NewGuid();
-            
-            (await persistRef.Ask<bool>(new SomeEvent { EventName = "rec-test", Guid = ourGuid, Number = 1 }))
-                .Should().BeTrue();
-            (await persistRef.Ask<bool>(new ContainsEvent { Guid = ourGuid }, TimeSpan.FromSeconds(5)))
-                .Should().BeTrue();
-            
-            (await persistRef.GracefulStop(10.Seconds())).Should().BeTrue();
-            // Intentionally being called twice to make sure that the actor state inside the user guardian has been cleared 
-            (await persistRef.GracefulStop(10.Seconds())).Should().BeTrue();
-            
-            persistRef = sys1.ActorOf(Props.Create(() =>
-                new SnapshotCompatActor(NewSnapshot, "p-2")), "test-snap-persist-1");
-            (await persistRef.Ask<bool>(new ContainsEvent { Guid = ourGuid }, TimeSpan.FromSeconds(5)))
-                .Should().BeTrue();
-            
-            var ourSecondGuid = Guid.NewGuid();
-            (await persistRef.Ask<bool>(new SomeEvent { EventName = "rec-test", Guid = ourSecondGuid, Number = 2 }))
-                .Should().BeTrue();
-            (await persistRef.Ask<bool>(new ContainsEvent { Guid = ourSecondGuid }, TimeSpan.FromSeconds(5)))
-                .Should().BeTrue();
+            Probe.Send(persistRef, new ContainsEvent { Guid = ourGuid });
+            Probe.ExpectMsg(true, 5.Seconds());
         }
         
         [Fact]
-        public async Task SqlCommon_Snapshot_Can_Recover_L2Db_Snapshot()
+        public void Can_Persist_SqlCommon_Snapshot()
         {
-            var sys1 = ActorSystem.Create("first", Config);
-            InitializeLogger(sys1);
+            var persistRef = Sys.ActorOf(Props.Create(() =>
+                new SnapshotCompatActor(OldSnapshot, "p-2")), "test-snap-persist-1");
+            var ourGuid = Guid.NewGuid();
+
+            Probe.Send(persistRef, new SomeEvent { EventName = "rec-test", Guid = ourGuid, Number = 1 });
+            Probe.ExpectMsg(true);
+            Probe.Send(persistRef, new ContainsEvent { Guid = ourGuid });
+            Probe.ExpectMsg(true, 5.Seconds());
             
-            var persistRef = sys1.ActorOf(Props.Create(() =>
+            Probe.Watch(persistRef);
+            persistRef.Tell(PoisonPill.Instance);
+            Probe.ExpectTerminated(persistRef);
+            Probe.Unwatch(persistRef);
+            
+            persistRef = Sys.ActorOf(Props.Create(() =>
+                new SnapshotCompatActor(NewSnapshot, "p-2")), "test-snap-persist-1");
+            Probe.Send(persistRef, new ContainsEvent { Guid = ourGuid });
+            Probe.ExpectMsg(true, 5.Seconds());
+            
+            var ourSecondGuid = Guid.NewGuid();
+            Probe.Send(persistRef, new SomeEvent { EventName = "rec-test", Guid = ourSecondGuid, Number = 2 });
+            Probe.ExpectMsg(true);
+            Probe.Send(persistRef, new ContainsEvent { Guid = ourSecondGuid });
+            Probe.ExpectMsg(true, 5.Seconds());
+        }
+        
+        [Fact]
+        public void SqlCommon_Snapshot_Can_Recover_L2Db_Snapshot()
+        {
+            var persistRef = Sys.ActorOf(Props.Create(() =>
                 new SnapshotCompatActor(NewSnapshot, "p-3")), "test-snap-recover-2");
             var ourGuid = Guid.NewGuid();
             
-            (await persistRef.Ask<bool>(new SomeEvent { EventName = "rec-test", Guid = ourGuid, Number = 1 }))
-                .Should().BeTrue();
-            (await persistRef.Ask<bool>(new ContainsEvent { Guid = ourGuid }, TimeSpan.FromSeconds(5)))
-                .Should().BeTrue();
+            Probe.Send(persistRef, new SomeEvent { EventName = "rec-test", Guid = ourGuid, Number = 1 });
+            Probe.ExpectMsg(true);
+            Probe.Send(persistRef, new ContainsEvent { Guid = ourGuid });
+            Probe.ExpectMsg(true, 5.Seconds());
             
-            (await persistRef.GracefulStop(10.Seconds())).Should().BeTrue();
-            // Intentionally being called twice to make sure that the actor state inside the user guardian has been cleared 
-            (await persistRef.GracefulStop(10.Seconds())).Should().BeTrue();
+            Probe.Watch(persistRef);
+            persistRef.Tell(PoisonPill.Instance);
+            Probe.ExpectTerminated(persistRef);
+            Probe.Unwatch(persistRef);
             
-            persistRef = sys1.ActorOf(Props.Create(() =>
+            persistRef = Sys.ActorOf(Props.Create(() =>
                 new SnapshotCompatActor(OldSnapshot, "p-3")), "test-snap-recover-2");
-            (await persistRef.Ask<bool>(new ContainsEvent { Guid = ourGuid }, TimeSpan.FromSeconds(5)))
-                .Should().BeTrue();
+            Probe.Send(persistRef, new ContainsEvent { Guid = ourGuid });
+            Probe.ExpectMsg(true, 5.Seconds());
         }
         
         [Fact]
-        public async Task SqlCommon_Snapshot_Can_Persist_L2db_Snapshot()
+        public void SqlCommon_Snapshot_Can_Persist_L2db_Snapshot()
         {
-            var sys1 = ActorSystem.Create("first", Config);
-            InitializeLogger(sys1);
-            
-            var persistRef = sys1.ActorOf(Props.Create(() =>
+            var persistRef = Sys.ActorOf(Props.Create(() =>
                 new SnapshotCompatActor(NewSnapshot, "p-4")), "test-snap-persist-2");
             var ourGuid = Guid.NewGuid();
             
-            (await persistRef.Ask<bool>(new SomeEvent { EventName = "rec-test", Guid = ourGuid, Number = 1 }))
-                .Should().BeTrue();
-            (await persistRef.Ask<bool>(new ContainsEvent { Guid = ourGuid }, TimeSpan.FromSeconds(5)))
-                .Should().BeTrue();
+            Probe.Send(persistRef, new SomeEvent { EventName = "rec-test", Guid = ourGuid, Number = 1 });
+            Probe.ExpectMsg(true);
+            Probe.Send(persistRef, new ContainsEvent { Guid = ourGuid });
+            Probe.ExpectMsg(true, 5.Seconds());
             
-            (await persistRef.GracefulStop(10.Seconds())).Should().BeTrue();
-            // Intentionally being called twice to make sure that the actor state inside the user guardian has been cleared 
-            (await persistRef.GracefulStop(10.Seconds())).Should().BeTrue();
+            Probe.Watch(persistRef);
+            persistRef.Tell(PoisonPill.Instance);
+            Probe.ExpectTerminated(persistRef);
+            Probe.Unwatch(persistRef);
             
-            persistRef = sys1.ActorOf(Props.Create(() =>
+            persistRef = Sys.ActorOf(Props.Create(() =>
                 new SnapshotCompatActor(OldSnapshot, "p-4")), "test-snap-persist-2");
-            (await persistRef.Ask<bool>(new ContainsEvent { Guid = ourGuid }, TimeSpan.FromSeconds(10)))
-                .Should().BeTrue();
+            Probe.Send(persistRef, new ContainsEvent { Guid = ourGuid });
+            Probe.ExpectMsg(true, 10.Seconds());
             
             var ourSecondGuid = Guid.NewGuid();
-            (await persistRef.Ask<bool>(new SomeEvent { EventName = "rec-test", Guid = ourSecondGuid, Number = 2 }))
-                .Should().BeTrue();
-            (await persistRef.Ask<bool>(new ContainsEvent { Guid = ourSecondGuid }, TimeSpan.FromSeconds(5)))
-                .Should().BeTrue();
+            Probe.Send(persistRef, new SomeEvent { EventName = "rec-test", Guid = ourSecondGuid, Number = 2 });
+            Probe.ExpectMsg(true);
+            Probe.Send(persistRef, new ContainsEvent { Guid = ourSecondGuid });
+            Probe.ExpectMsg(true, 10.Seconds());
         }
     }
 }


### PR DESCRIPTION
Fixes unit test problem where new actor names kept colliding with dead ones.

## Changes

Refactor compatibility unit tests to use TestKit