### PR TITLE
Optimize tag query by avoiding multi-query

### DIFF
--- a/src/Akka.Persistence.Sql/Query/Dao/BaseByteReadArrayJournalDao.cs
+++ b/src/Akka.Persistence.Sql/Query/Dao/BaseByteReadArrayJournalDao.cs
@@ -21,9 +21,6 @@ using Akka.Streams;
 using Akka.Streams.Dsl;
 using Akka.Util;
 using LinqToDB;
-using LinqToDB.Data;
-using LinqToDB.Tools;
-using TaskExtensions = LanguageExt.TaskExtensions;
 
 namespace Akka.Persistence.Sql.Query.Dao
 {
@@ -118,11 +115,7 @@ namespace Akka.Persistence.Sql.Query.Dao
                                 orderby r.Ordering
                                 select r;
 
-                            var mainRows = await query.ToListAsync();
-
-                            await AddTagDataFromTagTable(mainRows, connection);
-
-                            return mainRows;
+                            return await AddTagDataFromTagTable(query, connection);
                         })
                     .Via(_deserializeFlow),
 
@@ -141,7 +134,7 @@ namespace Akka.Persistence.Sql.Query.Dao
                     new { connection, persistenceId, fromSequenceNr, toSequenceNr, toTake = MaxTake(max) },
                     async state =>
                     {
-                        var mainRows = await connection
+                        var query = connection
                             .GetTable<JournalRow>()
                             .Where(r =>
                                 r.PersistenceId == state.persistenceId &&
@@ -149,13 +142,9 @@ namespace Akka.Persistence.Sql.Query.Dao
                                 r.SequenceNumber <= state.toSequenceNr &&
                                 r.Deleted == false)
                             .OrderBy(r => r.SequenceNumber)
-                            .Take(state.toTake)
-                            .ToListAsync();
+                            .Take(state.toTake);
 
-                        if (_readJournalConfig.PluginConfig.TagMode == TagMode.TagTable)
-                            await AddTagDataFromTagTable(mainRows, connection);
-
-                        return mainRows;
+                        return await AddTagDataIfNeeded(query, connection);
                     })
                 .Via(_deserializeFlow)
                 .Select(
@@ -223,51 +212,51 @@ namespace Akka.Persistence.Sql.Query.Dao
                 {
                     await using var connection = input._connectionFactory.GetConnection();
 
-                    var events = await connection
+                    var query = connection
                         .GetTable<JournalRow>()
                         .Where(r =>
                             r.Ordering > input.offset &&
                             r.Ordering <= input.maxOffset &&
                             r.Deleted == false)
                         .OrderBy(r => r.Ordering)
-                        .Take(input.maxTake)
-                        .ToListAsync();
+                        .Take(input.maxTake);
 
-                    return await AddTagDataIfNeeded(events, connection);
+                    return await AddTagDataIfNeeded(query, connection);
                 }
             ).Via(_deserializeFlow);
         }
 
-        private async Task<List<JournalRow>> AddTagDataIfNeeded(List<JournalRow> toAdd, AkkaDataConnection connection)
+        private async Task<List<JournalRow>> AddTagDataIfNeeded(IQueryable<JournalRow> rowQuery, AkkaDataConnection connection)
         {
-            if (_readJournalConfig.PluginConfig.TagMode == TagMode.TagTable)
-                await AddTagDataFromTagTable(toAdd, connection);
-
-            return toAdd;
+            if (_readJournalConfig.PluginConfig.TagMode != TagMode.TagTable)
+                return await rowQuery.ToListAsync();
+            
+            return await AddTagDataFromTagTable(rowQuery, connection);
         }
 
-        private static async Task AddTagDataFromTagTable(List<JournalRow> toAdd, AkkaDataConnection connection)
+        private static async Task<List<JournalRow>> AddTagDataFromTagTable(IQueryable<JournalRow> rowQuery, AkkaDataConnection connection)
         {
-            if (toAdd.Count == 0)
-                return;
-
-            var tagRows = await connection
-                .GetTable<JournalTagRow>()
-                .Where(r => r.OrderingId.In(toAdd.Select(row => row.Ordering).Distinct()))
-                .Select(r => new TagRow
+            var tagTable = connection.GetTable<JournalTagRow>();
+            var q =
+                from jr in rowQuery
+                select new
                 {
-                    OrderingId = r.OrderingId,
-                    TagValue = r.TagValue
-                })
-                .ToListAsync();
+                    row = jr, 
+                    tags = tagTable
+                    .Where(r => r.OrderingId == jr.Ordering)
+                    .StringAggregate(";", r => r.TagValue)
+                    .ToValue()
+                };
 
-            foreach (var journalRow in toAdd)
+            var res = await q.ToListAsync();
+
+            var result = new List<JournalRow>();
+            foreach (var row in res)
             {
-                journalRow.TagArr = tagRows
-                    .Where(r => r.OrderingId == journalRow.Ordering)
-                    .Select(r => r.TagValue)
-                    .ToArray();
+                row.row.TagArr = row.tags.Split(';');
+                result.Add(row.row);
             }
+            return result;
         }
     }
 }

--- a/src/Akka.Persistence.Sql/Query/Dao/BaseByteReadArrayJournalDao.cs
+++ b/src/Akka.Persistence.Sql/Query/Dao/BaseByteReadArrayJournalDao.cs
@@ -253,7 +253,7 @@ namespace Akka.Persistence.Sql.Query.Dao
             var result = new List<JournalRow>();
             foreach (var row in res)
             {
-                row.row.TagArr = row.tags.Split(';');
+                row.row.TagArr = row.tags?.Split(';') ?? Array.Empty<string>();
                 result.Add(row.row);
             }
             return result;


### PR DESCRIPTION
## Changes

Use SQL built-in aggregate string to retrieve journal row and tags in 1 go

### Latest `dev` Benchmarks 

| Tag Count |  TagMode |         Mean |      Error |     StdDev |       Gen0 |      Gen1 |    Allocated |
|---------------- |--------- |-------------:|-----------:|-----------:|-----------:|----------:|-------------:|
|    10 |      Csv | 1,712.480 ms | 22.7837 ms | 21.3119 ms |          - |         - |    390.94 KB |
|   100 |      Csv | 1,720.164 ms | 21.3537 ms | 19.9743 ms |          - |         - |   1368.78 KB |
|  1000 |      Csv | 1,763.240 ms | 30.8206 ms | 28.8296 ms |  1000.0000 |         - |  10675.73 KB |
| 10000 |      Csv | 1,887.153 ms | 35.8259 ms | 35.1858 ms | 12000.0000 | 3000.0000 | 103176.36 KB |
|    10 | TagTable |     3.262 ms |  0.0645 ms |  0.1096 ms |    42.9688 |    3.9063 |    355.72 KB |
|   100 | TagTable |     4.935 ms |  0.0969 ms |  0.1420 ms |   156.2500 |   31.2500 |   1307.93 KB |
|  1000 | TagTable |    24.775 ms |  0.4383 ms |  0.3885 ms |  1312.5000 |  656.2500 |  10923.02 KB |
| 10000 | TagTable |   418.739 ms |  5.3480 ms |  5.0025 ms | 12000.0000 | 3000.0000 | 106984.68 KB |

### This PR's Benchmarks

| Tag Count |  TagMode |         Mean |      Error |     StdDev |       Gen0 |      Gen1 |      Gen2 |    Allocated |
|---------------- |--------- |-------------:|-----------:|-----------:|-----------:|----------:|----------:|-------------:|
|    10 |      Csv | 1,760.393 ms | 27.1970 ms | 25.4401 ms |          - |         - |         - |    449.35 KB |
|   100 |      Csv | 1,766.355 ms | 25.0182 ms | 23.4021 ms |          - |         - |         - |   1368.33 KB |
|  1000 |      Csv | 1,755.960 ms | 33.8171 ms | 34.7276 ms |  1000.0000 |         - |         - |  10733.67 KB |
| 10000 |      Csv | 1,905.026 ms | 22.3564 ms | 20.9122 ms | 12000.0000 | 3000.0000 |         - |  103175.1 KB |
|    10 | TagTable |     2.336 ms |  0.0389 ms |  0.0344 ms |    39.0625 |    3.9063 |         - |    341.51 KB |
|   100 | TagTable |     3.943 ms |  0.0705 ms |  0.0660 ms |   148.4375 |   31.2500 |         - |   1262.26 KB |
|  1000 | TagTable |    18.597 ms |  0.3570 ms |  0.3506 ms |  1281.2500 |  718.7500 |         - |  10481.17 KB |
| 10000 | TagTable |   184.446 ms |  3.3447 ms |  2.9650 ms | 14000.0000 | 3666.6667 | 1666.6667 | 103154.93 KB |
