### PR TITLE
Update benchmark to cover more scenarios

### DIFF
--- a/src/Akka.Persistence.Sql.Benchmarks/Const.cs
+++ b/src/Akka.Persistence.Sql.Benchmarks/Const.cs
@@ -10,6 +10,13 @@ namespace Akka.Persistence.Sql.Benchmarks
     {
         public const int TotalMessages = 3000000;
         public const int TagLowerBound = 2 * (TotalMessages / 3);
-        public const int TagUpperBound = TagLowerBound + 10;
+        public const string Tag10 = "Tag1";
+        public const string Tag100 = "Tag2";
+        public const string Tag1000 = "Tag3";
+        public const string Tag10000 = "Tag4";
+        public const int Tag10UpperBound = TagLowerBound + 10;
+        public const int Tag100UpperBound = TagLowerBound + 100;
+        public const int Tag1000UpperBound = TagLowerBound + 1000;
+        public const int Tag10000UpperBound = TagLowerBound + 10000;
     }
 }

--- a/src/Akka.Persistence.Sql.Benchmarks/EventTagger.cs
+++ b/src/Akka.Persistence.Sql.Benchmarks/EventTagger.cs
@@ -4,6 +4,7 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
+using System.Collections.Generic;
 using Akka.Persistence.Journal;
 
 namespace Akka.Persistence.Sql.Benchmarks
@@ -14,10 +15,18 @@ namespace Akka.Persistence.Sql.Benchmarks
 
         public object ToJournal(object evt)
         {
-            if (evt is not int i || i is <= Const.TagLowerBound or > Const.TagUpperBound)
+            if (evt is not int i)
                 return evt;
 
-            return new Tagged(i, new[] { "TAG" });
+            return i switch
+            {
+                <= Const.TagLowerBound => evt,
+                <= Const.Tag10UpperBound => new Tagged(evt, new[] { Const.Tag10, Const.Tag100, Const.Tag1000, Const.Tag10000 }),
+                <= Const.Tag100UpperBound => new Tagged(evt, new[] { Const.Tag100, Const.Tag1000, Const.Tag10000 }),
+                <= Const.Tag1000UpperBound => new Tagged(evt, new[] { Const.Tag1000, Const.Tag10000 }),
+                <= Const.Tag10000UpperBound => new Tagged(evt, new[] { Const.Tag10000 }),
+                _ => evt
+            };
         }
     }
 }

--- a/src/Akka.Persistence.Sql.Benchmarks/InitializeDbActor.cs
+++ b/src/Akka.Persistence.Sql.Benchmarks/InitializeDbActor.cs
@@ -42,7 +42,7 @@ namespace Akka.Persistence.Sql.Benchmarks
             var pending = -1;
             
             var messages = Enumerable.Range(1, Const.TotalMessages)
-                .Chunk(100000)
+                .Chunk(10000)
                 .ToList();
             
             Command<Initialize>(_ =>

--- a/src/Akka.Persistence.Sql.Benchmarks/SqlServer/SqlServerCsvTagBenchmark.cs
+++ b/src/Akka.Persistence.Sql.Benchmarks/SqlServer/SqlServerCsvTagBenchmark.cs
@@ -78,15 +78,51 @@ akka.persistence.query.journal.sql {{
         }
 
         [Benchmark]
-        public async Task QueryByTag()
+        public async Task QueryByTag10()
         {
             var events = new List<EventEnvelope>();
-            var source = ((ICurrentEventsByTagQuery)_readJournal!).CurrentEventsByTag("TAG", NoOffset.Instance);
+            var source = ((ICurrentEventsByTagQuery)_readJournal!).CurrentEventsByTag(Const.Tag10, NoOffset.Instance);
             await source.RunForeach(msg =>
             {
                 events.Add(msg);
             }, _materializer);
             events.Select(e => e.SequenceNr).Should().BeEquivalentTo(Enumerable.Range(2000001, 10));
+        }
+
+        [Benchmark]
+        public async Task QueryByTag100()
+        {
+            var events = new List<EventEnvelope>();
+            var source = ((ICurrentEventsByTagQuery)_readJournal!).CurrentEventsByTag(Const.Tag100, NoOffset.Instance);
+            await source.RunForeach(msg =>
+            {
+                events.Add(msg);
+            }, _materializer);
+            events.Select(e => e.SequenceNr).Should().BeEquivalentTo(Enumerable.Range(2000001, 100));
+        }
+
+        [Benchmark]
+        public async Task QueryByTag1000()
+        {
+            var events = new List<EventEnvelope>();
+            var source = ((ICurrentEventsByTagQuery)_readJournal!).CurrentEventsByTag(Const.Tag1000, NoOffset.Instance);
+            await source.RunForeach(msg =>
+            {
+                events.Add(msg);
+            }, _materializer);
+            events.Select(e => e.SequenceNr).Should().BeEquivalentTo(Enumerable.Range(2000001, 1000));
+        }
+
+        [Benchmark]
+        public async Task QueryByTag10000()
+        {
+            var events = new List<EventEnvelope>();
+            var source = ((ICurrentEventsByTagQuery)_readJournal!).CurrentEventsByTag(Const.Tag10000, NoOffset.Instance);
+            await source.RunForeach(msg =>
+            {
+                events.Add(msg);
+            }, _materializer);
+            events.Select(e => e.SequenceNr).Should().BeEquivalentTo(Enumerable.Range(2000001, 10000));
         }
     }
 }


### PR DESCRIPTION
Add several other scenarios for the tag benchmark.

### Result
BenchmarkDotNet=v0.13.5, OS=Windows 10 (10.0.19045.2728/22H2/2022Update)
AMD Ryzen 9 3900X, 1 CPU, 24 logical and 12 physical cores
.NET SDK=7.0.104
  [Host]     : .NET 7.0.4 (7.0.423.11508), X64 RyuJIT AVX2
  DefaultJob : .NET 7.0.4 (7.0.423.11508), X64 RyuJIT AVX2

|      Tag Count |  TagMode |         Mean |      Error |     StdDev |       Gen0 |      Gen1 |    Allocated |
|---------------- |--------- |-------------:|-----------:|-----------:|-----------:|----------:|-------------:|
|    10 |      Csv | 1,746.621 ms | 27.8946 ms | 29.8469 ms |          - |         - |    454.91 KB |
|   100 |      Csv | 1,724.465 ms | 25.4638 ms | 23.8189 ms |          - |         - |   1371.23 KB |
|  1000 |      Csv | 1,723.063 ms | 26.2311 ms | 24.5366 ms |  1000.0000 |         - |  10678.81 KB |
| 10000 |      Csv | 1,873.467 ms | 26.1173 ms | 23.1523 ms | 12000.0000 | 3000.0000 | 103184.85 KB |
|    10 | TagTable |     3.201 ms |  0.0633 ms |  0.1479 ms |    42.9688 |    3.9063 |    360.76 KB |
|   100 | TagTable |     5.163 ms |  0.1018 ms |  0.1358 ms |   164.0625 |   23.4375 |   1358.97 KB |
|  1000 | TagTable |    25.545 ms |  0.4952 ms |  0.4864 ms |  1375.0000 |  687.5000 |  11250.52 KB |
| 10000 | TagTable |   441.877 ms |  3.5410 ms |  2.9569 ms | 13000.0000 | 3000.0000 | 108664.53 KB |

It looks like memory allocation is something we need to look at in the near future