### PR TITLE
Fix journal and tag table indexing

### DIFF
--- a/src/Akka.Persistence.Sql/Db/AkkaPersistenceDataConnectionFactory.cs
+++ b/src/Akka.Persistence.Sql/Db/AkkaPersistenceDataConnectionFactory.cs
@@ -37,6 +37,8 @@ namespace Akka.Persistence.Sql.Db
 
             var fmb = new FluentMappingBuilder(mappingSchema);
             MapJournalRow(config, fmb);
+            MapMetadataRow(config, fmb);
+            MapTagRow(config, fmb);
             fmb.Build();
 
             _useCloneDataConnection = config.UseCloneConnection;
@@ -107,6 +109,11 @@ namespace Akka.Persistence.Sql.Db
 
             journalRowBuilder
                 .HasTableName(journalConfig.Name)
+                
+                .Member(r => r.Ordering)
+                .HasColumnName(columnNames.Ordering)
+                .IsIdentity()
+                .IsPrimaryKey()
 
                 .Member(r => r.Deleted)
                 .HasColumnName(columnNames.Deleted)
@@ -118,9 +125,6 @@ namespace Akka.Persistence.Sql.Db
                 .Member(r => r.Message)
                 .HasColumnName(columnNames.Message)
                 .IsNullable(false)
-
-                .Member(r => r.Ordering)
-                .HasColumnName(columnNames.Ordering)
 
                 .Member(r => r.Identifier)
                 .HasColumnName(columnNames.Identifier)
@@ -139,6 +143,13 @@ namespace Akka.Persistence.Sql.Db
                 .Member(r => r.TagArr)
                 .IsNotColumn();
 
+            if (config.ProviderName.ToLower().Contains("sqlite"))
+            {
+                journalRowBuilder
+                    .Member(r => r.Ordering)
+                    .HasDbType("INTEGER");
+            }
+            
             if (journalConfig.UseWriterUuidColumn)
             {
                 journalRowBuilder
@@ -169,22 +180,6 @@ namespace Akka.Persistence.Sql.Db
                     .HasLength(100);
             }
 
-            if (config.ProviderName.ToLower().Contains("sqlite"))
-            {
-                journalRowBuilder
-                    .Member(r => r.Ordering)
-                    .IsPrimaryKey()
-                    .HasDbType("INTEGER")
-                    .IsIdentity();
-            }
-            else
-            {
-                journalRowBuilder
-                    .Member(r => r.Ordering).IsIdentity()
-                    .Member(r => r.PersistenceId).IsPrimaryKey()
-                    .Member(r => r.SequenceNumber).IsPrimaryKey();
-            }
-
             // TODO: UseEventManifestColumn is always false
             if (config.TableConfig.UseEventManifestColumn)
             {
@@ -199,89 +194,80 @@ namespace Akka.Persistence.Sql.Db
                     .Member(r => r.EventManifest)
                     .IsNotColumn();
             }
+        }
 
-            if (config.PluginConfig.TagMode is not TagMode.Csv)
-            {
-                var tagConfig = tableConfig.TagTable;
-                var tagColumns = tagConfig.ColumnNames;
-
-                var rowBuilder = fmb.Entity<JournalTagRow>();
-                if (tableConfig.SchemaName is { })
-                    rowBuilder.HasSchemaName(tableConfig.SchemaName);
-
-                rowBuilder
-                    .HasTableName(tagConfig.Name)
-
-                    .Member(r => r.TagValue)
-                    .HasColumnName(tagColumns.Tag)
-                    .IsColumn()
-                    .IsNullable(false)
-                    .HasLength(64)
-                    .IsPrimaryKey()
-
-                    .Member(r => r.SequenceNumber)
-                    .HasColumnName(tagColumns.SequenceNumber)
-                    .IsColumn()
-                    .IsNullable(false)
-
-                    .Member(r => r.PersistenceId)
-                    .HasColumnName(tagColumns.PersistenceId)
-                    .HasLength(255)
-                    .IsColumn()
-                    .IsNullable(false)
-                    .IsPrimaryKey();
-
-                if (config.ProviderName.ToLower().Contains("sqlite"))
-                {
-                    rowBuilder
-                        .Member(r => r.OrderingId)
-                        .HasColumnName(tagColumns.OrderingId)
-                        .HasDbType("INTEGER")
-                        .IsColumn()
-                        .IsNullable(false)
-                        .IsPrimaryKey();
-
-                    rowBuilder
-                        .Member(r => r.SequenceNumber)
-                        .HasColumnName(tagColumns.SequenceNumber)
-                        .HasDbType("INTEGER")
-                        .IsColumn()
-                        .IsNullable(false);
-                }
-                else
-                {
-                    rowBuilder
-                        .Member(r => r.OrderingId)
-                        .HasColumnName(tagColumns.OrderingId)
-                        .IsColumn()
-                        .IsNullable(false)
-                        .IsPrimaryKey();
-
-                    rowBuilder
-                        .Member(r => r.SequenceNumber)
-                        .HasColumnName(tagColumns.SequenceNumber)
-                        .IsColumn()
-                        .IsNullable(false);
-                }
-            }
-
+        private static void MapMetadataRow(
+            IProviderConfig<JournalTableConfig> config,
+            FluentMappingBuilder fmb)
+        {
+            if (!config.IDaoConfig.SqlCommonCompatibilityMode)
+                return;
+            
             // Probably overkill, but we only set Metadata Mapping if specified
             // That we are in delete compatibility mode.
-            if (config.IDaoConfig.SqlCommonCompatibilityMode)
+            var tableConfig = config.TableConfig;
+            var rowBuilder = fmb.Entity<JournalMetaData>();
+            if (tableConfig.SchemaName is { })
+                rowBuilder.HasSchemaName(tableConfig.SchemaName);
+            
+            rowBuilder
+                .HasTableName(tableConfig.MetadataTable.Name)
+                
+                .Member(r => r.PersistenceId)
+                .HasColumnName(tableConfig.MetadataTable.ColumnNames.PersistenceId)
+                .HasLength(255)
+                .IsPrimaryKey()
+                
+                .Member(r => r.SequenceNumber)
+                .HasColumnName(tableConfig.MetadataTable.ColumnNames.SequenceNumber)
+                .IsPrimaryKey();
+        }
+
+        private static void MapTagRow(
+            IProviderConfig<JournalTableConfig> config,
+            FluentMappingBuilder fmb)
+        {
+            if (config.PluginConfig.TagMode is TagMode.Csv)
+                return;
+
+            var tableConfig = config.TableConfig;
+            var tagConfig = tableConfig.TagTable;
+            var tagColumns = tagConfig.ColumnNames;
+
+            var rowBuilder = fmb.Entity<JournalTagRow>();
+            if (tableConfig.SchemaName is { })
+                rowBuilder.HasSchemaName(tableConfig.SchemaName);
+
+            rowBuilder
+                .HasTableName(tagConfig.Name)
+                
+                .Member(r => r.OrderingId)
+                .HasColumnName(tagColumns.OrderingId)
+                .IsNullable(false)
+                .IsPrimaryKey()
+                
+                .Member(r => r.TagValue)
+                .HasColumnName(tagColumns.Tag)
+                .IsNullable(false)
+                .HasLength(64)
+                .IsPrimaryKey()
+                
+                .Member(r => r.PersistenceId)
+                .HasColumnName(tagColumns.PersistenceId)
+                .IsNullable(false)
+                
+                .Member(r => r.SequenceNumber)
+                .HasColumnName(tagColumns.SequenceNumber)
+                .IsNullable(false);
+            
+            if (config.ProviderName.ToLower().Contains("sqlite"))
             {
-                var rowBuilder = fmb.Entity<JournalMetaData>();
-                if (tableConfig.SchemaName is { })
-                    rowBuilder.HasSchemaName(tableConfig.SchemaName);
-
                 rowBuilder
-                    .HasTableName(tableConfig.MetadataTable.Name)
-
-                    .Member(r => r.PersistenceId)
-                    .HasColumnName(tableConfig.MetadataTable.ColumnNames.PersistenceId)
-                    .HasLength(255)
-
+                    .Member(r => r.OrderingId)
+                    .HasDbType("INTEGER")
+                    
                     .Member(r => r.SequenceNumber)
-                    .HasColumnName(tableConfig.MetadataTable.ColumnNames.SequenceNumber);
+                    .HasDbType("INTEGER");
             }
         }
 

--- a/src/Akka.Persistence.Sql/Db/FooterGenerator.cs
+++ b/src/Akka.Persistence.Sql/Db/FooterGenerator.cs
@@ -1,0 +1,251 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="FooterGenerator.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Persistence.Sql.Config;
+using LinqToDB;
+
+#nullable enable
+namespace Akka.Persistence.Sql.Db
+{
+    public static class FooterGenerator
+    {
+        public static string? GenerateJournalFooter(this JournalConfig config)
+        {
+            var tableName = config.TableConfig.EventJournalTable.Name;
+            var columns = config.TableConfig.EventJournalTable.ColumnNames;
+            var journalFullTableName = string.IsNullOrEmpty(config.TableConfig.SchemaName) 
+                ? tableName : $"{config.TableConfig.SchemaName}.{tableName}";
+			
+            #region SqlServer
+            if (config.ProviderName.StartsWith(ProviderName.SqlServer))
+                return @$";
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE
+        object_id = OBJECT_ID('{journalFullTableName}') AND
+        name = 'UQ_{tableName}'
+)
+ALTER TABLE {journalFullTableName} ADD CONSTRAINT UQ_{tableName} UNIQUE ({columns.PersistenceId}, {columns.SequenceNumber});
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE
+        object_id = OBJECT_ID('{journalFullTableName}') AND
+        name = 'IX_{tableName}_{columns.SequenceNumber}'
+)
+CREATE INDEX IX_{tableName}_{columns.SequenceNumber} ON {journalFullTableName}({columns.SequenceNumber});
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE 
+        object_id = OBJECT_ID('{journalFullTableName}') AND
+        name = 'IX_{tableName}_{columns.Created}'
+)
+CREATE INDEX IX_{tableName}_{columns.Created} ON {journalFullTableName}({columns.Created});";
+            #endregion
+			
+            #region MySql
+            if (config.ProviderName.StartsWith(ProviderName.MySql))
+                return $@";
+DROP PROCEDURE IF EXISTS AKKA_Journal_Setup;
+
+DELIMITER ??
+CREATE PROCEDURE AKKA_Journal_Setup()
+BEGIN
+	DECLARE UniqueExists TINYINT UNSIGNED DEFAULT 0;
+	DECLARE CreatedIndexExists TINYINT UNSIGNED DEFAULT 0;
+	DECLARE SequenceIndexExists TINYINT UNSIGNED DEFAULT 0;
+
+	SELECT 1 INTO UniqueExists
+	FROM information_schema.TABLE_CONSTRAINTS
+	WHERE
+        CONSTRAINT_SCHEMA = DATABASE() AND
+        TABLE_NAME = '{tableName}' AND
+        CONSTRAINT_NAME   = '{columns.PersistenceId}' AND
+        CONSTRAINT_TYPE   = 'UNIQUE';
+
+	SELECT 1 INTO CreatedIndexExists
+	FROM information_schema.INNODB_INDEXES
+	WHERE NAME = '{tableName}_{columns.Created}_idx';
+
+	SELECT 1 INTO SequenceIndexExists
+	FROM information_schema.INNODB_INDEXES
+	WHERE NAME = '{tableName}_{columns.SequenceNumber}_idx';
+
+	IF (UniqueExists = 0) THEN
+		ALTER TABLE {journalFullTableName} ADD UNIQUE ({columns.PersistenceId}, {columns.SequenceNumber});
+	END IF;
+
+	IF (CreatedIndexExists = 0) THEN
+		CREATE INDEX {tableName}_{columns.Created}_idx ON {journalFullTableName} ({columns.Created});
+	END IF;
+
+	IF (SequenceIndexExists = 0) THEN
+		CREATE INDEX {tableName}_{columns.SequenceNumber}_idx ON {journalFullTableName} ({columns.SequenceNumber});
+	END IF;
+END??
+DELIMITER ;
+
+CALL AKKA_Journal_Setup();
+
+DROP PROCEDURE IF EXISTS AKKA_Journal_Setup;";
+            #endregion
+			
+            #region PostgreSql
+            // These SQL syntax should be supported from PostgreSql 9.0
+            if (config.ProviderName.StartsWith(ProviderName.PostgreSQL))
+            {
+	            journalFullTableName = string.IsNullOrEmpty(config.TableConfig.SchemaName) 
+		            ? tableName : $"\"{config.TableConfig.SchemaName}\".\"{tableName}\"";
+	            
+	            return $@";
+do $BLOCK$
+begin
+	begin
+		alter table {journalFullTableName} add constraint {tableName}_uq unique ({columns.PersistenceId}, {columns.SequenceNumber});
+	exception
+		when duplicate_table
+		then raise notice 'unique constraint ""{tableName}_uq"" on {journalFullTableName} already exists, skipping';
+	end;
+
+	begin
+		create index {tableName}_{columns.PersistenceId}_idx on {journalFullTableName} ({columns.PersistenceId});
+	exception
+		when duplicate_table
+		then raise notice 'index ""{tableName}_{columns.PersistenceId}_idx"" on {journalFullTableName} already exists, skipping';
+	end;
+
+	begin
+		create index {tableName}_{columns.SequenceNumber}_idx on {journalFullTableName} ({columns.SequenceNumber});
+	exception
+		when duplicate_table
+		then raise notice 'index ""{tableName}_{columns.SequenceNumber}_idx"" on {journalFullTableName} already exists, skipping';
+	end;
+end;
+$BLOCK$
+";
+            }
+            #endregion
+			
+            #region Sqlite
+            if (config.ProviderName.StartsWith(ProviderName.SQLite))
+	            return $@";
+CREATE UNIQUE INDEX IF NOT EXISTS {tableName}_uq ON {journalFullTableName} ({columns.PersistenceId}, {columns.SequenceNumber});
+CREATE INDEX IF NOT EXISTS {tableName}_{columns.PersistenceId}_idx ON {journalFullTableName} ({columns.PersistenceId});
+CREATE INDEX IF NOT EXISTS {tableName}_{columns.SequenceNumber}_idx ON {journalFullTableName} ({columns.SequenceNumber});";
+            #endregion
+			
+            return null;
+        }
+
+        public static string? GenerateTagFooter(this JournalConfig config)
+        {
+	        var tableName = config.TableConfig.TagTable.Name;
+	        var columns = config.TableConfig.TagTable.ColumnNames;
+	        var tagFullTableName = string.IsNullOrEmpty(config.TableConfig.SchemaName)
+		        ? tableName : $"{config.TableConfig.SchemaName}.{tableName}";
+			
+	        #region SqlServer
+	        if (config.ProviderName.StartsWith(ProviderName.SqlServer))
+		        return $@";
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE 
+        object_id = OBJECT_ID('{tagFullTableName}') AND
+        name = 'IX_{tableName}_{columns.PersistenceId}_{columns.SequenceNumber}'
+)
+CREATE INDEX IX_{tableName}_{columns.PersistenceId}_{columns.SequenceNumber} ON {tagFullTableName} ({columns.PersistenceId}, {columns.SequenceNumber});
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE 
+        object_id = OBJECT_ID('{tagFullTableName}') AND
+        name = 'IX_{tableName}_{columns.Tag}'
+)
+CREATE INDEX IX_{tableName}_{columns.Tag} ON {tagFullTableName} ({columns.Tag});
+";
+	        #endregion
+			
+	        #region MySql
+	        if (config.ProviderName.StartsWith(ProviderName.MySql))
+		        return $@";
+DROP PROCEDURE IF EXISTS AKKA_Tag_Setup;
+
+DELIMITER ??
+CREATE PROCEDURE AKKA_Tag_Setup()
+BEGIN
+	DECLARE DeleteIndexExists TINYINT UNSIGNED DEFAULT 0;
+	DECLARE TagIndexExists TINYINT UNSIGNED DEFAULT 0;
+
+	SELECT 1 INTO DeleteIndexExists
+	FROM information_schema.INNODB_INDEXES
+	WHERE NAME = '{tableName}_{columns.PersistenceId}_{columns.SequenceNumber}_idx';
+
+	SELECT 1 INTO TagIndexExists
+	FROM information_schema.INNODB_INDEXES
+	WHERE NAME = '{tableName}_{columns.Tag}_idx';
+
+	IF (DeleteIndexExists = 0) THEN
+		CREATE INDEX {tableName}_{columns.PersistenceId}_{columns.SequenceNumber}_idx ON {tagFullTableName} ({columns.PersistenceId}, {columns.SequenceNumber});
+	END IF;
+
+	IF (TagIndexExists = 0) THEN
+		CREATE INDEX {tableName}_{columns.Tag}_idx ON {tagFullTableName} ({columns.Tag});
+	END IF;
+END??
+DELIMITER ;
+
+CALL AKKA_Journal_Setup();
+
+DROP PROCEDURE IF EXISTS AKKA_Tag_Setup;";
+	        #endregion
+			
+	        #region PostgreSql
+	        // These SQL syntax should be supported from PostgreSql 9.0
+	        if (config.ProviderName.StartsWith(ProviderName.PostgreSQL))
+	        {
+		        tagFullTableName = string.IsNullOrEmpty(config.TableConfig.SchemaName) 
+			        ? tableName : $"\"{config.TableConfig.SchemaName}\".\"{tableName}\"";
+	            
+		        return $@";
+do $BLOCK$
+begin
+	begin
+		create index {tableName}_{columns.PersistenceId}_{columns.SequenceNumber}_idx on {tagFullTableName} ({columns.PersistenceId}, {columns.SequenceNumber});
+	exception
+		when duplicate_table
+		then raise notice 'index ""{tableName}_{columns.PersistenceId}_{columns.SequenceNumber}_idx"" on {tagFullTableName} already exists, skipping';
+	end;
+
+	begin
+		create index {tableName}_{columns.Tag}_idx on {tagFullTableName} ({columns.Tag});
+	exception
+		when duplicate_table
+		then raise notice 'index ""{tableName}_{columns.Tag}_idx"" on {tagFullTableName} already exists, skipping';
+	end;
+end;
+$BLOCK$
+";
+	        }
+	        #endregion
+			
+	        #region Sqlite
+	        if (config.ProviderName.StartsWith(ProviderName.SQLite))
+		        return $@";
+CREATE INDEX IF NOT EXISTS {tableName}_{columns.PersistenceId}_{columns.SequenceNumber}_idx ON {tagFullTableName} ({columns.PersistenceId}, {columns.SequenceNumber});
+CREATE INDEX IF NOT EXISTS {tableName}_{columns.Tag}_idx ON {tagFullTableName} ({columns.Tag});";
+	        #endregion
+	        
+	        return null;
+        }
+    }
+}


### PR DESCRIPTION
## Changes

* Change table creation to match old Sql persistence tables
  * Change journal table primary key from composite (persistence_id, sequence_nr) to ordering
  * Add custom unique (persistence_id, sequence_nr) constraint on journal table
  * Add custom persistence_id index to journal table
  * Add custom sequence_nr index to journal table

* Change tag table primary key to composite (ordering, tag)
* Add custom (persistence_id, sequence_nr) index to tag table (used for deletion)
* Add custom tag index on tag table (used for tag query lookup)

### Latest `dev` Benchmarks 

Tested on 3 million events database with 10 tagged events at the end of the table.

failed

### This PR's Benchmarks

Tested on 3 million events database with 10 tagged events at the end of the table.

|     Method |  TagMode |         Mean |      Error |     StdDev |    Gen0 | Allocated |
|----------- |--------- |-------------:|-----------:|-----------:|--------:|----------:|
| QueryByTag |      Csv | 1,745.617 ms | 27.1483 ms | 24.0662 ms |       - | 398.95 KB |
| QueryByTag | TagTable |     3.000 ms |  0.0589 ms |  0.0917 ms | 35.1563 | 301.36 KB |

Note that there are sone Gen0 allocation with tag table because we need to perform the query in 2 steps, the join and then retrieving the tags.

| Test            | SqlServer | SqlServer</br>Batching | Old</br>Indexing | vs Normal | vs Batching | New</br>Indexing |  vs Old |
|:----------------|----------:|-------------------:|-------------:|----------:|------------:|-------------:|--------:|
| Persist         |       304 |                299 |          496 |   163.16% |     165.89% |          477 |  96.17% |
| PersistAll      |      1139 |               1275 |         7893 |   692.98% |     619.06% |         7196 |  91.17% |
| PersistAsync    |      1021 |               1371 |        31813 |  3115.87% |    2320.42% |        26956 |  84.73% |
| PersistAllAsync |      2828 |               1395 |        29634 |  1047.88% |    2124.30% |        27819 |  93.88% |
| PersistGroup10  |       986 |               1034 |         1675 |   169.88% |     161.99% |         1779 | 106.21% |
| PersistGroup25  |      1034 |               1010 |         3054 |   295.36% |     302.38% |         3201 | 104.81% |
| PersistGroup50  |       971 |                980 |         4932 |   507.93% |     503.27% |         5021 | 101.80% |
| PersistGroup100 |      1054 |               1304 |         6249 |   592.88% |     479.22% |         6965 | 111.46% |
| PersistGroup200 |       990 |               1662 |         8086 |   816.77% |     486.52% |         9100 | 112.54% |
| PersistGroup400 |      1049 |               2113 |         7237 |   689.59% |     342.50% |         9224 | 127.46% |
| Recovering      |     60516 |              77688 |        64457 |   106.51% |      82.96% |        62538 |  97.02% |
| RecoveringTwo   |     60730 |              53062 |        43325 |    71.34% |      81.65% |        68427 | 157.94% |
| RecoveringFour  |     86107 |              73218 |        66512 |    77.24% |      90.84% |       108357 | 162.91% |
| Recovering8     |    116401 |             101549 |       103463 |    88.89% |     101.88% |       130808 | 126.43% |

Note that, while there's a write penalty due to extra indices, write and read performance actually improves with parallelization
