### PR TITLE
Optimize SequenceNumber and Tag queries

### DIFF
--- a/src/Akka.Persistence.Sql/Journal/Types/JournalTagRow.cs
+++ b/src/Akka.Persistence.Sql/Journal/Types/JournalTagRow.cs
@@ -6,14 +6,17 @@
 
 namespace Akka.Persistence.Sql.Journal.Types
 {
-    public sealed class JournalTagRow
+    public class TagRow
+    {
+        public long OrderingId { get; set; }
+
+        public string TagValue { get; set; }
+    }
+    
+    public sealed class JournalTagRow: TagRow
     {
         public long SequenceNumber { get; set; }
 
         public string PersistenceId { get; set; }
-
-        public long OrderingId { get; set; }
-
-        public string TagValue { get; set; }
     }
 }


### PR DESCRIPTION
## Changes

* Change highest sequence number query to use `.MaxAsync()` to leverage indexed column
* Change tag query to retrieve only the ordering and tag column