### PR TITLE
use plugin identifier instead of hardcoded 'sql'

### DIFF
--- a/src/Akka.Persistence.Sql.Hosting.Tests/JournalSettingsSpec.cs
+++ b/src/Akka.Persistence.Sql.Hosting.Tests/JournalSettingsSpec.cs
@@ -128,12 +128,13 @@ akka.persistence.journal.sql {
             };
 
             var fullConfig = opt.ToConfig();
+            
             var journalConfig = fullConfig
                 .GetConfig("akka.persistence.journal.custom")
                 .WithFallback(SqlPersistence.DefaultJournalConfiguration);
             var config = new JournalConfig(journalConfig);
 
-            fullConfig.GetTimeSpan("akka.persistence.query.journal.sql.refresh-interval").Should().Be(5.Seconds());
+            fullConfig.GetTimeSpan("akka.persistence.query.journal.custom.refresh-interval").Should().Be(5.Seconds());
 
             config.AutoInitialize.Should().BeFalse();
             config.ConnectionString.Should().Be("a");

--- a/src/Akka.Persistence.Sql.Hosting.Tests/SqlEndToEndSpec.cs
+++ b/src/Akka.Persistence.Sql.Hosting.Tests/SqlEndToEndSpec.cs
@@ -40,7 +40,8 @@ namespace Akka.Persistence.Sql.Hosting.Tests
         {
             builder.WithSqlPersistence(
                     connectionString: _fixture.ConnectionString,
-                    providerName: _fixture.ProviderName)
+                    providerName: _fixture.ProviderName,
+                    pluginIdentifier : _fixture.PluginIdentifier)
                 .StartActors(
                     (system, registry) =>
                     {
@@ -77,11 +78,11 @@ namespace Akka.Persistence.Sql.Hosting.Tests
 
             // validate configs
             var config = Sys.Settings.Config;
-            config.GetString("akka.persistence.journal.plugin").Should().Be("akka.persistence.journal.sql");
-            config.GetString("akka.persistence.snapshot-store.plugin").Should().Be("akka.persistence.snapshot-store.sql");
+            config.GetString("akka.persistence.journal.plugin").Should().Be($"akka.persistence.journal.{ _fixture.PluginIdentifier}");
+            config.GetString("akka.persistence.snapshot-store.plugin").Should().Be($"akka.persistence.snapshot-store.{_fixture.PluginIdentifier}");
 
             // validate that query is working
-            var readJournal = Sys.ReadJournalFor<SqlReadJournal>("akka.persistence.query.journal.sql");
+            var readJournal = Sys.ReadJournalFor<SqlReadJournal>($"akka.persistence.query.journal.{ _fixture.PluginIdentifier}");
             var source = readJournal.AllEvents(Offset.NoOffset());
             var probe = source.RunWith(this.SinkProbe<EventEnvelope>(), Sys.Materializer());
             probe.Request(2);

--- a/src/Akka.Persistence.Sql.Hosting/SqlJournalOptions.cs
+++ b/src/Akka.Persistence.Sql.Hosting/SqlJournalOptions.cs
@@ -156,7 +156,7 @@ namespace Akka.Persistence.Sql.Hosting
 
             if (IsDefaultPlugin)
             {
-                sb.AppendLine("akka.persistence.query.journal.sql {");
+                sb.AppendLine($"akka.persistence.query.journal.{Identifier} {{");
                 sb.AppendLine($"connection-string = {ConnectionString.ToHocon()}");
                 sb.AppendLine($"provider-name = {ProviderName.ToHocon()}");
                 
@@ -178,7 +178,7 @@ namespace Akka.Persistence.Sql.Hosting
             }
 
             if (QueryRefreshInterval is not null)
-                sb.AppendLine($"akka.persistence.query.journal.sql.refresh-interval = {QueryRefreshInterval.ToHocon()}");
+                sb.AppendLine($"akka.persistence.query.journal.{Identifier}.refresh-interval = {QueryRefreshInterval.ToHocon()}");
 
             return sb;
         }

--- a/src/Akka.Persistence.Sql.Tests.Common/Containers/SqliteContainer.cs
+++ b/src/Akka.Persistence.Sql.Tests.Common/Containers/SqliteContainer.cs
@@ -26,6 +26,8 @@ namespace Akka.Persistence.Sql.Tests.Common.Containers
         public string ContainerName => string.Empty;
 
         public string ProviderName => LinqToDB.ProviderName.SQLiteClassic;
+        
+        public string PluginIdentifier => "sqlite";
 
         public event EventHandler<OutputReceivedArgs>? OnStdOut;
 


### PR DESCRIPTION
Fixes #358

## Changes

Use plugin identifier from the hosting options constructor instead of hard-coded `sql`

## Checklist

### Latest `dev` Benchmarks 

I don't expect this change to have any performance implications 
 
### This PR's Benchmarks

I don't expect this change to have any performance implications 
