### PR TITLE
added v1.5.27 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 * [Bump Akka to 1.5.27.1](https://github.com/akkadotnet/akka.net/releases/tag/1.5.27.1)
 * [Bump Akka.Hosting to v1.5.27](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.27)
 * [Resolved: Auto initialization of tables isn't supported from the read journal side.](https://github.com/akkadotnet/Akka.Persistence.Sql/issues/344)
+* [Add EventEnvelope Tags support on queries](https://github.com/akkadotnet/Akka.Persistence.Sql/pull/426)
 
 #### 1.5.26 July 9th 2024 ####
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+#### 1.5.27 July 30th 2024 ####
+
+* [Bump Akka to 1.5.27.1](https://github.com/akkadotnet/akka.net/releases/tag/1.5.27.1)
+* [Bump Akka.Hosting to v1.5.27](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.27)
+* [Resolved: Auto initialization of tables isn't supported from the read journal side.](https://github.com/akkadotnet/Akka.Persistence.Sql/issues/344)
+
 #### 1.5.26 July 9th 2024 ####
 
 * [Bump AkkaVersion to 1.5.26](https://github.com/akkadotnet/akka.net/releases/tag/1.5.26)

--- a/src/Directory.Generated.props
+++ b/src/Directory.Generated.props
@@ -1,11 +1,8 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.5.13</VersionPrefix>
-    <PackageReleaseNotes>[Update Akka.NET to 1.5.13](https://github.com/akkadotnet/akka.net/releases/tag/1.5.13)
-[Fix missing Persistence.Query configuration in legacy HOCON configuration mode](https://github.com/akkadotnet/Akka.Persistence.Sql/pull/317)
-[Bump Akka.Hosting version to 1.5.12.1](https://github.com/akkadotnet/Akka.Persistence.Sql/pull/312)
-[Bump Language.Ext.Core version to 4.4.4](https://github.com/akkadotnet/Akka.Persistence.Sql/pull/315)
-[Bump System.Reactive.Linq version to 6.0.0](https://github.com/akkadotnet/Akka.Persistence.Sql/pull/260)
-[Bump linq2db version to 5.2.2](https://github.com/akkadotnet/Akka.Persistence.Sql/pull/266)</PackageReleaseNotes>
+    <VersionPrefix>1.5.27</VersionPrefix>
+    <PackageReleaseNotes>* [Bump Akka to 1.5.27.1](https://github.com/akkadotnet/akka.net/releases/tag/1.5.27.1)
+* [Bump Akka.Hosting to v1.5.27](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.27)
+* [Resolved: Auto initialization of tables isn't supported from the read journal side.](https://github.com/akkadotnet/Akka.Persistence.Sql/issues/344)</PackageReleaseNotes>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
#### 1.5.27 July 30th 2024 ####

* [Bump Akka to 1.5.27.1](https://github.com/akkadotnet/akka.net/releases/tag/1.5.27.1)
* [Bump Akka.Hosting to v1.5.27](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.27)
* [Resolved: Auto initialization of tables isn't supported from the read journal side.](https://github.com/akkadotnet/Akka.Persistence.Sql/issues/344)
* [Add EventEnvelope Tags support on queries](https://github.com/akkadotnet/Akka.Persistence.Sql/pull/426)