### PR TITLE
Change default config values to be more greenfield friendly

### DIFF
--- a/src/Akka.Persistence.Sql.Data.Compatibility.Tests/DataCompatibilitySpecBase.cs
+++ b/src/Akka.Persistence.Sql.Data.Compatibility.Tests/DataCompatibilitySpecBase.cs
@@ -74,10 +74,12 @@ akka.persistence {{
 		sql {{
 			connection-string = ""{Fixture.ConnectionString}""
 			provider-name = {Settings.ProviderName}
+
+            # Compatibility settings
 			table-mapping = {Settings.TableMapping}
             auto-initialize = off
-            warn-on-auto-init-fail = true
             tag-write-mode = Csv
+            delete-compatibility-mode = true
 
             # Testing for https://github.com/akkadotnet/Akka.Persistence.Sql/pull/117#discussion_r1027345449
             batch-size = 3
@@ -93,9 +95,9 @@ akka.persistence {{
 	query.journal.sql {{
 		connection-string = ""{Fixture.ConnectionString}""
 		provider-name = {Settings.ProviderName}
+
+        # Compatibility settings
 		table-mapping = {Settings.TableMapping}
-        auto-initialize = off
-        warn-on-auto-init-fail = true
         tag-read-mode = Csv
 
         # Testing for https://github.com/akkadotnet/Akka.Persistence.Sql/pull/117#discussion_r1027345449
@@ -108,6 +110,8 @@ akka.persistence {{
 		sql {{
 			connection-string = ""{Fixture.ConnectionString}""
 			provider-name = {Settings.ProviderName}
+
+            # Compatibility settings
 			table-mapping = {Settings.TableMapping}
             auto-initialize = off
 

--- a/src/Akka.Persistence.Sql.Tests.Common/Query/BaseAllEventsSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests.Common/Query/BaseAllEventsSpec.cs
@@ -60,13 +60,11 @@ akka.persistence.journal.sql {{
     provider-name = ""{fixture.ProviderName}""
     tag-write-mode = ""{tagMode}""
     connection-string = ""{fixture.ConnectionString}""
-    auto-initialize = on
 }}
 akka.persistence.query.journal.sql {{
     provider-name = ""{fixture.ProviderName}""
     connection-string = ""{fixture.ConnectionString}""
     tag-read-mode = ""{tagMode}""
-    auto-initialize = on
     refresh-interval = 1s
 }}
 akka.test.single-expect-default = 10s")

--- a/src/Akka.Persistence.Sql.Tests.Common/Query/BaseCurrentAllEventsSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests.Common/Query/BaseCurrentAllEventsSpec.cs
@@ -60,13 +60,11 @@ akka.persistence.journal.sql {{
     provider-name = ""{fixture.ProviderName}""
     tag-write-mode = ""{tagMode}""
     connection-string = ""{fixture.ConnectionString}""
-    auto-initialize = on
 }}
 akka.persistence.query.journal.sql {{
     provider-name = ""{fixture.ProviderName}""
     connection-string = ""{fixture.ConnectionString}""
     tag-read-mode = ""{tagMode}""
-    auto-initialize = on
     refresh-interval = 1s
 }}
 akka.test.single-expect-default = 10s")

--- a/src/Akka.Persistence.Sql.Tests.Common/Query/BaseCurrentEventsByPersistenceIdSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests.Common/Query/BaseCurrentEventsByPersistenceIdSpec.cs
@@ -56,7 +56,6 @@ akka.persistence {{
             provider-name = ""{fixture.ProviderName}""
             tag-write-mode = ""{tagMode}""
             connection-string = ""{fixture.ConnectionString}""
-            auto-initialize = on
         }}
     }}
     query {{
@@ -65,7 +64,6 @@ akka.persistence {{
                 provider-name = ""{fixture.ProviderName}""
                 connection-string = ""{fixture.ConnectionString}""
                 tag-read-mode = ""{tagMode}""
-                auto-initialize = on
                 refresh-interval = 1s
             }}
         }}

--- a/src/Akka.Persistence.Sql.Tests.Common/Query/BaseCurrentEventsByTagSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests.Common/Query/BaseCurrentEventsByTagSpec.cs
@@ -60,13 +60,11 @@ akka.persistence.journal.sql {{
     provider-name = ""{fixture.ProviderName}""
     tag-write-mode = ""{tagMode}""
     connection-string = ""{fixture.ConnectionString}""
-    auto-initialize = on
 }}
 akka.persistence.query.journal.sql {{
     provider-name = ""{fixture.ProviderName}""
     connection-string = ""{fixture.ConnectionString}""
     tag-read-mode = ""{tagMode}""
-    auto-initialize = on
     refresh-interval = 1s
 }}
 akka.test.single-expect-default = 10s")

--- a/src/Akka.Persistence.Sql.Tests.Common/Query/BaseCurrentPersistenceIdsSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests.Common/Query/BaseCurrentPersistenceIdsSpec.cs
@@ -54,14 +54,12 @@ akka.persistence.journal.sql {{
     provider-name = ""{fixture.ProviderName}""
     tag-write-mode = ""{tagMode}""
     connection-string = ""{fixture.ConnectionString}""
-    auto-initialize = on
 }}
 akka.persistence.query.journal.sql
 {{
     provider-name = ""{fixture.ProviderName}""
     connection-string = ""{fixture.ConnectionString}""
     tag-read-mode = ""{tagMode}""
-    auto-initialize = on
     refresh-interval = 1s
 }}
 akka.test.single-expect-default = 10s")

--- a/src/Akka.Persistence.Sql.Tests.Common/Query/BaseEventsByPersistenceIdSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests.Common/Query/BaseEventsByPersistenceIdSpec.cs
@@ -54,14 +54,12 @@ akka.persistence.journal.sql {{
     provider-name = ""{fixture.ProviderName}""
     tag-write-mode = ""{tagMode}""
     connection-string = ""{fixture.ConnectionString}""
-    auto-initialize = on
 }}
 akka.persistence.query.journal.sql
 {{
     provider-name = ""{fixture.ProviderName}""
     connection-string = ""{fixture.ConnectionString}""
     tag-read-mode = ""{tagMode}""
-    auto-initialize = on
     refresh-interval = 1s
 }}
 akka.test.single-expect-default = 10s")

--- a/src/Akka.Persistence.Sql.Tests.Common/Query/BaseEventsByTagSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests.Common/Query/BaseEventsByTagSpec.cs
@@ -60,14 +60,12 @@ akka.persistence.journal.sql {{
     provider-name = ""{fixture.ProviderName}""
     tag-write-mode = ""{tagMode}""
     connection-string = ""{fixture.ConnectionString}""
-    auto-initialize = on
 }}
 akka.persistence.query.journal.sql
 {{
     provider-name = ""{fixture.ProviderName}""
     connection-string = ""{fixture.ConnectionString}""
     tag-read-mode = ""{tagMode}""
-    auto-initialize = on
     refresh-interval = 1s
 }}
 akka.test.single-expect-default = 10s")

--- a/src/Akka.Persistence.Sql.Tests.Common/Query/BasePersistenceIdsSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests.Common/Query/BasePersistenceIdsSpec.cs
@@ -65,7 +65,6 @@ akka.persistence {{
             provider-name = ""{fixture.ProviderName}""
             tag-write-mode = ""{tagMode}""
             connection-string = ""{fixture.ConnectionString}""
-            auto-initialize = on
         }}
     }}
     snapshot-store {{
@@ -73,7 +72,6 @@ akka.persistence {{
         sql {{
             provider-name = ""{fixture.ProviderName}""
             connection-string = ""{fixture.ConnectionString}""
-            auto-initialize = on
         }}
     }}
 }}
@@ -81,7 +79,6 @@ akka.persistence.query.journal.sql {{
     provider-name = ""{fixture.ProviderName}""
     connection-string = ""{fixture.ConnectionString}""
     tag-read-mode = ""{tagMode}""
-    auto-initialize = on
     refresh-interval = 200ms
 }}
 akka.test.single-expect-default = 10s")

--- a/src/Akka.Persistence.Sql.Tests/PostgreSql/Compatibility/PostgreSqlCompatibilitySpecConfig.cs
+++ b/src/Akka.Persistence.Sql.Tests/PostgreSql/Compatibility/PostgreSqlCompatibilitySpecConfig.cs
@@ -76,6 +76,7 @@ namespace Akka.Persistence.Sql.Tests.PostgreSql.Compatibility
                             table-mapping = postgresql
                             auto-initialize = true
                             tag-write-mode = Csv
+                            delete-compatibility-mode = true
                             postgresql {{
                                 journal {{
                                     table-name = ""{tableName}""

--- a/src/Akka.Persistence.Sql.Tests/PostgreSql/PostgreSqlJournalSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests/PostgreSql/PostgreSqlJournalSpec.cs
@@ -46,8 +46,6 @@ akka.persistence {{
         sql {{
             connection-string = ""{fixture.ConnectionString}""
             provider-name = ""{fixture.ProviderName}""
-            use-clone-connection = true
-            auto-initialize = true
         }}
     }}
 }}")

--- a/src/Akka.Persistence.Sql.Tests/PostgreSql/PostgreSqlSnapshotSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests/PostgreSql/PostgreSqlSnapshotSpec.cs
@@ -42,18 +42,8 @@ akka.persistence {{
     snapshot-store {{
         plugin = ""akka.persistence.snapshot-store.sql""
         sql {{
-            class = ""{typeof(SqlSnapshotStore).AssemblyQualifiedName}""
-            plugin-dispatcher = ""akka.persistence.dispatchers.default-plugin-dispatcher""
             connection-string = ""{fixture.ConnectionString}""
             provider-name = ""{fixture.ProviderName}""
-            use-clone-connection = true
-            auto-initialize = true
-            warn-on-auto-init-fail = false
-            default {{
-                journal {{
-                    table-name = l2dbSnapshotSpec
-                }}
-            }}
         }}
     }}
 }}")

--- a/src/Akka.Persistence.Sql.Tests/Settings/JournalConfigSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests/Settings/JournalConfigSpec.cs
@@ -36,21 +36,21 @@ namespace Akka.Persistence.Sql.Tests.Settings
             journal.GetString("plugin-dispatcher").Should().Be("akka.persistence.dispatchers.default-plugin-dispatcher");
             journal.GetString("connection-string", "invalid").Should().BeNullOrEmpty();
             journal.GetString("provider-name", "invalid").Should().BeNullOrEmpty();
-            journal.GetBoolean("delete-compatibility-mode").Should().BeTrue();
+            journal.GetBoolean("delete-compatibility-mode").Should().BeFalse();
             journal.GetString("table-mapping", "invalid").Should().Be("default");
             journal.GetInt("buffer-size").Should().Be(5000);
             journal.GetInt("batch-size").Should().Be(100);
             journal.GetInt("db-round-trip-max-batch-size").Should().Be(1000);
-            journal.GetBoolean("prefer-parameters-on-multirow-insert").Should().BeTrue();
+            journal.GetBoolean("prefer-parameters-on-multirow-insert").Should().BeFalse();
             journal.GetInt("replay-batch-size").Should().Be(1000);
             journal.GetInt("parallelism").Should().Be(3);
             journal.GetInt("max-row-by-row-size").Should().Be(100);
-            journal.GetBoolean("use-clone-connection").Should().BeFalse();
+            journal.GetBoolean("use-clone-connection").Should().BeTrue();
             journal.GetString("materializer-dispatcher", "invalid").Should().Be("akka.actor.default-dispatcher");
             journal.GetString("serializer", "invalid").Should().BeNullOrEmpty();
             journal.GetString("tag-separator", "invalid").Should().Be(";");
             journal.GetString("dao", "invalid").Should().Be("Akka.Persistence.Sql.Journal.Dao.ByteArrayJournalDao, Akka.Persistence.Sql");
-            journal.GetBoolean("auto-initialize").Should().BeFalse();
+            journal.GetBoolean("auto-initialize").Should().BeTrue();
             journal.GetBoolean("warn-on-auto-init-fail").Should().BeTrue();
 
             var journalTables = journal.GetConfig("default");
@@ -280,9 +280,9 @@ namespace Akka.Persistence.Sql.Tests.Settings
             journal.MaterializerDispatcher.Should().Be("akka.actor.default-dispatcher");
             journal.ProviderName.Should().BeNullOrEmpty();
             journal.UseSharedDb.Should().BeNullOrEmpty();
-            journal.UseCloneConnection.Should().BeFalse();
+            journal.UseCloneConnection.Should().BeTrue();
             journal.DefaultSerializer.Should().BeNullOrEmpty();
-            journal.AutoInitialize.Should().BeFalse();
+            journal.AutoInitialize.Should().BeTrue();
             journal.WarnOnAutoInitializeFail.Should().BeTrue();
 
             var pluginConfig = journal.PluginConfig;
@@ -294,11 +294,11 @@ namespace Akka.Persistence.Sql.Tests.Settings
             daoConfig.BufferSize.Should().Be(5000);
             daoConfig.BatchSize.Should().Be(100);
             daoConfig.DbRoundTripBatchSize.Should().Be(1000);
-            daoConfig.PreferParametersOnMultiRowInsert.Should().BeTrue();
+            daoConfig.PreferParametersOnMultiRowInsert.Should().BeFalse();
             daoConfig.ReplayBatchSize.Should().Be(1000);
             daoConfig.Parallelism.Should().Be(3);
             daoConfig.MaxRowByRowSize.Should().Be(100);
-            daoConfig.SqlCommonCompatibilityMode.Should().BeTrue();
+            daoConfig.SqlCommonCompatibilityMode.Should().BeFalse();
         }
     }
 }

--- a/src/Akka.Persistence.Sql.Tests/Settings/ReadJournalConfigSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests/Settings/ReadJournalConfigSpec.cs
@@ -45,7 +45,7 @@ namespace Akka.Persistence.Sql.Tests.Settings
             query.GetInt("replay-batch-size").Should().Be(1000);
             query.GetInt("parallelism").Should().Be(3);
             query.GetInt("max-row-by-row-size").Should().Be(100);
-            query.GetBoolean("use-clone-connection").Should().BeFalse();
+            query.GetBoolean("use-clone-connection").Should().BeTrue();
             query.GetString("tag-separator", "invalid").Should().Be(";");
             query.GetString("dao", "invalid").Should().Be("Akka.Persistence.Sql.Journal.Dao.ByteArrayJournalDao, Akka.Persistence.Sql");
 
@@ -271,7 +271,7 @@ namespace Akka.Persistence.Sql.Tests.Settings
         {
             journal.ConnectionString.Should().BeNullOrEmpty();
             journal.ProviderName.Should().BeNullOrEmpty();
-            journal.UseCloneConnection.Should().BeFalse();
+            journal.UseCloneConnection.Should().BeTrue();
             journal.RefreshInterval.Should().Be(1.Seconds());
             journal.MaxBufferSize.Should().Be(500);
             journal.AddShutdownHook.Should().BeTrue();

--- a/src/Akka.Persistence.Sql.Tests/Settings/SnapshotConfigSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests/Settings/SnapshotConfigSpec.cs
@@ -35,11 +35,11 @@ namespace Akka.Persistence.Sql.Tests.Settings
             snapshot.GetString("plugin-dispatcher").Should().Be("akka.persistence.dispatchers.default-plugin-dispatcher");
             snapshot.GetString("connection-string", "invalid").Should().BeNullOrEmpty();
             snapshot.GetString("provider-name", "invalid").Should().BeNullOrEmpty();
-            snapshot.GetBoolean("use-clone-connection").Should().BeFalse();
+            snapshot.GetBoolean("use-clone-connection").Should().BeTrue();
             snapshot.GetString("table-mapping", "invalid").Should().Be("default");
             snapshot.GetString("serializer", "invalid").Should().BeNullOrEmpty();
             snapshot.GetString("dao", "invalid").Should().Be("Akka.Persistence.Sql.Snapshot.ByteArraySnapshotDao, Akka.Persistence.Sql");
-            snapshot.GetBoolean("auto-initialize").Should().BeFalse();
+            snapshot.GetBoolean("auto-initialize").Should().BeTrue();
             snapshot.GetBoolean("warn-on-auto-init-fail").Should().BeTrue();
 
             var snapshotConfig = snapshot.GetConfig("default");
@@ -197,7 +197,7 @@ namespace Akka.Persistence.Sql.Tests.Settings
         {
             snapshot.ConnectionString.Should().BeNullOrEmpty();
             snapshot.ProviderName.Should().BeNullOrEmpty();
-            snapshot.UseCloneConnection.Should().BeFalse();
+            snapshot.UseCloneConnection.Should().BeTrue();
             snapshot.DefaultSerializer.Should().BeNullOrEmpty();
             snapshot.UseSharedDb.Should().BeNullOrEmpty();
 

--- a/src/Akka.Persistence.Sql.Tests/SqlJournalDefaultSpecConfig.cs
+++ b/src/Akka.Persistence.Sql.Tests/SqlJournalDefaultSpecConfig.cs
@@ -10,7 +10,7 @@ namespace Akka.Persistence.Sql.Tests
 {
     public static class SqlJournalDefaultSpecConfig
     {
-        public static string CustomConfig(
+        private static string CustomConfig(
             string customJournalName,
             string journalTableName,
             string metadataTableName,
@@ -21,30 +21,9 @@ akka.persistence.journal.{customJournalName} {{
     class = ""Akka.Persistence.Sql.Journal.SqlWriteJournal, Akka.Persistence.Sql""
     provider-name = ""{providerName}""
     connection-string = ""{connectionString}""
-    auto-initialize = true
     default {{
         journal {{
             table-name = ""{journalTableName}""
-        }}
-        metadata {{
-            table-name = ""{metadataTableName}""
-        }}
-    }}
-}}";
-
-        public static string JournalBaseConfig(
-            string tableName,
-            string metadataTableName,
-            string providerName,
-            string connectionString)
-            => $@"
-akka.persistence.journal.sql {{
-    provider-name = ""{providerName}""
-    connection-string = ""{connectionString}""
-    auto-initialize = true
-    default {{
-        journal {{
-            table-name = ""{tableName}""
         }}
         metadata {{
             table-name = ""{metadataTableName}""
@@ -65,27 +44,9 @@ akka.persistence.journal.sql {{
                 metadataTableName,
                 providerName,
                 connectionString) + (asDefault
-                ? $@"
-akka{{
-  persistence {{
-    journal {{
-      plugin = akka.persistence.journal.{configName}
-    }}
-  }}
-}}"
+                ? $"akka.persistence.journal.plugin = akka.persistence.journal.{configName}"
                 : string.Empty);
 
-        public static Configuration.Config GetConfig(
-            string tableName,
-            string metadataTableName,
-            string providerName,
-            string connectionString)
-            => JournalBaseConfig(
-                tableName,
-                metadataTableName,
-                providerName,
-                connectionString);
-        
         public static Configuration.Config GetDefaultConfig(
             string providerName,
             string connectionString)
@@ -95,7 +56,6 @@ akka.persistence.journal {{
     sql {{
         provider-name = ""{providerName}""
         connection-string = ""{connectionString}""
-        auto-initialize = true
     }}
 }}")
                 .WithFallback(SqlPersistence.DefaultConfiguration);

--- a/src/Akka.Persistence.Sql.Tests/SqlServer/Compatibility/SqlServerCompatibilitySpecConfig.cs
+++ b/src/Akka.Persistence.Sql.Tests/SqlServer/Compatibility/SqlServerCompatibilitySpecConfig.cs
@@ -70,11 +70,12 @@ namespace Akka.Persistence.Sql.Tests.SqlServer.Compatibility
                             class = ""{typeof(SqlWriteJournal).AssemblyQualifiedName}""
                             plugin-dispatcher = ""akka.persistence.dispatchers.default-plugin-dispatcher""
                             connection-string = ""{fixture.ConnectionString}""
-                            provider-name = ""{ProviderName.SqlServer2017}""
+                            provider-name = ""{fixture.ProviderName}""
                             parallelism = 3
                             table-mapping = sql-server
                             tag-write-mode = Csv
                             auto-initialize = true
+                            delete-compatibility-mode = true
                             sql-server {{
                                 journal {{
                                     table-name = ""{tableName}""

--- a/src/Akka.Persistence.Sql.Tests/SqlServer/SqlServerJournalDefaultConfigSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests/SqlServer/SqlServerJournalDefaultConfigSpec.cs
@@ -101,17 +101,6 @@ namespace Akka.Persistence.Sql.Tests.SqlServer
             }
             journalColumns.Should().BeEmpty("Journal table should not contain any superfluous columns");
             
-            // metadata table
-            var metadataTable = schema.Tables.FirstOrDefault(t => t.TableName == "journal_metadata");
-            metadataTable.Should().NotBeNull();
-            var metadataColumns = metadataTable!.Columns.Select(c => c.ColumnName).ToList();
-            foreach (var column in _metadataTableColumnNames)
-            {
-                if (!metadataColumns.Remove(column))
-                    throw new XunitException($"Journal metadata table does not contain the required column {column}");
-            }
-            metadataColumns.Should().BeEmpty("Journal metadata table should not contain any superfluous columns");
-
             // tag table
             var tagTable = schema.Tables.FirstOrDefault(t => t.TableName == "tags");
             tagTable.Should().NotBeNull();
@@ -122,6 +111,20 @@ namespace Akka.Persistence.Sql.Tests.SqlServer
                     throw new XunitException($"Tag table does not contain the required column {column}");
             }
             tagColumns.Should().BeEmpty("Tag table should not contain any superfluous columns");
+        }
+
+        // Used to test that metadata table is valid
+        private void AssertMetadataTableExistsAndValid(DatabaseSchema schema)
+        {
+            var metadataTable = schema.Tables.FirstOrDefault(t => t.TableName == "journal_metadata");
+            metadataTable.Should().NotBeNull();
+            var metadataColumns = metadataTable!.Columns.Select(c => c.ColumnName).ToList();
+            foreach (var column in _metadataTableColumnNames)
+            {
+                if (!metadataColumns.Remove(column))
+                    throw new XunitException($"Journal metadata table does not contain the required column {column}");
+            }
+            metadataColumns.Should().BeEmpty("Journal metadata table should not contain any superfluous columns");
         }
 
         private JournalConfig GetConfig()

--- a/src/Akka.Persistence.Sql.Tests/SqlServer/SqlServerJournalSpecConfig.cs
+++ b/src/Akka.Persistence.Sql.Tests/SqlServer/SqlServerJournalSpecConfig.cs
@@ -6,8 +6,6 @@
 
 using System;
 using Akka.Configuration;
-using Akka.Persistence.Sql.Journal;
-using Akka.Persistence.Sql.Snapshot;
 using Akka.Persistence.Sql.Tests.Common.Containers;
 using FluentAssertions.Extensions;
 
@@ -15,11 +13,7 @@ namespace Akka.Persistence.Sql.Tests.SqlServer
 {
     public static class SqlServerJournalSpecConfig
     {
-        public static Configuration.Config Create(
-            SqlServerContainer fixture,
-            string tableName,
-            int batchSize = 100,
-            int parallelism = 2)
+        public static Configuration.Config Create(SqlServerContainer fixture, string tableName)
         {
             if (!fixture.InitializeDbAsync().Wait(10.Seconds()))
                 throw new Exception("Failed to clean up database in 10 seconds");
@@ -32,9 +26,6 @@ akka.persistence {{
         sql {{
             connection-string = ""{fixture.ConnectionString}""
             provider-name = ""{fixture.ProviderName}""
-            parallelism = {parallelism}
-            batch-size = {batchSize}
-            auto-initialize = true
             default {{
                 journal {{
                     table-name = ""{tableName}""
@@ -49,11 +40,7 @@ akka.persistence {{
 
     public static class SqlServerSnapshotSpecConfig
     {
-        public static Configuration.Config Create(
-            SqlServerContainer fixture,
-            string tableName,
-            int batchSize = 100,
-            int parallelism = 2)
+        public static Configuration.Config Create(SqlServerContainer fixture, string tableName)
         {
             if (!fixture.InitializeDbAsync().Wait(10.Seconds()))
                 throw new Exception("Failed to clean up database in 10 seconds");
@@ -66,9 +53,6 @@ akka.persistence {{
         sql {{
             connection-string = ""{fixture.ConnectionString}""
             provider-name = ""{fixture.ProviderName}""
-            parallelism = {parallelism}
-            batch-size = {batchSize}
-            auto-initialize = true
             default {{
                 journal {{
                     table-name = ""{tableName}""

--- a/src/Akka.Persistence.Sql.Tests/Sqlite/Compatibility/SqliteCompatibilitySpecConfig.cs
+++ b/src/Akka.Persistence.Sql.Tests/Sqlite/Compatibility/SqliteCompatibilitySpecConfig.cs
@@ -73,6 +73,7 @@ namespace Akka.Persistence.Sql.Tests.Sqlite.Compatibility
                             table-mapping = sqlite
                             tag-write-mode = Csv
                             auto-initialize = true
+                            delete-compatibility-mode = true
                             sqlite {{
                                 journal {{
                                     table-name = ""{tableName}""

--- a/src/Akka.Persistence.Sql.Tests/Sqlite/SqliteJournalSpecConfig.cs
+++ b/src/Akka.Persistence.Sql.Tests/Sqlite/SqliteJournalSpecConfig.cs
@@ -27,10 +27,6 @@ namespace Akka.Persistence.Sql.Tests.Sqlite
                         sql {{
                             connection-string = ""{fixture.ConnectionString}""
                             provider-name = ""{fixture.ProviderName}""
-                            parallelism = 1
-                            max-row-by-row-size = 100
-                            auto-initialize = true
-                            use-clone-connection = {(fixture.ProviderName == ProviderName.SQLiteMS ? "on" : "off")}
                         }}
                     }}
                 }}")
@@ -55,11 +51,6 @@ namespace Akka.Persistence.Sql.Tests.Sqlite
                         sql {{
                             connection-string = ""{fixture.ConnectionString}""
                             provider-name = ""{fixture.ProviderName}""
-                            parallelism = 1
-                            max-row-by-row-size = 100
-                            delete-compatibility-mode = {(nativeMode == false ? "on" : "off")}
-                            auto-initialize = true
-                            use-clone-connection = {(fixture.ProviderName == ProviderName.SQLiteMS ? "on" : "off")}
                         }}
                     }}
                 }}")

--- a/src/Akka.Persistence.Sql/persistence.conf
+++ b/src/Akka.Persistence.Sql/persistence.conf
@@ -21,7 +21,7 @@
       # The database schema, table names, and column names configuration mapping.
       # The details are described in their respective configuration block below.
       # If set to "sqlite", "sql-server", "mysql", or "postgresql",
-      # column names will be compatible with Akka.Persistence.Sql
+      # column names will be compatible with legacy Akka.NET persistence sql plugins
       table-mapping = default
 
       # If more entries than this are pending, writes will be rejected.
@@ -297,6 +297,15 @@
 
         connection-string = "" # Connection String is Required!
 
+        # This setting dictates how journal event tags are being read from the database.
+        # Valid values:
+        #   * Csv 
+        #     This value will make the plugin read event tags from a CSV formatted string 
+        #     `tags` column inside the journal table. This is the backward compatible
+        #     way of reading event tag information.
+        #   * TagTable
+        #     This value will make the plugin read event tags from the tag
+        #     table to improve tag related query speed.
         tag-read-mode = TagTable
 
         journal-sequence-retrieval{

--- a/src/Akka.Persistence.Sql/persistence.conf
+++ b/src/Akka.Persistence.Sql/persistence.conf
@@ -16,7 +16,7 @@
       # If true, journal_metadata is created and used for deletes
       # and max sequence number queries.
       # note that there is a performance penalty for using this.
-      delete-compatibility-mode = true
+      delete-compatibility-mode = false
 
       # The database schema, table names, and column names configuration mapping.
       # The details are described in their respective configuration block below.
@@ -48,7 +48,7 @@
       # Linq2Db by default will use a built string for multi-row inserts
       # Somewhat counterintuitively, this is faster than using parameters in most cases,
       # But if you would prefer parameters, you can set this to true.
-      prefer-parameters-on-multirow-insert = true
+      prefer-parameters-on-multirow-insert = false
 
       # Denotes the number of messages retrieved
       # Per round-trip to DB on recovery.
@@ -72,7 +72,7 @@
 
       # Only set to TRUE if unit tests pass with the connection string you intend to use!
       # This setting will go away once https://github.com/linq2db/linq2db/issues/2466 is resolved
-      use-clone-connection = false
+      use-clone-connection = true
 
       # This dispatcher will be used for the Stream Materializers
       # Note that while all calls will be Async to Linq2Db,
@@ -99,7 +99,7 @@
       # should corresponding journal table be initialized automatically
       # if delete-compatibility-mode is true, both tables are created
       # if delete-compatibility-mode is false, only journal table will be created.
-      auto-initialize = off
+      auto-initialize = true
 
       # if true, a warning will be logged
       # if auto-init of tables fails.
@@ -354,7 +354,7 @@
 
         # Only set to TRUE if unit tests pass with the connection string you intend to use!
         # This setting will go away once https://github.com/linq2db/linq2db/issues/2466 is resolved
-        use-clone-connection = false
+        use-clone-connection = true
 
         tag-separator = ";"
 

--- a/src/Akka.Persistence.Sql/snapshot.conf
+++ b/src/Akka.Persistence.Sql/snapshot.conf
@@ -15,7 +15,7 @@
 
       # Only set to TRUE if unit tests pass with the connection string you intend to use!
       # This setting will go away once https://github.com/linq2db/linq2db/issues/2466 is resolved
-      use-clone-connection = false
+      use-clone-connection = true
 
       # The database schema, table names, and column names configuration mapping.
       # The details are described in their respective configuration block below.
@@ -30,10 +30,8 @@
 
       dao = "Akka.Persistence.Sql.Snapshot.ByteArraySnapshotDao, Akka.Persistence.Sql"
 
-      compatibility-mode = false
-
       # if true, tables will attempt to be created.
-      auto-initialize = false
+      auto-initialize = true
 
       # if true, a warning will be logged
       # if auto-init of tables fails.


### PR DESCRIPTION
Fixes #194

## Changes
- akka.persistence.journal.sql
  - Change `delete-compatibility-mode` to `false`
  - Change `prefer-parameters-on-multirow-insert` to `false`
  - Change `use-clone-connection` to `true`
  - Change `auto-initialize` to `true`
- akka.persistence.query.journal.sql
  - Change `use-clone-connection` to `true`
- akka.persistence.snapshot-store.sql
  - Change `use-clone-connection` to `true`
  - Change `auto-initialize` to `true`
  - Remove `compatibility-mode`, it is not being used.