### PR TITLE
Fix missing SQL query configuration file

### DIFF
--- a/src/Akka.Persistence.Sql.Hosting/HostingExtensions.cs
+++ b/src/Akka.Persistence.Sql.Hosting/HostingExtensions.cs
@@ -301,7 +301,8 @@ namespace Akka.Persistence.Sql.Hosting
                 (_, null) =>
                     builder
                         .AddHocon(journalOptions.ToConfig(), HoconAddMode.Prepend)
-                        .AddHocon(journalOptions.DefaultConfig, HoconAddMode.Append),
+                        .AddHocon(journalOptions.DefaultConfig, HoconAddMode.Append)
+                        .AddHocon(SqlPersistence.DefaultConfiguration, HoconAddMode.Append),
 
                 (null, _) =>
                     builder
@@ -313,7 +314,8 @@ namespace Akka.Persistence.Sql.Hosting
                         .AddHocon(journalOptions.ToConfig(), HoconAddMode.Prepend)
                         .AddHocon(snapshotOptions.ToConfig(), HoconAddMode.Prepend)
                         .AddHocon(journalOptions.DefaultConfig, HoconAddMode.Append)
-                        .AddHocon(snapshotOptions.DefaultConfig, HoconAddMode.Append),
+                        .AddHocon(snapshotOptions.DefaultConfig, HoconAddMode.Append)
+                        .AddHocon(SqlPersistence.DefaultConfiguration, HoconAddMode.Append),
             };
         }
     }


### PR DESCRIPTION
Bug reported in Discord, Hosting extension does not automatically add Query default configurations

## Changes

* Append Query default HOCON configuration when journal is being used.