### PR TITLE
Remove actor names from unit tests

### DIFF
--- a/src/Akka.Persistence.Linq2Db.Compatibility.Tests/SqlCommonJournalCompatibilitySpec.cs
+++ b/src/Akka.Persistence.Linq2Db.Compatibility.Tests/SqlCommonJournalCompatibilitySpec.cs
@@ -42,8 +42,7 @@ namespace Akka.Persistence.Linq2Db.CompatibilityTests
         [Fact]
         public void Can_Recover_SqlCommon_Journal()
         {
-            var persistRef = Sys.ActorOf(Props.Create(() =>
-                new JournalCompatActor(OldJournal, "p-1")), "test-recover-1");
+            var persistRef = Sys.ActorOf(Props.Create(() => new JournalCompatActor(OldJournal, "p-1")));
             var ourGuid = Guid.NewGuid();
             var someEvent = new SomeEvent { EventName = "rec-test", Guid = ourGuid, Number = 1 };
             
@@ -57,8 +56,7 @@ namespace Akka.Persistence.Linq2Db.CompatibilityTests
             Probe.ExpectTerminated(persistRef);
             Probe.Unwatch(persistRef);
             
-            persistRef = Sys.ActorOf(Props.Create(() =>
-                new JournalCompatActor(NewJournal, "p-1")), "test-recover-1");
+            persistRef = Sys.ActorOf(Props.Create(() => new JournalCompatActor(NewJournal, "p-1")));
             Probe.Send(persistRef, new ContainsEvent { Guid = ourGuid });
             Probe.ExpectMsg(true, 5.Seconds());
         }
@@ -66,8 +64,7 @@ namespace Akka.Persistence.Linq2Db.CompatibilityTests
         [Fact]
         public void Can_Persist_SqlCommon_Journal()
         {
-            var persistRef = Sys.ActorOf(Props.Create(() =>
-                new JournalCompatActor(OldJournal, "p-2")), "test-persist-1");
+            var persistRef = Sys.ActorOf(Props.Create(() => new JournalCompatActor(OldJournal, "p-2")));
             var ourGuid = Guid.NewGuid();
             var someEvent = new SomeEvent { EventName = "rec-test", Guid = ourGuid, Number = 1 };
             
@@ -81,8 +78,7 @@ namespace Akka.Persistence.Linq2Db.CompatibilityTests
             Probe.ExpectTerminated(persistRef);
             Probe.Unwatch(persistRef);
             
-            persistRef = Sys.ActorOf(Props.Create(() =>
-                new JournalCompatActor(NewJournal, "p-2")), "test-persist-1");
+            persistRef = Sys.ActorOf(Props.Create(() => new JournalCompatActor(NewJournal, "p-2")));
             Probe.Send(persistRef, new ContainsEvent { Guid = ourGuid });
             Probe.ExpectMsg(true, 5.Seconds());
             
@@ -98,8 +94,7 @@ namespace Akka.Persistence.Linq2Db.CompatibilityTests
         [Fact]
         public void SqlCommon_Journal_Can_Recover_L2Db_Journal()
         {
-            var persistRef = Sys.ActorOf(Props.Create(() =>
-                new JournalCompatActor(NewJournal, "p-3")), "test-recover-2");
+            var persistRef = Sys.ActorOf(Props.Create(() => new JournalCompatActor(NewJournal, "p-3")));
             var ourGuid = Guid.NewGuid();
             var someEvent = new SomeEvent { EventName = "rec-test", Guid = ourGuid, Number = 1 };
             
@@ -113,8 +108,7 @@ namespace Akka.Persistence.Linq2Db.CompatibilityTests
             Probe.ExpectTerminated(persistRef);
             Probe.Unwatch(persistRef);
             
-            persistRef = Sys.ActorOf(Props.Create(() =>
-                new JournalCompatActor(OldJournal, "p-3")), "test-recover-2");
+            persistRef = Sys.ActorOf(Props.Create(() => new JournalCompatActor(OldJournal, "p-3")));
             Probe.Send(persistRef, new ContainsEvent { Guid = ourGuid });
             Probe.ExpectMsg(true, 5.Seconds());
         }
@@ -122,8 +116,7 @@ namespace Akka.Persistence.Linq2Db.CompatibilityTests
         [Fact]
         public void SqlCommon_Journal_Can_Persist_L2db_Journal()
         {
-            var persistRef = Sys.ActorOf(Props.Create(() =>
-                new JournalCompatActor(NewJournal, "p-4")), "test-persist-2");
+            var persistRef = Sys.ActorOf(Props.Create(() => new JournalCompatActor(NewJournal, "p-4")));
             var ourGuid = Guid.NewGuid();
             var someEvent = new SomeEvent { EventName = "rec-test", Guid = ourGuid, Number = 1 };
             
@@ -137,8 +130,7 @@ namespace Akka.Persistence.Linq2Db.CompatibilityTests
             Probe.ExpectTerminated(persistRef);
             Probe.Unwatch(persistRef);
             
-            persistRef = Sys.ActorOf(Props.Create(() =>
-                new JournalCompatActor(OldJournal, "p-4")), "test-persist-2");
+            persistRef = Sys.ActorOf(Props.Create(() => new JournalCompatActor(OldJournal, "p-4")));
             Probe.Send(persistRef, new ContainsEvent { Guid = ourGuid });
             Probe.ExpectMsg(true, 5.Seconds());
             
@@ -154,8 +146,7 @@ namespace Akka.Persistence.Linq2Db.CompatibilityTests
         public void L2db_Journal_Delete_Compat_mode_Preserves_proper_SequenceNr()
         {
             const string persistenceId = "d-1";
-            var persistRef = Sys.ActorOf(Props.Create(() =>
-                new JournalCompatActor(NewJournal, persistenceId)), "test-compat-delete-seqNo");
+            var persistRef = Sys.ActorOf(Props.Create(() => new JournalCompatActor(NewJournal, persistenceId)));
             
             var ourGuid1 = Guid.NewGuid();
             var ourGuid2 = Guid.NewGuid();
@@ -194,8 +185,7 @@ namespace Akka.Persistence.Linq2Db.CompatibilityTests
             Probe.ExpectTerminated(persistRef);
             Probe.Unwatch(persistRef);
             
-            persistRef = Sys.ActorOf(Props.Create(() =>
-                new JournalCompatActor(NewJournal, persistenceId)), "test-compat-delete-seqNo");
+            persistRef = Sys.ActorOf(Props.Create(() => new JournalCompatActor(NewJournal, persistenceId)));
             
             Probe.Send(persistRef, new GetSequenceNr());
             var reincaranatedSequenceNrNewJournal = Probe.ExpectMsg<CurrentSequenceNr>(5.Seconds());
@@ -207,8 +197,7 @@ namespace Akka.Persistence.Linq2Db.CompatibilityTests
             Probe.ExpectTerminated(persistRef);
             Probe.Unwatch(persistRef);
             
-            persistRef = Sys.ActorOf(Props.Create(() =>
-                new JournalCompatActor(OldJournal, persistenceId)), "test-compat-delete-seqNo");
+            persistRef = Sys.ActorOf(Props.Create(() => new JournalCompatActor(OldJournal, persistenceId)));
             
             Probe.Send(persistRef, new GetSequenceNr());
             var reincaranatedSequenceNr = Probe.ExpectMsg<CurrentSequenceNr>(5.Seconds());

--- a/src/Akka.Persistence.Linq2Db.Compatibility.Tests/SqlCommonSnapshotCompatibilitySpec.cs
+++ b/src/Akka.Persistence.Linq2Db.Compatibility.Tests/SqlCommonSnapshotCompatibilitySpec.cs
@@ -1,10 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Akka.Actor;
-using Akka.Event;
 using Akka.TestKit;
-using Akka.TestKit.Xunit2.Internals;
-using FluentAssertions;
 using LanguageExt.UnitsOfMeasure;
 using Xunit;
 using Xunit.Abstractions;
@@ -42,8 +39,7 @@ namespace Akka.Persistence.Linq2Db.CompatibilityTests
         [Fact]
         public void Can_Recover_SqlCommon_Snapshot()
         {
-            var persistRef = Sys.ActorOf(Props.Create(() =>
-                new SnapshotCompatActor(OldSnapshot, "p-1")), "test-snap-recover-1");
+            var persistRef = Sys.ActorOf(Props.Create(() => new SnapshotCompatActor(OldSnapshot, "p-1")));
             var ourGuid = Guid.NewGuid();
 
             Probe.Send(persistRef, new SomeEvent { EventName = "rec-test", Guid = ourGuid, Number = 1 });
@@ -56,8 +52,7 @@ namespace Akka.Persistence.Linq2Db.CompatibilityTests
             Probe.ExpectTerminated(persistRef);
             Probe.Unwatch(persistRef);
             
-            persistRef = Sys.ActorOf(Props.Create(() =>
-                new SnapshotCompatActor(NewSnapshot, "p-1")), "test-snap-recover-1");
+            persistRef = Sys.ActorOf(Props.Create(() => new SnapshotCompatActor(NewSnapshot, "p-1")));
             Probe.Send(persistRef, new ContainsEvent { Guid = ourGuid });
             Probe.ExpectMsg(true, 5.Seconds());
         }
@@ -65,8 +60,7 @@ namespace Akka.Persistence.Linq2Db.CompatibilityTests
         [Fact]
         public void Can_Persist_SqlCommon_Snapshot()
         {
-            var persistRef = Sys.ActorOf(Props.Create(() =>
-                new SnapshotCompatActor(OldSnapshot, "p-2")), "test-snap-persist-1");
+            var persistRef = Sys.ActorOf(Props.Create(() => new SnapshotCompatActor(OldSnapshot, "p-2")));
             var ourGuid = Guid.NewGuid();
 
             Probe.Send(persistRef, new SomeEvent { EventName = "rec-test", Guid = ourGuid, Number = 1 });
@@ -79,8 +73,7 @@ namespace Akka.Persistence.Linq2Db.CompatibilityTests
             Probe.ExpectTerminated(persistRef);
             Probe.Unwatch(persistRef);
             
-            persistRef = Sys.ActorOf(Props.Create(() =>
-                new SnapshotCompatActor(NewSnapshot, "p-2")), "test-snap-persist-1");
+            persistRef = Sys.ActorOf(Props.Create(() => new SnapshotCompatActor(NewSnapshot, "p-2")));
             Probe.Send(persistRef, new ContainsEvent { Guid = ourGuid });
             Probe.ExpectMsg(true, 5.Seconds());
             
@@ -94,8 +87,7 @@ namespace Akka.Persistence.Linq2Db.CompatibilityTests
         [Fact]
         public void SqlCommon_Snapshot_Can_Recover_L2Db_Snapshot()
         {
-            var persistRef = Sys.ActorOf(Props.Create(() =>
-                new SnapshotCompatActor(NewSnapshot, "p-3")), "test-snap-recover-2");
+            var persistRef = Sys.ActorOf(Props.Create(() => new SnapshotCompatActor(NewSnapshot, "p-3")));
             var ourGuid = Guid.NewGuid();
             
             Probe.Send(persistRef, new SomeEvent { EventName = "rec-test", Guid = ourGuid, Number = 1 });
@@ -108,8 +100,7 @@ namespace Akka.Persistence.Linq2Db.CompatibilityTests
             Probe.ExpectTerminated(persistRef);
             Probe.Unwatch(persistRef);
             
-            persistRef = Sys.ActorOf(Props.Create(() =>
-                new SnapshotCompatActor(OldSnapshot, "p-3")), "test-snap-recover-2");
+            persistRef = Sys.ActorOf(Props.Create(() => new SnapshotCompatActor(OldSnapshot, "p-3")));
             Probe.Send(persistRef, new ContainsEvent { Guid = ourGuid });
             Probe.ExpectMsg(true, 5.Seconds());
         }
@@ -117,8 +108,7 @@ namespace Akka.Persistence.Linq2Db.CompatibilityTests
         [Fact]
         public void SqlCommon_Snapshot_Can_Persist_L2db_Snapshot()
         {
-            var persistRef = Sys.ActorOf(Props.Create(() =>
-                new SnapshotCompatActor(NewSnapshot, "p-4")), "test-snap-persist-2");
+            var persistRef = Sys.ActorOf(Props.Create(() => new SnapshotCompatActor(NewSnapshot, "p-4")));
             var ourGuid = Guid.NewGuid();
             
             Probe.Send(persistRef, new SomeEvent { EventName = "rec-test", Guid = ourGuid, Number = 1 });
@@ -131,8 +121,7 @@ namespace Akka.Persistence.Linq2Db.CompatibilityTests
             Probe.ExpectTerminated(persistRef);
             Probe.Unwatch(persistRef);
             
-            persistRef = Sys.ActorOf(Props.Create(() =>
-                new SnapshotCompatActor(OldSnapshot, "p-4")), "test-snap-persist-2");
+            persistRef = Sys.ActorOf(Props.Create(() => new SnapshotCompatActor(OldSnapshot, "p-4")));
             Probe.Send(persistRef, new ContainsEvent { Guid = ourGuid });
             Probe.ExpectMsg(true, 10.Seconds());
             


### PR DESCRIPTION
## Changes

Remove actor names from unit tests to prevent name collision