### PR TITLE
fix: add default SqlReadJournal static method

### DIFF
--- a/src/Akka.Persistence.Sql/Query/SqlReadJournal.cs
+++ b/src/Akka.Persistence.Sql/Query/SqlReadJournal.cs
@@ -38,7 +38,7 @@ namespace Akka.Persistence.Sql.Query
     {
         // ReSharper disable once UnusedMember.Global
         [Obsolete(message: "Use SqlPersistence.Get(ActorSystem).DefaultConfig instead")]
-        public static readonly Configuration.Config DefaultConfiguration = SqlWriteJournal.DefaultConfiguration;
+        public static Configuration.Config DefaultConfiguration() => SqlWriteJournal.DefaultConfiguration;
 
         private readonly Source<long, ICancelable> _delaySource;
         private readonly EventAdapters _eventAdapters;


### PR DESCRIPTION
## Changes

In the PersistenceQuery, in the GetDefaultConfig the framework relies on the fact that in the SqlReadJournal there is a public static method called "[GetDefaultConfig](https://github.com/akkadotnet/akka.net/blob/dev/src/core/Akka.Persistence.Query/PersistenceQuery.cs)". However, this is not the case int this implementation of the class and the ReadJournalFor will fail without that.

