### PR TITLE
Make snapshot table initialization asynchronous

### DIFF
--- a/src/Akka.Persistence.Sql/Snapshot/ByteArraySnapshotDao.cs
+++ b/src/Akka.Persistence.Sql/Snapshot/ByteArraySnapshotDao.cs
@@ -320,30 +320,16 @@ namespace Akka.Persistence.Sql.Snapshot
             }
         }
 
-        // TODO: This should be converted to async
-        public void InitializeTables()
+        public async Task InitializeTables()
         {
-            using var connection = _connectionFactory.GetConnection();
-
-            try
+            await using var connection = _connectionFactory.GetConnection();
+            if (connection.UseDateTime)
             {
-                if (connection.UseDateTime)
-                {
-                    connection.CreateTable<DateTimeSnapshotRow>();
-                }
-                else
-                {
-                    connection.CreateTable<LongSnapshotRow>();
-                }
+                await connection.CreateTableAsync<DateTimeSnapshotRow>(TableOptions.CreateIfNotExists);
             }
-            catch (Exception e)
+            else
             {
-                if (_snapshotConfig.WarnOnAutoInitializeFail)
-                {
-                    _logger.Warning(
-                        e,
-                        $"Could not Create Snapshot Table {_snapshotConfig.TableConfig.SnapshotTable.Name} as requested by config.");
-                }
+                await connection.CreateTableAsync<LongSnapshotRow>(TableOptions.CreateIfNotExists);
             }
         }
     }


### PR DESCRIPTION
Make snapshot table initialization more robust 

## Changes

* Make snapshot table initialization async
* Change table creation to "if not exist" instead of bruteforcing it
* Stop actor if initialization failed