### PR TITLE
docs: typo in Concurrent

### DIFF
--- a/README.md
+++ b/README.md
@@ -716,7 +716,7 @@ akka.persistence {
         #     table to improve tag related query speed.
         tag-read-mode = TagTable
 
-        journal-sequence-retrieval{
+        journal-sequence-retrieval {
           batch-size = 10000
           max-tries = 10
           query-delay = 1s

--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ akka.persistence {
       # As well as limit memory usage on journal retrieval in CLR
       replay-batch-size = 1000
 
-      # Number of Concurrennt writers.
+      # Number of Concurrent writers.
       # On larger servers with more cores you can increase this number
       # But in most cases 2-4 is a safe bet.
       parallelism = 3
@@ -755,7 +755,7 @@ akka.persistence {
         # As well as limit memory usage on journal retrieval in CLR
         replay-batch-size = 1000
 
-        # Number of Concurrennt writers.
+        # Number of Concurrent writers.
         # On larger servers with more cores you can increase this number
         # But in most cases 2-4 is a safe bet.
         parallelism = 3


### PR DESCRIPTION
Fixing a small typo