### PR TITLE
WIP Snapshot Load Batch Queue

### DIFF
--- a/src/Akka.Persistence.Sql/Config/SnapshotConfig.cs
+++ b/src/Akka.Persistence.Sql/Config/SnapshotConfig.cs
@@ -39,7 +39,10 @@ namespace Akka.Persistence.Sql.Config
             WarnOnAutoInitializeFail = config.GetBoolean("warn-on-auto-init-fail");
             ReadIsolationLevel = config.GetIsolationLevel("read-isolation-level");
             WriteIsolationLevel = config.GetIsolationLevel("write-isolation-level");
+            MaxSubStreamsForReads = config.GetInt("max-substreams-for-reads", 8);
+            MaxBatchPerSubStreamRead = config.GetInt("max-batch-per-substream-read", 25);
         }
+
 
         public string UseSharedDb { get; }
 
@@ -67,5 +70,8 @@ namespace Akka.Persistence.Sql.Config
         public IsolationLevel WriteIsolationLevel { get; }
 
         public IsolationLevel ReadIsolationLevel { get; }
+        public int MaxSubStreamsForReads { get; }
+        
+        public int MaxBatchPerSubStreamRead { get; }
     }
 }

--- a/src/Akka.Persistence.Sql/Snapshot/ByteArraySnapshotDao.cs
+++ b/src/Akka.Persistence.Sql/Snapshot/ByteArraySnapshotDao.cs
@@ -5,20 +5,49 @@
 // -----------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using Akka.Event;
 using Akka.Persistence.Sql.Config;
 using Akka.Persistence.Sql.Db;
 using Akka.Persistence.Sql.Extensions;
 using Akka.Streams;
+using Akka.Streams.Dsl;
 using Akka.Util;
 using LinqToDB;
+using LinqToDB.Tools;
 
 namespace Akka.Persistence.Sql.Snapshot
 {
+    public class LatestSnapRequestEntry
+    {
+        public LatestSnapRequestEntry(string persistenceId)
+        {
+            PersistenceId = persistenceId;
+            TCS = new TaskCompletionSource<Option<SelectedSnapshot>>(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        public readonly string PersistenceId;
+        public readonly TaskCompletionSource<Option<SelectedSnapshot>> TCS;
+    }
+
+    public class QueryLatestSnapSet
+    {
+        public readonly Dictionary<string, List<TaskCompletionSource<Option<SelectedSnapshot>>>> Entries = new();
+
+        public void Add(LatestSnapRequestEntry entry)
+        {
+            if (Entries.TryGetValue(entry.PersistenceId, out var item) == false)
+            {
+                item = Entries[entry.PersistenceId] = new List<TaskCompletionSource<Option<SelectedSnapshot>>>();
+            }
+            item.Add(entry.TCS);
+        }
+    }
     public class ByteArraySnapshotDao : ISnapshotDao
     {
         private readonly AkkaPersistenceDataConnectionFactory _connectionFactory;
@@ -29,6 +58,8 @@ namespace Akka.Persistence.Sql.Snapshot
         private readonly CancellationTokenSource _shutdownCts;
         private readonly SnapshotConfig _snapshotConfig;
         private readonly IsolationLevel _writeIsolationLevel;
+        private readonly Channel<LatestSnapRequestEntry> _pendingLatestChannel;
+        private readonly Task<Done> _latestSnapStream;
 
         public ByteArraySnapshotDao(
             AkkaPersistenceDataConnectionFactory connectionFactory,
@@ -48,6 +79,171 @@ namespace Akka.Persistence.Sql.Snapshot
             _readIsolationLevel = snapshotConfig.ReadIsolationLevel;
 
             _shutdownCts = new CancellationTokenSource();
+            _pendingLatestChannel = Channel.CreateUnbounded<LatestSnapRequestEntry>();
+            _latestSnapStream = Source.ChannelReader(_pendingLatestChannel.Reader).BatchWeighted(
+                    50,
+                    a => 1,
+                    e =>
+                    {
+                        var a = new QueryLatestSnapSet();
+                        a.Add(e);
+                        return a;
+                    },
+                    (a, e) =>
+                    {
+                        a.Add(e);
+                        return a;
+                    })
+                .SelectAsync(
+                    1,
+                    async a =>
+                    {
+
+                        using (var connection = _connectionFactory.GetConnection())
+                        {
+                            if (connection.UseDateTime)
+                            {
+                                //TODO: Make this actually work because at some point we split tables, may need to generalize.
+                                var set = await connection.GetTable<LongSnapshotRow>()
+                                    .Where(r => r.PersistenceId.In(a.Entries.Keys))
+                                    .Select(
+                                        r => new
+                                        {
+                                            Created = r.Created,
+                                            PersistenceId = r.PersistenceId,
+                                            SequenceNumber = r.SequenceNumber,
+                                            Manifest = r.Manifest,
+                                            Payload = r.Payload,
+                                            SerializerId = r.SerializerId,
+                                            RowNum = LinqToDB.Sql.Ext.Rank().Over().PartitionBy(r.PersistenceId).OrderByDesc(r.SequenceNumber).ToValue()
+                                        })
+                                    .Where(r => r.RowNum == 1)
+                                    .Select(
+                                        r => new LongSnapshotRow()
+                                        {
+                                            Created = r.Created,
+                                            PersistenceId = r.PersistenceId,
+                                            SequenceNumber = r.SequenceNumber,
+                                            Manifest = r.Manifest,
+                                            Payload = r.Payload,
+                                            SerializerId = r.SerializerId,
+                                        }).ToListAsync();
+                                return (a, set, err: (Exception?)null);
+                            }
+                            else
+                            {
+                                try
+                                {
+                                    var set = await connection.GetTable<LongSnapshotRow>()
+                                        .Where(r => r.PersistenceId.In(a.Entries.Keys))
+                                        .Select(
+                                            r => new
+                                            {
+                                                Created = r.Created,
+                                                PersistenceId = r.PersistenceId,
+                                                SequenceNumber = r.SequenceNumber,
+                                                Manifest = r.Manifest,
+                                                Payload = r.Payload,
+                                                SerializerId = r.SerializerId,
+                                                RowNum = LinqToDB.Sql.Ext.Rank().Over().PartitionBy(r.PersistenceId).OrderByDesc(r.SequenceNumber).ToValue()
+                                            })
+                                        .Where(r => r.RowNum == 1)
+                                        .Select(
+                                            r => new LongSnapshotRow()
+                                            {
+                                                Created = r.Created,
+                                                PersistenceId = r.PersistenceId,
+                                                SequenceNumber = r.SequenceNumber,
+                                                Manifest = r.Manifest,
+                                                Payload = r.Payload,
+                                                SerializerId = r.SerializerId,
+                                            }).ToListAsync();
+                                    return (a, set, err: (Exception?)null);
+                                }
+                                catch (Exception ex)
+                                {
+                                    return (a, null, err: ex);
+                                }
+                            }
+                        }
+                    }).Async().Select(
+                    (ab) =>
+                    {
+                        var (a, b, c) = ab;
+                        if (c != null)
+                        {
+                            foreach (var taskCompletionSourcese in a!.Entries.Values.ToList())
+                            {
+                                foreach (var taskCompletionSource in taskCompletionSourcese)
+                                {
+                                    taskCompletionSource.TrySetException(c);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            //TODO: Pool this set:
+                            var tempSet = new List<string>();
+                            if (b.Count == 0)
+                            {
+                                foreach (var keyValuePair in a.Entries)
+                                {
+                                    foreach (var taskCompletionSource in keyValuePair.Value)
+                                    {
+                                        taskCompletionSource.TrySetResult(Option<SelectedSnapshot>.None);
+                                    }
+                                }
+                            }
+                            foreach (var result in b)
+                            {
+                                if (a.Entries.TryGetValue(result.PersistenceId, out var toSet))
+                                {
+                                    try
+                                    {
+                                        var res = _longSerializer.Deserialize(result);
+                                        if (res.IsSuccess)
+                                        {
+                                            foreach (var taskCompletionSource in toSet)
+                                            {
+                                                taskCompletionSource.TrySetResult(res.Success);
+                                            }
+                                        }
+                                        else
+                                        {
+                                            foreach (var taskCompletionSource in toSet)
+                                            {
+                                                taskCompletionSource.TrySetException(res.Failure.Value);
+                                            }
+                                        }
+                                    }
+                                    catch (Exception e)
+                                    {
+                                        foreach (var taskCompletionSource in toSet)
+                                        {
+                                            taskCompletionSource.TrySetException(e);
+                                        }
+                                    }
+                                }
+                                else
+                                {
+                                    tempSet.Add(result.PersistenceId);
+                                }
+
+                                foreach (var se in tempSet)
+                                {
+                                    if (a.Entries.TryGetValue(se, out var setNo))
+                                    {
+                                        foreach (var taskCompletionSource in setNo)
+                                        {
+                                            taskCompletionSource.TrySetResult(Option<SelectedSnapshot>.None);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        return Done.Instance;
+                    }).RunWith(Sink.Ignore<Done>(), materializer);
         }
 
         public async Task DeleteAllSnapshotsAsync(
@@ -182,41 +378,50 @@ namespace Akka.Persistence.Sql.Snapshot
                 });
         }
 
-        public async Task<Option<SelectedSnapshot>> LatestSnapshotAsync(
+        public Task<Option<SelectedSnapshot>> LatestSnapshotAsync(
             string persistenceId,
             CancellationToken cancellationToken = default)
         {
-            var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);
-            return await _connectionFactory.ExecuteWithTransactionAsync(
-                _readIsolationLevel,
-                cts.Token,
-                async (connection, token) =>
-                {
-                    if (connection.UseDateTime)
-                    {
-                        var row = await connection
-                            .GetTable<DateTimeSnapshotRow>()
-                            .Where(r => r.PersistenceId == persistenceId)
-                            .OrderByDescending(t => t.SequenceNumber)
-                            .FirstOrDefaultAsync(token);
-
-                        return row != null
-                            ? _dateTimeSerializer.Deserialize(row).Get()
-                            : Option<SelectedSnapshot>.None;
-                    }
-                    else
-                    {
-                        var row = await connection
-                            .GetTable<LongSnapshotRow>()
-                            .Where(r => r.PersistenceId == persistenceId)
-                            .OrderByDescending(t => t.SequenceNumber)
-                            .FirstOrDefaultAsync(token);
-
-                        return row != null
-                            ? _longSerializer.Deserialize(row).Get()
-                            : Option<SelectedSnapshot>.None;
-                    }
-                });
+            var req = new LatestSnapRequestEntry(persistenceId);
+            if (_pendingLatestChannel.Writer.TryWrite(req))
+            {
+                return req.TCS.Task;
+            }
+            else
+            {
+                return Task.FromException<Option<SelectedSnapshot>>(new Exception("Queue is closed, System may be shutting down!"));
+            }
+            //var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);
+            //return await _connectionFactory.ExecuteWithTransactionAsync(
+            //    _readIsolationLevel,
+            //    cts.Token,
+            //    async (connection, token) =>
+            //    {
+            //        if (connection.UseDateTime)
+            //        {
+            //            var row = await connection
+            //                .GetTable<DateTimeSnapshotRow>()
+            //                .Where(r => r.PersistenceId == persistenceId)
+            //                .OrderByDescending(t => t.SequenceNumber)
+            //                .FirstOrDefaultAsync(token);
+            //
+            //            return row != null
+            //                ? _dateTimeSerializer.Deserialize(row).Get()
+            //                : Option<SelectedSnapshot>.None;
+            //        }
+            //        else
+            //        {
+            //            var row = await connection
+            //                .GetTable<LongSnapshotRow>()
+            //                .Where(r => r.PersistenceId == persistenceId)
+            //                .OrderByDescending(t => t.SequenceNumber)
+            //                .FirstOrDefaultAsync(token);
+            //
+            //            return row != null
+            //                ? _longSerializer.Deserialize(row).Get()
+            //                : Option<SelectedSnapshot>.None;
+            //        }
+            //    });
         }
 
         public async Task<Option<SelectedSnapshot>> SnapshotForMaxTimestampAsync(

--- a/src/Akka.Persistence.Sql/Snapshot/ByteArraySnapshotDao.cs
+++ b/src/Akka.Persistence.Sql/Snapshot/ByteArraySnapshotDao.cs
@@ -78,10 +78,7 @@ namespace Akka.Persistence.Sql.Snapshot
             item.Add(entry);
         }
     }
-            }
-            item.Add(entry.TCS);
-        }
-    }
+
     public class ByteArraySnapshotDao : ISnapshotDao
     {
         private readonly AkkaPersistenceDataConnectionFactory _connectionFactory;

--- a/src/Akka.Persistence.Sql/Snapshot/ByteArraySnapshotDao.cs
+++ b/src/Akka.Persistence.Sql/Snapshot/ByteArraySnapshotDao.cs
@@ -23,6 +23,15 @@ using LinqToDB.Tools;
 
 namespace Akka.Persistence.Sql.Snapshot
 {
+    public static class SubFlowExtensions
+    {
+        public static Source<TOut, TMat> MergeSubStreamsAsSource<TOut, TMat,
+            TClosed>(this SubFlow<TOut, TMat, TClosed> subFlow)
+        {
+            return (Source<TOut,TMat>)(subFlow.MergeSubstreams());
+        }
+    }
+
     public class LatestSnapRequestEntry
     {
         public LatestSnapRequestEntry(string persistenceId)
@@ -265,7 +274,7 @@ namespace Akka.Persistence.Sql.Snapshot
                         }
 
                         return Done.Instance;
-                    }).RunWith(Sink.Ignore<Done>(), materializer);
+                    }).MergeSubStreamsAsSource().RunWith(Sink.Ignore<Done>(), materializer);
         }
 
         public async Task DeleteAllSnapshotsAsync(

--- a/src/Akka.Persistence.Sql/Snapshot/ByteArraySnapshotDao.cs
+++ b/src/Akka.Persistence.Sql/Snapshot/ByteArraySnapshotDao.cs
@@ -204,8 +204,8 @@ namespace Akka.Persistence.Sql.Snapshot
                                 }
                             }
                         }
-                    }).Select(
-                    (ab) =>
+                    }).SelectAsync(1,
+                    async (ab) =>
                     {
                         var (a, b, c) = ab;
                         if (c != null)

--- a/src/Akka.Persistence.Sql/snapshot.conf
+++ b/src/Akka.Persistence.Sql/snapshot.conf
@@ -49,6 +49,14 @@
       #   https://learn.microsoft.com/en-us/dotnet/api/system.data.isolationlevel?#fields
       # Valid values: "read-committed", "read-uncommitted", "repeatable-read", "serializable", "snapshot", or "unspecified"
       write-isolation-level = unspecified
+      
+      # The max number of substreams for reads.
+      # Ideally a power of 2.
+      max-substreams-for-reads = 16
+      
+      # The max number of reads per substream.
+      # For smaller snapshots and overall 'grouping', one can use a larger batch for throughput.
+      max-batch-per-substream-read = 25
 
       default {
         schema-name = null


### PR DESCRIPTION
Will not fix #432 but will probably help on some level

## Changes

This PR changes Getting default snapshot store load operation of getting the 'newest' snapshot (i.e. not caring about SEQ or timestamp) from being a multitude of snapshot requests into a queue, similar to how we handle Write requests on Journals.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [ ] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [ ] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [ ] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed, if any.
* [ ] I have added website documentation for this feature.

### Latest `dev` Benchmarks 

We don't really have benchmarks against snapshot. if someone wants to add I'm happy to rebase/etc and test

### This PR's Benchmarks

See above.


### Stuff I still need to validate:

The main difference of course is that this is a -read- and more complex than a sequence number [0], and as such I did take the -small- step of splitting out deserialization from the main read logic as a separate stage.

This may have a minor performance impact on cases where only a small number of actors are recovering, however it should greatly improve recovery performance under load. Overall intent is to have the numbers be configurable for a given case (maybe we have a fallback switch for those who want old behavior?)

[0] - Hint hint ;)