### PR TITLE
refactor: cleanup naming, apply resharper hints

### DIFF
--- a/src/Akka.Persistence.Sql.Benchmarks/SqlServer/SqlServerCsvTagBenchmark.cs
+++ b/src/Akka.Persistence.Sql.Benchmarks/SqlServer/SqlServerCsvTagBenchmark.cs
@@ -73,7 +73,7 @@ akka.persistence.query.journal.sql {{
         [GlobalCleanup]
         public async Task Cleanup()
         {
-            if (_sys is { })
+            if (_sys is not null)
                 await _sys.Terminate();
         }
 

--- a/src/Akka.Persistence.Sql.Data.Compatibility.Tests/DataCompatibilitySpecBase.cs
+++ b/src/Akka.Persistence.Sql.Data.Compatibility.Tests/DataCompatibilitySpecBase.cs
@@ -64,7 +64,7 @@ namespace Akka.Persistence.Sql.Data.Compatibility.Tests
 
         public async Task DisposeAsync()
         {
-            if (TestCluster is { })
+            if (TestCluster is not null)
                 await TestCluster.DisposeAsync();
 
             await Fixture.DisposeAsync();
@@ -92,7 +92,7 @@ akka.persistence {{
             batch-size = 3
             db-round-trip-max-batch-size = 6
             replay-batch-size = 6
-{(Settings.SchemaName is { } ? @$"
+{(Settings.SchemaName is not null ? @$"
             {Settings.TableMapping} {{
                 schema-name = {Settings.SchemaName}
             }}" : string.Empty)}
@@ -128,7 +128,7 @@ akka.persistence {{
             read-isolation-level = {Settings.ReadIsolationLevel.ToHocon()}
             write-isolation-level = {Settings.WriteIsolationLevel.ToHocon()}
 
-{(Settings.SchemaName is { } ? @$"
+{(Settings.SchemaName is not null ? @$"
             {Settings.TableMapping} {{
                 schema-name = {Settings.SchemaName}
             }}" : string.Empty)}
@@ -159,7 +159,7 @@ akka.persistence {{
             foreach (var id in Enumerable.Range(0, 100))
             {
                 var (_, lastSnapshot) = await region.Ask<(string, StateSnapshot?)>(new Truncate(id), cts.Token);
-                if (lastSnapshot is { })
+                if (lastSnapshot is not null)
                 {
                     Output.WriteLine(
                         $"{id} data truncated. " +

--- a/src/Akka.Persistence.Sql.Data.Compatibility.Tests/Internal/DockerContainer.cs
+++ b/src/Akka.Persistence.Sql.Data.Compatibility.Tests/Internal/DockerContainer.cs
@@ -115,7 +115,7 @@ namespace Akka.Persistence.Sql.Data.Compatibility.Tests.Internal
             _readDockerTask = ReadDockerStreamAsync();
 
             // Wait until container is completely ready
-            if (ReadyMarker is { })
+            if (ReadyMarker is not null)
             {
                 await AwaitUntilReadyAsync(ReadyMarker, ReadyTimeout);
             }
@@ -211,10 +211,10 @@ namespace Akka.Persistence.Sql.Data.Compatibility.Tests.Internal
             _logsCts.Cancel();
             _logsCts.Dispose();
 
-            if (_readDockerTask is { })
+            if (_readDockerTask is not null)
                 await _readDockerTask;
 
-            if (_stream is { })
+            if (_stream is not null)
                 await _stream.DisposeAsync();
 
             try

--- a/src/Akka.Persistence.Sql.Data.Compatibility.Tests/MigratorCompatibilitySpec.cs
+++ b/src/Akka.Persistence.Sql.Data.Compatibility.Tests/MigratorCompatibilitySpec.cs
@@ -33,8 +33,9 @@ akka.persistence.query.journal.sql.tag-read-mode = TagTable";
             }
             catch
             {
-                if (TestCluster is { })
+                if (TestCluster is not null)
                     await TestCluster.DisposeAsync();
+
                 await Fixture.DisposeAsync();
                 throw;
             }

--- a/src/Akka.Persistence.Sql.Hosting/HostingExtensions.cs
+++ b/src/Akka.Persistence.Sql.Hosting/HostingExtensions.cs
@@ -140,7 +140,7 @@ namespace Akka.Persistence.Sql.Hosting
             bool? deleteCompatibilityMode = null,
             bool? useWriterUuidColumn = null)
         {
-            if (mode == PersistenceMode.SnapshotStore && journalBuilder is { })
+            if (mode == PersistenceMode.SnapshotStore && journalBuilder is not null)
                 throw new Exception($"{nameof(journalBuilder)} can only be set when {nameof(mode)} is set to either {PersistenceMode.Both} or {PersistenceMode.Journal}");
 
             if (string.IsNullOrWhiteSpace(connectionString))
@@ -158,16 +158,16 @@ namespace Akka.Persistence.Sql.Hosting
                 DeleteCompatibilityMode = deleteCompatibilityMode,
             };
 
-            if (databaseMapping is { })
+            if (databaseMapping is not null)
                 journalOpt.DatabaseOptions = databaseMapping.Value.JournalOption();
 
-            if (schemaName is { })
+            if (schemaName is not null)
             {
                 journalOpt.DatabaseOptions ??= JournalDatabaseOptions.Default;
                 journalOpt.DatabaseOptions.SchemaName = schemaName;
             }
 
-            if (useWriterUuidColumn is { })
+            if (useWriterUuidColumn is not null)
             {
                 journalOpt.DatabaseOptions ??= JournalDatabaseOptions.Default;
                 journalOpt.DatabaseOptions.JournalTable ??= JournalTableOptions.Default;
@@ -185,10 +185,10 @@ namespace Akka.Persistence.Sql.Hosting
                 AutoInitialize = autoInitialize,
             };
 
-            if (databaseMapping is { })
+            if (databaseMapping is not null)
                 snapshotOpt.DatabaseOptions = databaseMapping.Value.SnapshotOption();
 
-            if (schemaName is { })
+            if (schemaName is not null)
             {
                 snapshotOpt.DatabaseOptions ??= new SnapshotDatabaseOptions(DatabaseMapping.Default);
                 snapshotOpt.DatabaseOptions.SchemaName = schemaName;
@@ -247,14 +247,14 @@ namespace Akka.Persistence.Sql.Hosting
                 throw new ArgumentException($"{nameof(journalOptionConfigurator)} and {nameof(snapshotOptionConfigurator)} could not both be null");
 
             SqlJournalOptions? journalOptions = null;
-            if (journalOptionConfigurator is { })
+            if (journalOptionConfigurator is not null)
             {
                 journalOptions = new SqlJournalOptions(isDefaultPlugin);
                 journalOptionConfigurator(journalOptions);
             }
 
             SqlSnapshotOptions? snapshotOptions = null;
-            if (snapshotOptionConfigurator is { })
+            if (snapshotOptionConfigurator is not null)
             {
                 snapshotOptions = new SqlSnapshotOptions(isDefaultPlugin);
                 snapshotOptionConfigurator(snapshotOptions);

--- a/src/Akka.Persistence.Sql.Hosting/JournalDatabaseOptions.cs
+++ b/src/Akka.Persistence.Sql.Hosting/JournalDatabaseOptions.cs
@@ -76,7 +76,7 @@ namespace Akka.Persistence.Sql.Hosting
         internal void Build(StringBuilder psb)
         {
             var sb = new StringBuilder();
-            if (SchemaName is { })
+            if (SchemaName is not null)
                 sb.AppendLine($"schema-name = {SchemaName.ToHocon()}");
 
             JournalTable?.Build(sb);

--- a/src/Akka.Persistence.Sql.Hosting/JournalTableOptions.cs
+++ b/src/Akka.Persistence.Sql.Hosting/JournalTableOptions.cs
@@ -137,41 +137,41 @@ namespace Akka.Persistence.Sql.Hosting
         {
             var sb = new StringBuilder();
 
-            if (UseWriterUuidColumn is { })
+            if (UseWriterUuidColumn is not null)
                 sb.AppendLine($"use-writer-uuid-column = {UseWriterUuidColumn.ToHocon()}");
 
-            if (TableName is { })
+            if (TableName is not null)
                 sb.AppendLine($"table-name = {TableName.ToHocon()}");
 
             var columnSb = new StringBuilder();
-            if (OrderingColumnName is { })
+            if (OrderingColumnName is not null)
                 columnSb.AppendLine($"ordering = {OrderingColumnName.ToHocon()}");
 
-            if (DeletedColumnName is { })
+            if (DeletedColumnName is not null)
                 columnSb.AppendLine($"deleted = {DeletedColumnName.ToHocon()}");
 
-            if (PersistenceIdColumnName is { })
+            if (PersistenceIdColumnName is not null)
                 columnSb.AppendLine($"persistence-id = {PersistenceIdColumnName.ToHocon()}");
 
-            if (SequenceNumberColumnName is { })
+            if (SequenceNumberColumnName is not null)
                 columnSb.AppendLine($"sequence-number = {SequenceNumberColumnName.ToHocon()}");
 
-            if (CreatedColumnName is { })
+            if (CreatedColumnName is not null)
                 columnSb.AppendLine($"created = {CreatedColumnName.ToHocon()}");
 
-            if (TagsColumnName is { })
+            if (TagsColumnName is not null)
                 columnSb.AppendLine($"tags = {TagsColumnName.ToHocon()}");
 
-            if (MessageColumnName is { })
+            if (MessageColumnName is not null)
                 columnSb.AppendLine($"message = {MessageColumnName.ToHocon()}");
 
-            if (IdentifierColumnName is { })
+            if (IdentifierColumnName is not null)
                 columnSb.AppendLine($"identifier = {IdentifierColumnName.ToHocon()}");
 
-            if (ManifestColumnName is { })
+            if (ManifestColumnName is not null)
                 columnSb.AppendLine($"manifest = {ManifestColumnName.ToHocon()}");
 
-            if (WriterUuidColumnName is { })
+            if (WriterUuidColumnName is not null)
                 columnSb.AppendLine($"writer-uuid = {WriterUuidColumnName.ToHocon()}");
 
             if (columnSb.Length > 0)

--- a/src/Akka.Persistence.Sql.Hosting/MetadataTableOptions.cs
+++ b/src/Akka.Persistence.Sql.Hosting/MetadataTableOptions.cs
@@ -55,14 +55,14 @@ namespace Akka.Persistence.Sql.Hosting
         internal void Build(StringBuilder psb)
         {
             var sb = new StringBuilder();
-            if (TableName is { })
+            if (TableName is not null)
                 sb.AppendLine($"table-name = {TableName.ToHocon()}");
 
             var columnSb = new StringBuilder();
-            if (PersistenceIdColumnName is { })
+            if (PersistenceIdColumnName is not null)
                 columnSb.AppendLine($"persistence-id = {PersistenceIdColumnName.ToHocon()}");
 
-            if (SequenceNumberColumnName is { })
+            if (SequenceNumberColumnName is not null)
                 columnSb.AppendLine($"sequence-number = {SequenceNumberColumnName.ToHocon()}");
 
             if (columnSb.Length > 0)

--- a/src/Akka.Persistence.Sql.Hosting/SnapshotDatabaseOptions.cs
+++ b/src/Akka.Persistence.Sql.Hosting/SnapshotDatabaseOptions.cs
@@ -58,7 +58,7 @@ namespace Akka.Persistence.Sql.Hosting
         internal void Build(StringBuilder psb)
         {
             var sb = new StringBuilder();
-            if (SchemaName is { })
+            if (SchemaName is not null)
                 sb.AppendLine($"schema-name = {SchemaName.ToHocon()}");
 
             SnapshotTable?.Build(sb);

--- a/src/Akka.Persistence.Sql.Hosting/SnapshotTableOptions.cs
+++ b/src/Akka.Persistence.Sql.Hosting/SnapshotTableOptions.cs
@@ -78,26 +78,26 @@ namespace Akka.Persistence.Sql.Hosting
         internal void Build(StringBuilder psb)
         {
             var sb = new StringBuilder();
-            if (TableName is { })
+            if (TableName is not null)
                 sb.AppendLine($"table-name = {TableName.ToHocon()}");
 
             var columnSb = new StringBuilder();
-            if (PersistenceIdColumnName is { })
+            if (PersistenceIdColumnName is not null)
                 columnSb.AppendLine($"persistence-id = {PersistenceIdColumnName.ToHocon()}");
 
-            if (SequenceNumberColumnName is { })
+            if (SequenceNumberColumnName is not null)
                 columnSb.AppendLine($"sequence-number = {SequenceNumberColumnName.ToHocon()}");
 
-            if (CreatedColumnName is { })
+            if (CreatedColumnName is not null)
                 columnSb.AppendLine($"created = {CreatedColumnName.ToHocon()}");
 
-            if (SnapshotColumnName is { })
+            if (SnapshotColumnName is not null)
                 columnSb.AppendLine($"snapshot = {SnapshotColumnName.ToHocon()}");
 
-            if (ManifestColumnName is { })
+            if (ManifestColumnName is not null)
                 columnSb.AppendLine($"manifest = {ManifestColumnName.ToHocon()}");
 
-            if (SerializerIdColumnName is { })
+            if (SerializerIdColumnName is not null)
                 columnSb.AppendLine($"serializerId = {SerializerIdColumnName.ToHocon()}");
 
             if (columnSb.Length > 0)

--- a/src/Akka.Persistence.Sql.Hosting/SqlJournalOptions.cs
+++ b/src/Akka.Persistence.Sql.Hosting/SqlJournalOptions.cs
@@ -125,19 +125,19 @@ namespace Akka.Persistence.Sql.Hosting
             sb.AppendLine($"connection-string = {ConnectionString.ToHocon()}");
             sb.AppendLine($"provider-name = {ProviderName.ToHocon()}");
 
-            if (DeleteCompatibilityMode is { })
+            if (DeleteCompatibilityMode is not null)
                 sb.AppendLine($"delete-compatibility-mode = {DeleteCompatibilityMode.ToHocon()}");
 
-            if (TagStorageMode is { })
+            if (TagStorageMode is not null)
                 sb.AppendLine($"tag-write-mode = {TagStorageMode.ToString().ToHocon()}");
 
-            if (DatabaseOptions is { })
+            if (DatabaseOptions is not null)
                 sb.AppendLine($"table-mapping = {DatabaseOptions.Mapping.Name().ToHocon()}");
 
-            if (ReadIsolationLevel is { })
+            if (ReadIsolationLevel is not null)
                 sb.AppendLine($"read-isolation-level = {ReadIsolationLevel.ToHocon()}");
 
-            if (WriteIsolationLevel is { })
+            if (WriteIsolationLevel is not null)
                 sb.AppendLine($"write-isolation-level = {WriteIsolationLevel.ToHocon()}");
 
             DatabaseOptions?.Build(sb);
@@ -150,16 +150,16 @@ namespace Akka.Persistence.Sql.Hosting
                 sb.AppendLine($"connection-string = {ConnectionString.ToHocon()}");
                 sb.AppendLine($"provider-name = {ProviderName.ToHocon()}");
 
-                if (TagStorageMode is { })
+                if (TagStorageMode is not null)
                     sb.AppendLine($"tag-read-mode = {TagStorageMode.ToString().ToHocon()}");
 
-                if (ReadIsolationLevel is { })
+                if (ReadIsolationLevel is not null)
                     sb.AppendLine($"read-isolation-level = {ReadIsolationLevel.ToHocon()}");
 
                 sb.AppendLine("}");
             }
 
-            if (QueryRefreshInterval is { })
+            if (QueryRefreshInterval is not null)
                 sb.AppendLine($"akka.persistence.query.journal.sql.refresh-interval = {QueryRefreshInterval.ToHocon()}");
 
             return sb;

--- a/src/Akka.Persistence.Sql.Hosting/SqlSnapshotOptions.cs
+++ b/src/Akka.Persistence.Sql.Hosting/SqlSnapshotOptions.cs
@@ -91,13 +91,13 @@ namespace Akka.Persistence.Sql.Hosting
             sb.AppendLine($"connection-string = {ConnectionString.ToHocon()}");
             sb.AppendLine($"provider-name = {ProviderName.ToHocon()}");
 
-            if (DatabaseOptions is { })
+            if (DatabaseOptions is not null)
                 sb.AppendLine($"table-mapping = {DatabaseOptions.Mapping.Name().ToHocon()}");
 
-            if (ReadIsolationLevel is { })
+            if (ReadIsolationLevel is not null)
                 sb.AppendLine($"read-isolation-level = {ReadIsolationLevel.ToHocon()}");
 
-            if (WriteIsolationLevel is { })
+            if (WriteIsolationLevel is not null)
                 sb.AppendLine($"write-isolation-level = {WriteIsolationLevel.ToHocon()}");
 
             DatabaseOptions?.Build(sb);

--- a/src/Akka.Persistence.Sql.Hosting/TagTableOptions.cs
+++ b/src/Akka.Persistence.Sql.Hosting/TagTableOptions.cs
@@ -22,28 +22,30 @@ namespace Akka.Persistence.Sql.Hosting
 
         public string? TableName { get; set; }
 
-        public string? OrderingColumnName { get; set; }
+        // ReSharper disable once InconsistentNaming
         public string? TagColumnName { get; set; }
+
+        public string? OrderingColumnName { get; set; }
         public string? PersistenceIdColumnName { get; set; }
         public string? SequenceNumberColumnName { get; set; }
 
         internal void Build(StringBuilder psb)
         {
             var sb = new StringBuilder();
-            if (TableName is { })
+            if (TableName is not null)
                 sb.AppendLine($"table-name = {TableName.ToHocon()}");
 
             var columnSb = new StringBuilder();
-            if (OrderingColumnName is { })
+            if (OrderingColumnName is not null)
                 columnSb.AppendLine($"ordering-id = {OrderingColumnName.ToHocon()}");
 
-            if (TagColumnName is { })
+            if (TagColumnName is not null)
                 columnSb.AppendLine($"tag-value = {TagColumnName.ToHocon()}");
 
-            if (PersistenceIdColumnName is { })
+            if (PersistenceIdColumnName is not null)
                 columnSb.AppendLine($"persistence-id = {PersistenceIdColumnName.ToHocon()}");
 
-            if (SequenceNumberColumnName is { })
+            if (SequenceNumberColumnName is not null)
                 columnSb.AppendLine($"sequence-nr = {SequenceNumberColumnName.ToHocon()}");
 
             if (columnSb.Length > 0)

--- a/src/Akka.Persistence.Sql.TagTableMigration/Options.cs
+++ b/src/Akka.Persistence.Sql.TagTableMigration/Options.cs
@@ -91,7 +91,7 @@ akka.persistence {{
             warn-on-auto-init-fail = true
             tag-write-mode = Both
 
-{(opt.SchemaName is { } ? @$"
+{(opt.SchemaName is not null ? @$"
             {opt.TableMapping.ToHocon()} {{
                 schema-name = {opt.SchemaName}
             }}" : string.Empty)}

--- a/src/Akka.Persistence.Sql.Tests.Common/Containers/DockerContainer.cs
+++ b/src/Akka.Persistence.Sql.Tests.Common/Containers/DockerContainer.cs
@@ -125,7 +125,7 @@ namespace Akka.Persistence.Sql.Tests.Common.Containers
             _readDockerTask = ReadDockerStreamAsync();
 
             // Wait until container is completely ready
-            if (ReadyMarker is { })
+            if (ReadyMarker is not null)
             {
                 await AwaitUntilReadyAsync(ReadyMarker, ReadyTimeout);
             }
@@ -233,10 +233,10 @@ namespace Akka.Persistence.Sql.Tests.Common.Containers
             _logsCts.Cancel();
             _logsCts.Dispose();
 
-            if (_readDockerTask is { })
+            if (_readDockerTask is not null)
                 await _readDockerTask;
 
-            if (_stream is { })
+            if (_stream is not null)
                 await _stream.DisposeAsync();
 
             try

--- a/src/Akka.Persistence.Sql.Tests.Common/Containers/MsSqliteContainer.cs
+++ b/src/Akka.Persistence.Sql.Tests.Common/Containers/MsSqliteContainer.cs
@@ -29,7 +29,7 @@ namespace Akka.Persistence.Sql.Tests.Common.Containers
 
         public DockerClient? Client => null;
 
-        public bool Initialized => _heldConnection is { };
+        public bool Initialized => _heldConnection is not null;
 
         public string ProviderName => LinqToDB.ProviderName.SQLiteMS;
 

--- a/src/Akka.Persistence.Sql.Tests.Common/Containers/SqliteContainer.cs
+++ b/src/Akka.Persistence.Sql.Tests.Common/Containers/SqliteContainer.cs
@@ -31,7 +31,7 @@ namespace Akka.Persistence.Sql.Tests.Common.Containers
 
         public DockerClient? Client => null;
 
-        public bool Initialized => _heldConnection is { };
+        public bool Initialized => _heldConnection is not null;
 
         public async Task InitializeAsync()
         {

--- a/src/Akka.Persistence.Sql/Config/JournalConfig.cs
+++ b/src/Akka.Persistence.Sql/Config/JournalConfig.cs
@@ -92,10 +92,12 @@ namespace Akka.Persistence.Sql.Config
 
     public interface IPluginConfig
     {
+        // ReSharper disable once InconsistentNaming
         string TagSeparator { get; }
 
         string Dao { get; }
 
+        // ReSharper disable once InconsistentNaming
         TagMode TagMode { get; }
     }
 

--- a/src/Akka.Persistence.Sql/Config/JournalTableColumnNames.cs
+++ b/src/Akka.Persistence.Sql/Config/JournalTableColumnNames.cs
@@ -46,7 +46,7 @@ namespace Akka.Persistence.Sql.Config
         public string WriterUuid { get; }
 
         public bool Equals(JournalTableColumnNames other)
-            => other is { } &&
+            => other is not null &&
                Ordering == other.Ordering &&
                Deleted == other.Deleted &&
                PersistenceId == other.PersistenceId &&

--- a/src/Akka.Persistence.Sql/Config/JournalTableConfig.cs
+++ b/src/Akka.Persistence.Sql/Config/JournalTableConfig.cs
@@ -23,10 +23,8 @@ namespace Akka.Persistence.Sql.Config
             if (compatibility != null)
                 mappingPath = compatibility;
 
-            var mappingConfig = config.GetConfig(mappingPath);
-            if (mappingConfig is null)
-                throw new ConfigurationException(
-                    $"The configuration path akka.persistence.journal.sql.{mappingPath} does not exist");
+            var mappingConfig = config.GetConfig(mappingPath) ?? throw new ConfigurationException(
+                $"The configuration path akka.persistence.journal.sql.{mappingPath} does not exist");
 
             if (mappingPath != "default")
                 mappingConfig = mappingConfig.WithFallback(SqlPersistence.DefaultJournalMappingConfiguration);
@@ -47,6 +45,7 @@ namespace Akka.Persistence.Sql.Config
 
         public MetadataTableConfig MetadataTable { get; }
 
+        // ReSharper disable once InconsistentNaming
         public TagTableConfig TagTable { get; }
 
         public bool Equals(JournalTableConfig other)

--- a/src/Akka.Persistence.Sql/Config/SnapshotTableConfiguration.cs
+++ b/src/Akka.Persistence.Sql/Config/SnapshotTableConfiguration.cs
@@ -18,10 +18,8 @@ namespace Akka.Persistence.Sql.Config
                 throw new ConfigurationException(
                     "The configuration property akka.persistence.journal.sql.table-mapping is null or empty");
 
-            var mappingConfig = config.GetConfig(mappingPath);
-            if (mappingConfig is null)
-                throw new ConfigurationException(
-                    $"The configuration path akka.persistence.journal.sql.{mappingPath} does not exist");
+            var mappingConfig = config.GetConfig(mappingPath) ?? throw new ConfigurationException(
+                $"The configuration path akka.persistence.journal.sql.{mappingPath} does not exist");
 
             if (mappingPath != "default")
                 mappingConfig.WithFallback(SqlPersistence.DefaultSnapshotMappingConfiguration);

--- a/src/Akka.Persistence.Sql/Config/TagMode.cs
+++ b/src/Akka.Persistence.Sql/Config/TagMode.cs
@@ -6,10 +6,14 @@
 
 namespace Akka.Persistence.Sql.Config
 {
+    // ReSharper disable once InconsistentNaming
     public enum TagMode
     {
         Csv,
+
+        // ReSharper disable once InconsistentNaming
         TagTable,
+
         Both,
     }
 }

--- a/src/Akka.Persistence.Sql/Config/TagTableColumnNames.cs
+++ b/src/Akka.Persistence.Sql/Config/TagTableColumnNames.cs
@@ -8,6 +8,7 @@ using System;
 
 namespace Akka.Persistence.Sql.Config
 {
+    // ReSharper disable once InconsistentNaming
     public class TagTableColumnNames : IEquatable<TagTableColumnNames>
     {
         public TagTableColumnNames(Configuration.Config config)

--- a/src/Akka.Persistence.Sql/Config/TagTableConfig.cs
+++ b/src/Akka.Persistence.Sql/Config/TagTableConfig.cs
@@ -8,6 +8,7 @@ using System;
 
 namespace Akka.Persistence.Sql.Config
 {
+    // ReSharper disable once InconsistentNaming
     public class TagTableConfig : IEquatable<TagTableConfig>
     {
         public TagTableConfig(Configuration.Config config)

--- a/src/Akka.Persistence.Sql/Db/AkkaPersistenceDataConnectionFactory.cs
+++ b/src/Akka.Persistence.Sql/Db/AkkaPersistenceDataConnectionFactory.cs
@@ -139,7 +139,7 @@ namespace Akka.Persistence.Sql.Db
                 .Member(r => r.Timestamp)
                 .HasColumnName(columnNames.Created)
 
-                .Member(r => r.TagArr)
+                .Member(r => r.TagArray)
                 .IsNotColumn();
 
             if (config.ProviderName.StartsWith(ProviderName.MySql))
@@ -338,7 +338,7 @@ namespace Akka.Persistence.Sql.Db
             var snapshotConfig = tableConfig.SnapshotTable;
             var rowBuilder = fmb.Entity<LongSnapshotRow>();
 
-            if (tableConfig.SchemaName is { })
+            if (tableConfig.SchemaName is not null)
                 rowBuilder.HasSchemaName(tableConfig.SchemaName);
 
             rowBuilder

--- a/src/Akka.Persistence.Sql/Extensions/ConnectionFactoryExtensions.cs
+++ b/src/Akka.Persistence.Sql/Extensions/ConnectionFactoryExtensions.cs
@@ -8,8 +8,9 @@ using System;
 using System.Data;
 using System.Threading;
 using System.Threading.Tasks;
+using Akka.Persistence.Sql.Db;
 
-namespace Akka.Persistence.Sql.Db
+namespace Akka.Persistence.Sql.Extensions
 {
     public static class ConnectionFactoryExtensions
     {
@@ -21,6 +22,7 @@ namespace Akka.Persistence.Sql.Db
         {
             await using var connection = factory.GetConnection();
             await using var tx = await connection.BeginTransactionAsync(level, token);
+
             try
             {
                 await handler(connection, token);
@@ -49,6 +51,7 @@ namespace Akka.Persistence.Sql.Db
         {
             await using var connection = factory.GetConnection();
             await using var tx = await connection.BeginTransactionAsync(level, token);
+
             try
             {
                 var result = await handler(connection, token);

--- a/src/Akka.Persistence.Sql/Journal/Dao/BaseJournalDaoWithReadMessages.cs
+++ b/src/Akka.Persistence.Sql/Journal/Dao/BaseJournalDaoWithReadMessages.cs
@@ -83,7 +83,7 @@ namespace Akka.Persistence.Sql.Journal.Dao
 
                             var lastSeq = Option<long>.None;
                             if (msg.IsEmpty == false)
-                                lastSeq = msg.Last.Get().Repr.SequenceNr;
+                                lastSeq = msg.Last.Get().Representation.SequenceNr;
 
                             FlowControlEnum nextControl;
                             if ((lastSeq.HasValue && lastSeq.Value >= toSequenceNr) || opt.seqNr > toSequenceNr)

--- a/src/Akka.Persistence.Sql/Journal/SqlWriteJournal.cs
+++ b/src/Akka.Persistence.Sql/Journal/SqlWriteJournal.cs
@@ -131,10 +131,12 @@ namespace Akka.Persistence.Sql.Journal
                     UnbecomeStacked();
                     Stash.UnstashAll();
                     return true;
+
                 case Status.Failure fail:
                     _log.Error(fail.Cause, "Failure during {0} initialization.", Self);
                     Context.Stop(Self);
                     return true;
+
                 default:
                     Stash.Stash();
                     return true;
@@ -188,7 +190,7 @@ namespace Akka.Persistence.Sql.Journal
                     asyncMapper: t => t.IsSuccess
                         ? Task.FromResult(t.Success.Value)
                         : Task.FromException<ReplayCompletion>(t.Failure.Value))
-                .RunForeach(r => recoveryCallback(r.Repr), _mat);
+                .RunForeach(r => recoveryCallback(r.Representation), _mat);
 
         public override async Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr)
         {

--- a/src/Akka.Persistence.Sql/Journal/Types/JournalRow.cs
+++ b/src/Akka.Persistence.Sql/Journal/Types/JournalRow.cs
@@ -26,7 +26,8 @@ namespace Akka.Persistence.Sql.Journal.Types
 
         public int? Identifier { get; set; }
 
-        public string[] TagArr { get; set; }
+        // ReSharper disable once InconsistentNaming
+        public string[] TagArray { get; set; }
 
         public string WriterUuid { get; set; }
 

--- a/src/Akka.Persistence.Sql/Journal/Types/JournalTagRow.cs
+++ b/src/Akka.Persistence.Sql/Journal/Types/JournalTagRow.cs
@@ -6,10 +6,12 @@
 
 namespace Akka.Persistence.Sql.Journal.Types
 {
+    // ReSharper disable once InconsistentNaming
     public class TagRow
     {
         public long OrderingId { get; set; }
 
+        // ReSharper disable once InconsistentNaming
         public string TagValue { get; set; }
     }
 

--- a/src/Akka.Persistence.Sql/Journal/Types/ReplayCompletion.cs
+++ b/src/Akka.Persistence.Sql/Journal/Types/ReplayCompletion.cs
@@ -12,17 +12,17 @@ namespace Akka.Persistence.Sql.Journal.Types
     {
         public readonly long Ordering;
 
-        public readonly IPersistentRepresentation Repr;
+        public readonly IPersistentRepresentation Representation;
 
         public ReplayCompletion(
             IPersistentRepresentation representation,
             long ordering)
         {
-            Repr = representation;
+            Representation = representation;
             Ordering = ordering;
         }
 
         public ReplayCompletion((IPersistentRepresentation, IImmutableSet<string>, long) success)
-            => (Repr, _, Ordering) = success;
+            => (Representation, _, Ordering) = success;
     }
 }

--- a/src/Akka.Persistence.Sql/Query/Dao/ByteArrayReadJournalDao.cs
+++ b/src/Akka.Persistence.Sql/Query/Dao/ByteArrayReadJournalDao.cs
@@ -21,7 +21,7 @@ namespace Akka.Persistence.Sql.Query.Dao
             IMaterializer materializer,
             AkkaPersistenceDataConnectionFactory connectionFactory,
             ReadJournalConfig readJournalConfig,
-            FlowPersistentReprSerializer<JournalRow> serializer,
+            FlowPersistentRepresentationSerializer<JournalRow> serializer,
             CancellationToken token)
             : base(scheduler, materializer, connectionFactory, readJournalConfig, serializer, token) { }
     }

--- a/src/Akka.Persistence.Sql/Query/InternalProtocol/EventsByTagResponseItem.cs
+++ b/src/Akka.Persistence.Sql/Query/InternalProtocol/EventsByTagResponseItem.cs
@@ -15,12 +15,12 @@ namespace Akka.Persistence.Sql.Query.InternalProtocol
             ImmutableHashSet<string> tags,
             long sequenceNr)
         {
-            Repr = representation;
+            Representation = representation;
             Tags = tags;
             SequenceNr = sequenceNr;
         }
 
-        public IPersistentRepresentation Repr { get; }
+        public IPersistentRepresentation Representation { get; }
 
         public ImmutableHashSet<string> Tags { get; }
 

--- a/src/Akka.Persistence.Sql/Query/InternalProtocol/MissingElements.cs
+++ b/src/Akka.Persistence.Sql/Query/InternalProtocol/MissingElements.cs
@@ -15,7 +15,7 @@ namespace Akka.Persistence.Sql.Query.InternalProtocol
         public MissingElements(Seq<NumericRangeEntry> elements)
             => Elements = elements;
 
-        public bool Isempty
+        public bool IsEmpty
             => Elements.IsEmpty;
 
         public Seq<NumericRangeEntry> Elements { get; }

--- a/src/Akka.Persistence.Sql/Query/JournalSequenceActor.cs
+++ b/src/Akka.Persistence.Sql/Query/JournalSequenceActor.cs
@@ -137,7 +137,8 @@ namespace Akka.Persistence.Sql.Query
                 (currentMax: currentMaxOrdering, previousElement: currentMaxOrdering, missing: MissingElements.Empty),
                 (agg, currentElement) =>
                 {
-                    var newMax = new NumericRangeEntry(agg.currentMax + 1, currentElement).ToEnumerable()
+                    var newMax = new NumericRangeEntry(agg.currentMax + 1, currentElement)
+                        .ToEnumerable()
                         .ForAll(p => givenUp.Contains(p))
                         ? currentElement
                         : agg.currentMax;
@@ -156,7 +157,7 @@ namespace Akka.Persistence.Sql.Query
                 });
 
             var newMissingByCounter = missingByCounter.SetItem(moduloCounter, missingElems);
-            var noGapsFound = missingElems.Isempty;
+            var noGapsFound = missingElems.IsEmpty;
             var isFullBatch = elements.Count == _config.BatchSize;
             if (noGapsFound && isFullBatch)
             {

--- a/src/Akka.Persistence.Sql/Query/SqlReadJournal.cs
+++ b/src/Akka.Persistence.Sql/Query/SqlReadJournal.cs
@@ -190,7 +190,7 @@ namespace Akka.Persistence.Sql.Query
             => _readJournalDao
                 .MessagesWithBatch(persistenceId, fromSequenceNr, toSequenceNr, _readJournalConfig.MaxBufferSize, refreshInterval)
                 .SelectAsync(1, representationAndOrdering => Task.FromResult(representationAndOrdering.Get()))
-                .SelectMany(r => AdaptEvents(r.Repr).Select(_ => new { representation = r.Repr, ordering = r.Ordering }))
+                .SelectMany(r => AdaptEvents(r.Representation).Select(_ => new { representation = r.Representation, ordering = r.Ordering }))
                 .Select(
                     r =>
                         new EventEnvelope(

--- a/src/Akka.Persistence.Sql/Serialization/FlowPersistentRepresentationSerializer.cs
+++ b/src/Akka.Persistence.Sql/Serialization/FlowPersistentRepresentationSerializer.cs
@@ -1,5 +1,5 @@
 ﻿// -----------------------------------------------------------------------
-//  <copyright file="FlowPersistentReprSerializer.cs" company="Akka.NET Project">
+//  <copyright file="FlowPersistentRepresentationSerializer.cs" company="Akka.NET Project">
 //      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
 //  </copyright>
 // -----------------------------------------------------------------------
@@ -10,8 +10,7 @@ using Akka.Util;
 
 namespace Akka.Persistence.Sql.Serialization
 {
-    // TODO: Can we rename this to FlowPersistentRepresentationSerializer?
-    public abstract class FlowPersistentReprSerializer<T> : PersistentReprSerializer<T>
+    public abstract class FlowPersistentRepresentationSerializer<T> : PersistentRepresentationSerializer<T>
     {
         public Flow<T, Try<(IPersistentRepresentation, IImmutableSet<string>, long)>, NotUsed> DeserializeFlow()
             => Flow.Create<T, NotUsed>().Select(Deserialize);

--- a/src/Akka.Persistence.Sql/Serialization/PersistentRepresentationSerializer.cs
+++ b/src/Akka.Persistence.Sql/Serialization/PersistentRepresentationSerializer.cs
@@ -1,5 +1,5 @@
 ﻿// -----------------------------------------------------------------------
-//  <copyright file="PersistentReprSerializer.cs" company="Akka.NET Project">
+//  <copyright file="PersistentRepresentationSerializer.cs" company="Akka.NET Project">
 //      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
 //  </copyright>
 // -----------------------------------------------------------------------
@@ -13,8 +13,7 @@ using Akka.Util;
 
 namespace Akka.Persistence.Sql.Serialization
 {
-    // TODO: Can we rename this to PersistentRepresentationSerializer?
-    public abstract class PersistentReprSerializer<T>
+    public abstract class PersistentRepresentationSerializer<T>
     {
         public List<Try<T[]>> Serialize(IEnumerable<AtomicWrite> messages, long timeStamp = 0)
             => messages.Select(
@@ -55,18 +54,19 @@ namespace Akka.Persistence.Sql.Serialization
                     return new Try<T[]>(retList);
                 }).ToList();
 
-        private List<Try<T[]>> HandleSerializeList(long timeStamp, AtomicWrite[] msgArr)
+        private List<Try<T[]>> HandleSerializeList(long timeStamp, AtomicWrite[] messages)
         {
-            var fullSet = new List<Try<T[]>>(msgArr.Length);
-            for (var i = 0; i < msgArr.Length; i++)
+            var fullSet = new List<Try<T[]>>(messages.Length);
+
+            foreach (var message in messages)
             {
-                if (msgArr[i].Payload is not IImmutableList<IPersistentRepresentation> payloads)
+                if (message.Payload is not IImmutableList<IPersistentRepresentation> payloads)
                 {
                     fullSet.Add(
                         new Try<T[]>(
                             new ArgumentNullException(
-                                $"{msgArr[i].PersistenceId} received empty payload for sequenceNr range " +
-                                $"{msgArr[i].LowestSequenceNr} - {msgArr[i].HighestSequenceNr}")));
+                                $"{message.PersistenceId} received empty payload for sequenceNr range " +
+                                $"{message.LowestSequenceNr} - {message.HighestSequenceNr}")));
                 }
                 else
                 {

--- a/src/Akka.Persistence.Sql/Snapshot/ByteArrayDateTimeSnapshotSerializer.cs
+++ b/src/Akka.Persistence.Sql/Snapshot/ByteArrayDateTimeSnapshotSerializer.cs
@@ -54,7 +54,10 @@ namespace Akka.Persistence.Sql.Snapshot
                 // TODO: hack. Replace when https://github.com/akkadotnet/akka.net/issues/3811
                 return Akka.Serialization.Serialization.WithTransport(
                     system: _serialization.System,
-                    state: (serializer: _serialization.FindSerializerForType(type, _config.DefaultSerializer), binary, type),
+                    state: (
+                        serializer: _serialization.FindSerializerForType(type, _config.DefaultSerializer),
+                        binary,
+                        type),
                     action: state => state.serializer.FromBinary(state.binary, state.type));
             }
 

--- a/src/Akka.Persistence.Sql/Snapshot/ByteArrayLongSnapshotSerializer.cs
+++ b/src/Akka.Persistence.Sql/Snapshot/ByteArrayLongSnapshotSerializer.cs
@@ -54,7 +54,10 @@ namespace Akka.Persistence.Sql.Snapshot
                 // TODO: hack. Replace when https://github.com/akkadotnet/akka.net/issues/3811
                 return Akka.Serialization.Serialization.WithTransport(
                     system: _serialization.System,
-                    state: (serializer: _serialization.FindSerializerForType(type, _config.DefaultSerializer), binary, type),
+                    state: (
+                        serializer: _serialization.FindSerializerForType(type, _config.DefaultSerializer),
+                        binary,
+                        type),
                     action: state => state.serializer.FromBinary(state.binary, state.type));
             }
 

--- a/src/Akka.Persistence.Sql/Snapshot/ByteArraySnapshotDao.cs
+++ b/src/Akka.Persistence.Sql/Snapshot/ByteArraySnapshotDao.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Akka.Event;
 using Akka.Persistence.Sql.Config;
 using Akka.Persistence.Sql.Db;
+using Akka.Persistence.Sql.Extensions;
 using Akka.Streams;
 using Akka.Util;
 using LinqToDB;

--- a/src/Akka.Persistence.Sql/Snapshot/SqlSnapshotStore.cs
+++ b/src/Akka.Persistence.Sql/Snapshot/SqlSnapshotStore.cs
@@ -18,6 +18,7 @@ namespace Akka.Persistence.Sql.Snapshot
 {
     public class SqlSnapshotStore : SnapshotStore, IWithUnboundedStash
     {
+        // ReSharper disable once UnusedMember.Global
         [Obsolete(message: "Use SqlPersistence.Get(ActorSystem).DefaultConfig instead")]
         public static readonly Configuration.Config DefaultConfiguration =
             ConfigurationFactory.FromResource<SqlSnapshotStore>("Akka.Persistence.Sql.snapshot.conf");
@@ -58,10 +59,12 @@ namespace Akka.Persistence.Sql.Snapshot
                     UnbecomeStacked();
                     Stash.UnstashAll();
                     return true;
+
                 case Status.Failure msg:
                     _log.Error(msg.Cause, "Error during {0} initialization", Self);
                     Context.Stop(Self);
                     return true;
+
                 default:
                     Stash.Stash();
                     return true;

--- a/src/Akka.Persistence.Sql/Streams/ExtSeqStage.cs
+++ b/src/Akka.Persistence.Sql/Streams/ExtSeqStage.cs
@@ -56,7 +56,6 @@ namespace Akka.Persistence.Sql.Streams
         /// <returns>TBD</returns>
         public override string ToString() => "LanguageExtSeqStage";
 
-        #region stage logic
         private sealed class Logic : InGraphStageLogic
         {
             private readonly TaskCompletionSource<Seq<T>> _promise;
@@ -100,6 +99,5 @@ namespace Akka.Persistence.Sql.Streams
 
             public override void PreStart() => Pull(_stage.In);
         }
-        #endregion
     }
 }


### PR DESCRIPTION
Made some short variable names more descriptive, applied the `is not null` resharper advice, as well as some smaller refactorings.