### PR TITLE
Fix Missing take and optimize some captures

### DIFF
--- a/src/Akka.Persistence.Sql/Db/AkkaPersistenceDataConnectionFactory.cs
+++ b/src/Akka.Persistence.Sql/Db/AkkaPersistenceDataConnectionFactory.cs
@@ -42,17 +42,19 @@ namespace Akka.Persistence.Sql.Db
             fmb.Build();
 
             _useCloneDataConnection = config.UseCloneConnection;
-            _opts = new DataOptions()
+            var opts =new DataOptions()
                 .UseConnectionString(config.ProviderName, config.ConnectionString)
                 .UseMappingSchema(mappingSchema);
+            _opts = opts;
 
             if (config.ProviderName.ToLower().StartsWith("sqlserver"))
                 _policy = new SqlServerRetryPolicy();
-
+            
+            
             _cloneConnection = new Lazy<AkkaDataConnection>(
                 () => new AkkaDataConnection(
-                    _opts.ConnectionOptions.ProviderName,
-                    new DataConnection(_opts)));
+                    opts.ConnectionOptions.ProviderName,
+                    new DataConnection(opts)));
         }
 
         public AkkaPersistenceDataConnectionFactory(IProviderConfig<SnapshotTableConfiguration> config)
@@ -81,17 +83,17 @@ namespace Akka.Persistence.Sql.Db
             fmb.Build();
 
             _useCloneDataConnection = config.UseCloneConnection;
-            _opts = new DataOptions()
+            var opts = new DataOptions()
                 .UseConnectionString(config.ProviderName, config.ConnectionString)
                 .UseMappingSchema(mappingSchema);
-
+            _opts = opts;
             if (config.ProviderName.ToLower().StartsWith("sqlserver"))
                 _policy = new SqlServerRetryPolicy();
 
             _cloneConnection = new Lazy<AkkaDataConnection>(
                 () => new AkkaDataConnection(
-                    _opts.ConnectionOptions.ProviderName,
-                    new DataConnection(_opts)));
+                    opts.ConnectionOptions.ProviderName,
+                    new DataConnection(opts)));
         }
 
         private static void MapJournalRow(

--- a/src/Akka.Persistence.Sql/Extensions/ConnectionFactoryExtensions.cs
+++ b/src/Akka.Persistence.Sql/Extensions/ConnectionFactoryExtensions.cs
@@ -9,6 +9,7 @@ using System.Data;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Persistence.Sql.Db;
+using Akka.Persistence.Sql.Query.Dao;
 
 namespace Akka.Persistence.Sql.Extensions
 {
@@ -71,6 +72,14 @@ namespace Akka.Persistence.Sql.Extensions
 
                 throw;
             }
+        }
+        
+        internal static Task<T> ExecuteWithTransactionAsync<TState,T>(
+            this DbStateHolder factory,
+            TState state,
+            Func<AkkaDataConnection, CancellationToken, TState, Task<T>> handler)
+        {
+            return factory.ConnectionFactory.ExecuteWithTransactionAsync(state, factory.IsolationLevel, factory.ShutdownToken, handler);
         }
         
         public static async Task<T> ExecuteWithTransactionAsync<TState,T>(

--- a/src/Akka.Persistence.Sql/Query/Dao/BaseByteReadArrayJournalDao.cs
+++ b/src/Akka.Persistence.Sql/Query/Dao/BaseByteReadArrayJournalDao.cs
@@ -84,7 +84,9 @@ namespace Akka.Persistence.Sql.Query.Dao
             {
                 TagMode.Csv => AsyncSource<JournalRow>
                     .FromEnumerable(
-                        new { args= new QueryArgs(offset,maxOffset,maxTake,tag,TagMode.Csv), _connectionFactory = ConnectionFactory },
+                        new { args= new QueryArgs(offset,maxOffset,maxTake,
+                            $"{separator}{tag}{separator}"
+                            ,TagMode.Csv), _connectionFactory = ConnectionFactory },
                         async input =>
                         {
                             //var tagValue = input.tag;

--- a/src/Akka.Persistence.Sql/Query/Dao/DbStateHolder.cs
+++ b/src/Akka.Persistence.Sql/Query/Dao/DbStateHolder.cs
@@ -1,0 +1,36 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="DbStateHolder.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System.Data;
+using System.Threading;
+using Akka.Persistence.Sql.Config;
+using Akka.Persistence.Sql.Db;
+
+namespace Akka.Persistence.Sql.Query.Dao
+{
+    /// <summary>
+    /// Used to help improve capture usage and ease composition via extension methods.
+    /// </summary>
+    internal class DbStateHolder
+    {
+        public readonly AkkaPersistenceDataConnectionFactory ConnectionFactory;
+        public readonly IsolationLevel IsolationLevel;
+        public readonly CancellationToken ShutdownToken;
+        public readonly TagMode Mode;
+        public DbStateHolder(
+            AkkaPersistenceDataConnectionFactory connectionFactory,
+            IsolationLevel isolationLevel, 
+            CancellationToken shutdownToken, 
+            TagMode mode
+        )
+        {
+            ConnectionFactory = connectionFactory;
+            IsolationLevel = isolationLevel;
+            ShutdownToken = shutdownToken;
+            Mode = mode;
+        }
+    }
+}

--- a/src/Akka.Persistence.Sql/Query/Dao/DbStateHolder.cs
+++ b/src/Akka.Persistence.Sql/Query/Dao/DbStateHolder.cs
@@ -14,7 +14,7 @@ namespace Akka.Persistence.Sql.Query.Dao
     /// <summary>
     /// Used to help improve capture usage and ease composition via extension methods.
     /// </summary>
-    internal class DbStateHolder
+    internal sealed class DbStateHolder
     {
         public readonly AkkaPersistenceDataConnectionFactory ConnectionFactory;
         public readonly IsolationLevel IsolationLevel;

--- a/src/Akka.Persistence.Sql/Query/Dao/QueryArgs.cs
+++ b/src/Akka.Persistence.Sql/Query/Dao/QueryArgs.cs
@@ -1,0 +1,32 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="QueryArgs.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Persistence.Sql.Config;
+
+namespace Akka.Persistence.Sql.Query.Dao
+{
+    internal readonly struct QueryArgs
+    {
+        public readonly long Offset;
+        public readonly long MaxOffset;
+        public readonly int Max;
+        public readonly string Tag;
+        public readonly TagMode TagMode;
+            
+        public QueryArgs(long offset, long maxOffset, int max, string tag, TagMode tagMode)
+        {
+            Offset = offset;
+            MaxOffset = maxOffset;
+            Max = max;
+            Tag = tag;
+            TagMode= tagMode;
+        }
+
+        public QueryArgs(long offset, long maxOffset, int max, TagMode tagMode) : this(offset, maxOffset, max, null!,tagMode)
+        {
+        }
+    }
+}

--- a/src/Akka.Persistence.Sql/Query/Dao/QueryArgs.cs
+++ b/src/Akka.Persistence.Sql/Query/Dao/QueryArgs.cs
@@ -13,8 +13,8 @@ namespace Akka.Persistence.Sql.Query.Dao
         public readonly long Offset;
         public readonly long MaxOffset;
         public readonly int Max;
+        public readonly TagMode Mode;
         public readonly string Tag;
-        public readonly TagMode TagMode;
             
         public QueryArgs(long offset, long maxOffset, int max, string tag, TagMode tagMode)
         {
@@ -22,7 +22,7 @@ namespace Akka.Persistence.Sql.Query.Dao
             MaxOffset = maxOffset;
             Max = max;
             Tag = tag;
-            TagMode= tagMode;
+            Mode= tagMode;
         }
 
         public QueryArgs(long offset, long maxOffset, int max, TagMode tagMode) : this(offset, maxOffset, max, null!,tagMode)

--- a/src/Akka.Persistence.Sql/Query/Dao/QueryArgs.cs
+++ b/src/Akka.Persistence.Sql/Query/Dao/QueryArgs.cs
@@ -13,19 +13,17 @@ namespace Akka.Persistence.Sql.Query.Dao
         public readonly long Offset;
         public readonly long MaxOffset;
         public readonly int Max;
-        public readonly TagMode Mode;
         public readonly string Tag;
             
-        public QueryArgs(long offset, long maxOffset, int max, string tag, TagMode tagMode)
+        public QueryArgs(long offset, long maxOffset, int max, string tag)
         {
             Offset = offset;
             MaxOffset = maxOffset;
             Max = max;
             Tag = tag;
-            Mode= tagMode;
         }
 
-        public QueryArgs(long offset, long maxOffset, int max, TagMode tagMode) : this(offset, maxOffset, max, null!,tagMode)
+        public QueryArgs(long offset, long maxOffset, int max) : this(offset, maxOffset, max, null!)
         {
         }
     }


### PR DESCRIPTION
May help with #346 

## Changes

- Fixes missing `TAKE` on EventsByTag Query for Tag table case.
- Provides overload for `ExecuteInTransactionAsync` that takes input state to minimize captures
- Fixed a few spots where we weren't using capture-minimizing APIs completely
- Tried to do a few other capture related optimizations and remove a double-prop access on read paths.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).

### Benchmarks

Will see what I can do...