### PR TITLE
Adds DataOptionsSetup

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,9 @@ var host = new HostBuilder()
         });
     })
 ```
-
-You must always provide a `connectionString` and a `providerName`, even if you provide a `DataOptions` object. 
-Please consult the Linq2Db documentation for more information on how to configure a valid `DataOptions` object. 
-The `MappingSchema` will always be overridden by Akka.Persistence.Sql.
+If `dataOptions` are provided, you must give enough information for linq2db to connect to the database.
+This includes setting the connection string and provider name again, if needed in your use case. 
+Please consult the Linq2Db documentation for more information on how to configure a valid `DataOptions` object.  `MappingSchema` and `RetryPolicy` will always be overridden by Akka.Persistence.Sql.
 
 ## The Classic Way, Using HOCON
 

--- a/README.md
+++ b/README.md
@@ -53,22 +53,21 @@ var host = new HostBuilder()
 ```
 
 You can also provide your own [`LinqToDb.DataOptions`](https://linq2db.github.io/api/linq2db/LinqToDB.DataOptions.html) object for a more advanced configuration.
-Assuming a setup with a custom connection factory with Npgsql: 
-Ï
+Assuming a setup with a custom `NpgsqlDataSource`:
 ```csharp
-var npgsqlDataSource = new NpgsqlDataSourceBuilder(_myConnectionString)
-    .UsePasswordProvider(stringBuilder => "my dynamic password", null)
-    .Build();
+NpgsqlDataSource dataSource = new NpgsqlDataSourceBuilder(_myConnectionString).Build();
 
-var dataOptions = new DataOptions()
-    .UseConnectionFactory((opt) => npgsqlDataSource.CreateConnection());
+DataOptions dataOptions = new DataOptions()
+    .UseDataProvider(DataConnection.GetDataProvider(ProviderName.PostgreSQL, dataSource.ConnectionString) ?? throw new Exception("Could not get data provider"))
+    .UseProvider(ProviderName.PostgreSQL)
+    .UseConnectionFactory((opt) => dataSource.CreateConnection());
     
 var host = new HostBuilder()
     .ConfigureServices((context, services) => {
         services.AddAkka("my-system-name", (builder, provider) =>
         {
             builder.WithSqlPersistence(
-                connectionString: _myConnectionString,
+                connectionString: dataSource.ConnectionString,
                 providerName: ProviderName.PostgreSQL,
                 dataOptions: dataOptions)
         });

--- a/README.md
+++ b/README.md
@@ -73,9 +73,10 @@ var host = new HostBuilder()
         });
     })
 ```
-If `dataOptions` are provided, you must give enough information for linq2db to connect to the database.
-This includes setting the connection string and provider name again, if needed in your use case. 
-Please consult the Linq2Db documentation for more information on how to configure a valid `DataOptions` object.  `MappingSchema` and `RetryPolicy` will always be overridden by Akka.Persistence.Sql.
+If `dataOptions` are provided, you must supply enough information for linq2db to connect to the database. 
+This includes setting the connection string and provider name again, if necessary for your use case. 
+Please consult the Linq2Db documentation for more details on configuring a valid DataOptions object. 
+Note that `MappingSchema` and `RetryPolicy` will always be overridden by Akka.Persistence.Sql.
 
 ## The Classic Way, Using HOCON
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ var host = new HostBuilder()
         {
             builder.WithSqlPersistence(
                 connectionString: _myConnectionString,
-                providerName: ProviderName.SqlServer2019)
+                providerName: ProviderName.SqlServer2019);
         });
-    })
+    });
 ```
 
 You can also provide your own [`LinqToDb.DataOptions`](https://linq2db.github.io/api/linq2db/LinqToDB.DataOptions.html) object for a more advanced configuration.
@@ -69,9 +69,9 @@ var host = new HostBuilder()
             builder.WithSqlPersistence(
                 connectionString: dataSource.ConnectionString,
                 providerName: ProviderName.PostgreSQL,
-                dataOptions: dataOptions)
+                dataOptions: dataOptions);
         });
-    })
+    });
 ```
 If `dataOptions` are provided, you must supply enough information for linq2db to connect to the database. 
 This includes setting the connection string and provider name again, if necessary for your use case. 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ var host = new HostBuilder()
 
 You must always provide a `connectionString` and a `providerName`, even if you provide a `DataOptions` object. 
 Please consult the Linq2Db documentation for more information on how to configure a valid `DataOptions` object. 
-The `ConnectionOptions.MappingSchema` option will always be overridden by Akka.Persistence.Sql.
+The `MappingSchema` will always be overridden by Akka.Persistence.Sql.
 
 ## The Classic Way, Using HOCON
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,33 @@ var host = new HostBuilder()
     })
 ```
 
+You can also provide your own [`LinqToDb.DataOptions`](https://linq2db.github.io/api/linq2db/LinqToDB.DataOptions.html) object for a more advanced configuration.
+Assuming a setup with a custom connection factory with Npgsql: 
+Ï
+```csharp
+var npgsqlDataSource = new NpgsqlDataSourceBuilder(_myConnectionString)
+    .UsePasswordProvider(stringBuilder => "my dynamic password", null)
+    .Build();
+
+var dataOptions = new DataOptions()
+    .UseConnectionFactory((opt) => npgsqlDataSource.CreateConnection());
+    
+var host = new HostBuilder()
+    .ConfigureServices((context, services) => {
+        services.AddAkka("my-system-name", (builder, provider) =>
+        {
+            builder.WithSqlPersistence(
+                connectionString: _myConnectionString,
+                providerName: ProviderName.PostgreSQL,
+                dataOptions: dataOptions)
+        });
+    })
+```
+
+You must always provide a `connectionString` and a `providerName`, even if you provide a `DataOptions` object. 
+Please consult the Linq2Db documentation for more information on how to configure a valid `DataOptions` object. 
+The `ConnectionOptions.MappingSchema` option will always be overridden by Akka.Persistence.Sql.
+
 ## The Classic Way, Using HOCON
 
 These are the minimum HOCON configuration you need to start using Akka.Persistence.Sql:

--- a/README.md
+++ b/README.md
@@ -66,10 +66,7 @@ var host = new HostBuilder()
     .ConfigureServices((context, services) => {
         services.AddAkka("my-system-name", (builder, provider) =>
         {
-            builder.WithSqlPersistence(
-                connectionString: dataSource.ConnectionString,
-                providerName: ProviderName.PostgreSQL,
-                dataOptions: dataOptions);
+            builder.WithSqlPersistence(dataOptions);
         });
     });
 ```

--- a/src/Akka.Persistence.Sql.Hosting.Tests/CustomSqlDataOptionsEndToEndSpec.cs
+++ b/src/Akka.Persistence.Sql.Hosting.Tests/CustomSqlDataOptionsEndToEndSpec.cs
@@ -1,0 +1,287 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="SqlEndToEndSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System.Data.SQLite;
+using Akka.Actor;
+using Akka.Hosting;
+using Akka.Persistence.Query;
+using Akka.Persistence.Sql.Config;
+using Akka.Persistence.Sql.Query;
+using Akka.Persistence.Sql.Tests.Common.Containers;
+using Akka.Streams;
+using Akka.Streams.TestKit;
+using FluentAssertions;
+using LanguageExt.UnitsOfMeasure;
+using LinqToDB;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Sql.Hosting.Tests
+{
+    public class CustomSqlDataOptionsEndToEndSpec : Akka.Hosting.TestKit.TestKit, IClassFixture<SqliteContainer>
+    {
+        private const string GetAll = "getAll";
+        private const string Ack = "ACK";
+        private const string SnapshotAck = "SnapACK";
+        private const string PId = "ac1";
+
+        private readonly SqliteContainer _fixture;
+        private readonly DataOptions _dataOptions;
+
+        public CustomSqlDataOptionsEndToEndSpec(ITestOutputHelper output, SqliteContainer fixture) : base(nameof(SqlEndToEndSpec), output)
+        {
+            _fixture = fixture;
+            _dataOptions = new DataOptions().UseConnectionString(_fixture.ProviderName, _fixture.ConnectionString);
+        }
+
+        protected override async Task BeforeTestStart()
+        {
+            await base.BeforeTestStart();
+            await _fixture.InitializeAsync();
+        }
+
+        protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+        {
+            builder
+                .WithSqlPersistence(_dataOptions)
+                .WithSqlPersistence(
+                    journal =>
+                    {
+                        journal.IsDefaultPlugin = false;
+                        journal.Identifier = "custom";
+                        journal.DatabaseOptions = JournalDatabaseOptions.Default;
+                        journal.DatabaseOptions.JournalTable!.TableName = "journal2";
+                        journal.DatabaseOptions.MetadataTable!.TableName = "journal_metadata2";
+                        journal.DatabaseOptions.TagTable!.TableName = "tags2";
+                        journal.DataOptions = _dataOptions;
+                    },
+                    snapshot =>
+                    {
+                        snapshot.IsDefaultPlugin = false;
+                        snapshot.Identifier = "custom";
+                        snapshot.DatabaseOptions = SnapshotDatabaseOptions.Default;
+                        snapshot.DatabaseOptions.SnapshotTable!.TableName = "snapshot2";
+                        snapshot.DataOptions = _dataOptions;
+                    })
+                .StartActors(
+                    (system, registry) =>
+                    {
+                        var myActor = system.ActorOf(Props.Create(() => new MyPersistenceActor(PId)), "default");
+                        registry.Register<MyPersistenceActor>(myActor);
+                        
+                        myActor = system.ActorOf(Props.Create(() => new MyCustomPersistenceActor(PId)), "custom");
+                        registry.Register<MyCustomPersistenceActor>(myActor);
+                    });
+        }
+
+        [Fact]
+        public async Task Should_Start_ActorSystem_wth_Sql_Persistence()
+        {
+            var timeout = 3.Seconds();
+
+            #region Default SQL plugin
+            
+            // arrange
+            var myPersistentActor = await ActorRegistry.GetAsync<MyPersistenceActor>();
+
+            // act
+            myPersistentActor.Tell(1, TestActor);
+            ExpectMsg<string>(Ack);
+            myPersistentActor.Tell(2, TestActor);
+            ExpectMsg<string>(Ack);
+            ExpectMsg<string>(SnapshotAck);
+            var snapshot = await myPersistentActor.Ask<int[]>(GetAll, timeout);
+
+            // assert
+            snapshot.Should().BeEquivalentTo(new[] { 1, 2 });
+            
+            #endregion
+
+            #region Custom SQL plugin
+            
+            // arrange
+            var customMyPersistentActor = await ActorRegistry.GetAsync<MyCustomPersistenceActor>();
+
+            // act
+            customMyPersistentActor.Tell(1, TestActor);
+            ExpectMsg<string>(Ack);
+            customMyPersistentActor.Tell(2, TestActor);
+            ExpectMsg<string>(Ack);
+            ExpectMsg<string>(SnapshotAck);
+            var customSnapshot = await customMyPersistentActor.Ask<int[]>(GetAll, timeout);
+
+            // assert
+            customSnapshot.Should().BeEquivalentTo(new[] { 1, 2 });
+            
+            #endregion
+            
+            
+            // kill + recreate actor with same PersistentId
+            await myPersistentActor.GracefulStop(timeout);
+            var myPersistentActor2 = Sys.ActorOf(Props.Create(() => new MyPersistenceActor(PId)));
+
+            var snapshot2 = await myPersistentActor2.Ask<int[]>(GetAll, timeout);
+            snapshot2.Should().BeEquivalentTo(new[] { 1, 2 });
+
+            await customMyPersistentActor.GracefulStop(timeout);
+            var customMyPersistentActor2 = Sys.ActorOf(Props.Create(() => new MyCustomPersistenceActor(PId)));
+
+            var customSnapshot2 = await customMyPersistentActor2.Ask<int[]>(GetAll, timeout);
+            customSnapshot2.Should().BeEquivalentTo(new[] { 1, 2 });
+            
+            // validate configs
+            var config = Sys.Settings.Config;
+            config.GetString("akka.persistence.journal.plugin").Should().Be("akka.persistence.journal.sql");
+            config.GetString("akka.persistence.snapshot-store.plugin").Should().Be("akka.persistence.snapshot-store.sql");
+
+            var setupOption = Sys.Settings.Setup.Get<MultiDataOptionsSetup>();
+            setupOption.HasValue.Should().BeTrue();
+            var setup = setupOption.Value;
+            
+            var customJournalConfig = config.GetConfig("akka.persistence.journal.custom");
+            customJournalConfig.Should().NotBeNull();
+            customJournalConfig.GetString("connection-string").Should().Be(string.Empty);
+            customJournalConfig.GetString("provider-name").Should().Be(string.Empty);
+
+            setup.TryGetDataOptionsFor("akka.persistence.journal.custom", out var journalDataOptions).Should().BeTrue();
+            journalDataOptions.Should().Be(_dataOptions);
+
+            var customSnapshotConfig = config.GetConfig("akka.persistence.snapshot-store.custom");
+            customSnapshotConfig.Should().NotBeNull();
+            customSnapshotConfig.GetString("connection-string").Should().Be(string.Empty);
+            customSnapshotConfig.GetString("provider-name").Should().Be(string.Empty);
+
+            setup.TryGetDataOptionsFor("akka.persistence.snapshot-store.custom", out var snapshotDataOptions).Should().BeTrue();
+            snapshotDataOptions.Should().Be(_dataOptions);
+
+            // validate that query is working
+            var readJournal = Sys.ReadJournalFor<SqlReadJournal>("akka.persistence.query.journal.sql");
+            var source = readJournal.AllEvents(Offset.NoOffset());
+            var probe = source.RunWith(this.SinkProbe<EventEnvelope>(), Sys.Materializer());
+            probe.Request(2);
+            probe.ExpectNext<EventEnvelope>(p => p.PersistenceId == PId && p.SequenceNr == 1L && p.Event.Equals(1));
+            probe.ExpectNext<EventEnvelope>(p => p.PersistenceId == PId && p.SequenceNr == 2L && p.Event.Equals(2));
+            await probe.CancelAsync();
+
+            var customReadJournal = Sys.ReadJournalFor<SqlReadJournal>("akka.persistence.query.journal.custom");
+            var customSource = customReadJournal.AllEvents(Offset.NoOffset());
+            var customProbe = customSource.RunWith(this.SinkProbe<EventEnvelope>(), Sys.Materializer());
+            customProbe.Request(2);
+            customProbe.ExpectNext<EventEnvelope>(p => p.PersistenceId == PId && p.SequenceNr == 1L && p.Event.Equals(1));
+            customProbe.ExpectNext<EventEnvelope>(p => p.PersistenceId == PId && p.SequenceNr == 2L && p.Event.Equals(2));
+            await customProbe.CancelAsync();
+
+            // Probe the database directly to make sure that all tables were created properly
+            var tables = await GetTableNamesAsync(_fixture.ConnectionString);
+
+            tables.Should().Contain("journal");
+            tables.Should().Contain("tags");
+            tables.Should().Contain("snapshot");
+            tables.Should().Contain("journal2");
+            tables.Should().Contain("tags2");
+            tables.Should().Contain("snapshot2");
+        }
+
+        private static async Task<string[]> GetTableNamesAsync(string connectionString)
+        {
+            await using var conn = new SQLiteConnection(connectionString);
+            await conn.OpenAsync();
+            
+            var cmd = new SQLiteCommand("SELECT name FROM sqlite_schema WHERE type = 'table' AND name NOT LIKE 'sqlite_%'", conn);
+            var reader = await cmd.ExecuteReaderAsync();
+            var tables = new List<string>();
+            while (await reader.ReadAsync())
+            {
+                tables.Add(reader.GetString(0));
+            }
+            await reader.CloseAsync();
+            
+            return tables.ToArray();
+        }
+
+        private sealed class MyPersistenceActor : ReceivePersistentActor
+        {
+            private List<int> _values = new();
+            private IActorRef? _sender;
+
+            public MyPersistenceActor(string persistenceId)
+            {
+                PersistenceId = persistenceId;
+                JournalPluginId = "akka.persistence.journal.sql";
+                SnapshotPluginId = "akka.persistence.snapshot-store.sql";
+
+                Recover<SnapshotOffer>(offer =>
+                {
+                    if (offer.Snapshot is IEnumerable<int> ints)
+                        _values = new List<int>(ints);
+                });
+
+                Recover<int>(_values.Add);
+
+                Command<int>( i =>
+                {
+                    _sender = Sender;
+                    Persist(
+                        i,
+                        _ =>
+                        {
+                            _values.Add(i);
+                            if (LastSequenceNr % 2 == 0)
+                                SaveSnapshot(_values);
+                            _sender.Tell(Ack);
+                        });
+                });
+
+                Command<string>(str => str.Equals(GetAll), _ => Sender.Tell(_values.ToArray()));
+
+                Command<SaveSnapshotSuccess>(_ => _sender.Tell(SnapshotAck));
+            }
+
+            public override string PersistenceId { get; }
+        }
+        
+        private sealed class MyCustomPersistenceActor : ReceivePersistentActor
+        {
+            private List<int> _values = new();
+            private IActorRef? _sender;
+
+            public MyCustomPersistenceActor(string persistenceId)
+            {
+                PersistenceId = persistenceId;
+                JournalPluginId = "akka.persistence.journal.custom";
+                SnapshotPluginId = "akka.persistence.snapshot-store.custom";
+
+                Recover<SnapshotOffer>(offer =>
+                {
+                    if (offer.Snapshot is IEnumerable<int> ints)
+                        _values = new List<int>(ints);
+                });
+
+                Recover<int>(_values.Add);
+
+                Command<int>( i =>
+                {
+                    _sender = Sender;
+                    Persist(
+                        i,
+                        _ =>
+                        {
+                            _values.Add(i);
+                            if (LastSequenceNr % 2 == 0)
+                                SaveSnapshot(_values);
+                            _sender.Tell(Ack);
+                        });
+                });
+
+                Command<string>(str => str.Equals(GetAll), _ => Sender.Tell(_values.ToArray()));
+
+                Command<SaveSnapshotSuccess>(_ => _sender.Tell(SnapshotAck));
+            }
+
+            public override string PersistenceId { get; }
+        }
+    }
+}

--- a/src/Akka.Persistence.Sql.Hosting.Tests/JournalSettingsSpec.cs
+++ b/src/Akka.Persistence.Sql.Hosting.Tests/JournalSettingsSpec.cs
@@ -55,6 +55,7 @@ namespace Akka.Persistence.Sql.Hosting.Tests
             var actualConfig = config.GetConfig(SqlPersistence.JournalConfigPath);
 
             actualConfig.AssertType(defaultConfig, "class", typeof(SqlWriteJournal));
+            actualConfig.AssertString(defaultConfig, "plugin-id");
             actualConfig.AssertString(defaultConfig, "plugin-dispatcher");
             actualConfig.AssertString(defaultConfig, "connection-string", "a");
             actualConfig.AssertString(defaultConfig, "provider-name", "b");
@@ -87,6 +88,7 @@ namespace Akka.Persistence.Sql.Hosting.Tests
             var actualQueryConfig = config.GetConfig(SqlPersistence.QueryConfigPath);
 
             actualQueryConfig.AssertType(defaultQueryConfig, "class", typeof(SqlReadJournalProvider));
+            actualConfig.AssertString(defaultConfig, "plugin-id");
             actualQueryConfig.AssertString(defaultQueryConfig, "write-plugin", "akka.persistence.journal.sql");
             actualQueryConfig.AssertInt(defaultQueryConfig, "max-buffer-size", 500);
             actualQueryConfig.AssertTimeSpan(defaultQueryConfig, "refresh-interval", 1.Seconds());
@@ -174,6 +176,7 @@ namespace Akka.Persistence.Sql.Hosting.Tests
                     .GetConfig("akka.persistence.journal.custom")
                     .WithFallback(SqlPersistence.DefaultJournalConfiguration));
 
+            journalConfig.PluginId.Should().Be("akka.persistence.journal.custom");
             journalConfig.AutoInitialize.Should().BeFalse();
             journalConfig.ConnectionString.Should().Be("a");
             journalConfig.ProviderName.Should().Be("b");
@@ -222,6 +225,7 @@ namespace Akka.Persistence.Sql.Hosting.Tests
                     .GetConfig("akka.persistence.query.journal.custom")
                     .WithFallback(SqlPersistence.DefaultQueryConfiguration));
 
+            queryConfig.PluginId.Should().Be("akka.persistence.query.journal.custom");
             queryConfig.ConnectionString.Should().Be("a");
             queryConfig.ProviderName.Should().Be("b");
             queryConfig.WritePluginId.Should().Be("akka.persistence.journal.custom");

--- a/src/Akka.Persistence.Sql.Hosting.Tests/SnapshotSettingsSpec.cs
+++ b/src/Akka.Persistence.Sql.Hosting.Tests/SnapshotSettingsSpec.cs
@@ -38,6 +38,7 @@ akka.persistence.snapshot-store.sql {
             actualConfig = actualConfig.GetConfig(SqlPersistence.SnapshotStoreConfigPath);
 
             actualConfig.GetString("connection-string").Should().Be(defaultConfig.GetString("connection-string"));
+            actualConfig.GetString("plugin-id").Should().Be(defaultConfig.GetString("plugin-id"));
             actualConfig.GetString("provider-name").Should().Be(defaultConfig.GetString("provider-name"));
             actualConfig.GetString("table-mapping").Should().Be(defaultConfig.GetString("table-mapping"));
             actualConfig.GetString("serializer").Should().Be(defaultConfig.GetString("serializer"));
@@ -91,6 +92,7 @@ akka.persistence.snapshot-store.sql {
                 .WithFallback(SqlPersistence.DefaultSnapshotConfiguration);
             var config = new SnapshotConfig(snapshotConfig);
 
+            config.PluginId.Should().Be("akka.persistence.snapshot-store.custom");
             config.AutoInitialize.Should().BeFalse();
             config.ConnectionString.Should().Be("a");
             config.ProviderName.Should().Be("b");

--- a/src/Akka.Persistence.Sql.Hosting/HostingExtensions.cs
+++ b/src/Akka.Persistence.Sql.Hosting/HostingExtensions.cs
@@ -32,11 +32,9 @@ namespace Akka.Persistence.Sql.Hosting
         ///     <i>Default</i>: <c>false</c>
         /// </param>
         /// <param name="providerName">
-        ///     <para>
-        ///         A string constant defining the database type to connect to, valid values are defined inside
-        ///         <see cref="LinqToDB.ProviderName" /> static class.
-        ///         Refer to the Members of <see cref="LinqToDB.ProviderName" /> for included providers.
-        ///     </para>
+        ///     A string constant defining the database type to connect to, valid values are defined inside
+        ///     <see cref="LinqToDB.ProviderName" /> static class.
+        ///     Refer to the Members of <see cref="LinqToDB.ProviderName" /> for included providers.
         /// </param>
         /// <param name="mode">
         ///     <para>
@@ -120,37 +118,16 @@ namespace Akka.Persistence.Sql.Hosting
         ///         </item>
         ///     </list>
         /// </param>
-        /// <param name="dataOptions">
-        ///     <para>
-        ///         The custom <see cref="DataOptions"/> used for the connection to the database. If not provided,
-        ///         <see cref="DataOptionsExtensions.UseConnectionString(LinqToDB.DataOptions,string,string)"/> will be used.
-        ///     </para>
-        ///     <para>
-        ///         If provided, you must give enough information for linq2db to connect to the database.
-        ///         This includes setting the connection string and provider name again, if needed in your use case.
-        ///     </para>
-        ///     <para>
-        ///         The following settings will be always overriden by Akka.Persistence.Sql:
-        ///         <list type="number">
-        ///             <item>
-        ///                 MappingSchema
-        ///             </item>
-        ///             <item>
-        ///                 RetryPolicy
-        ///             </item>
-        ///         </list>
-        ///     </para>
-        ///     <para>
-        ///         DataOptions documentation can be read
-        ///         <a href="https://linq2db.github.io/api/linq2db/LinqToDB.DataOptions.html">here</a>
-        ///     </para>
-        /// </param>
         /// <returns>
         ///     The same <see cref="AkkaConfigurationBuilder" /> instance originally passed in.
         /// </returns>
         /// <exception cref="ArgumentOutOfRangeException">
         ///     Thrown when <paramref name="journalBuilder" /> is set and <paramref name="mode" /> is set to
         ///     <see cref="PersistenceMode.SnapshotStore" />
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when <paramref name="connectionString"/> or <paramref name="providerName"/> is null
+        ///     or whitespace
         /// </exception>
         public static AkkaConfigurationBuilder WithSqlPersistence(
             this AkkaConfigurationBuilder builder,
@@ -165,8 +142,7 @@ namespace Akka.Persistence.Sql.Hosting
             DatabaseMapping? databaseMapping = null,
             TagMode? tagStorageMode = null,
             bool? deleteCompatibilityMode = null,
-            bool? useWriterUuidColumn = null,
-            DataOptions? dataOptions = null)
+            bool? useWriterUuidColumn = null)
         {
             if (mode == PersistenceMode.SnapshotStore && journalBuilder is not null)
                 throw new Exception($"{nameof(journalBuilder)} can only be set when {nameof(mode)} is set to either {PersistenceMode.Both} or {PersistenceMode.Journal}");
@@ -224,13 +200,211 @@ namespace Akka.Persistence.Sql.Hosting
 
             return mode switch
             {
-                PersistenceMode.Journal => builder.WithSqlPersistence(journalOpt, null, dataOptions),
-                PersistenceMode.SnapshotStore => builder.WithSqlPersistence(null, snapshotOpt, dataOptions),
-                PersistenceMode.Both => builder.WithSqlPersistence(journalOpt, snapshotOpt, dataOptions),
+                PersistenceMode.Journal => builder.WithSqlPersistence(journalOpt, null),
+                PersistenceMode.SnapshotStore => builder.WithSqlPersistence(null, snapshotOpt),
+                PersistenceMode.Both => builder.WithSqlPersistence(journalOpt, snapshotOpt),
                 _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, "Invalid PersistenceMode defined."),
             };
         }
 
+        /// <summary>
+        ///     Adds Akka.Persistence.Sql support to this <see cref="ActorSystem" />.
+        /// </summary>
+        /// <param name="builder">
+        ///     The builder instance being configured.
+        /// </param>
+        /// <param name="dataOptions">
+        ///     <para>
+        ///         The custom <see cref="DataOptions"/> used for the connection to the database. If not provided,
+        ///         <see cref="DataOptionsExtensions.UseConnectionString(LinqToDB.DataOptions,string,string)"/> will be used.
+        ///     </para>
+        ///     <para>
+        ///         If provided, you must give enough information for linq2db to connect to the database.
+        ///         This includes setting the connection string and provider name again, if needed in your use case.
+        ///     </para>
+        ///     <para>
+        ///         The following settings will be always overriden by Akka.Persistence.Sql:
+        ///         <list type="number">
+        ///             <item>
+        ///                 MappingSchema
+        ///             </item>
+        ///         </list>
+        ///     </para>
+        ///     <para>
+        ///         DataOptions documentation can be read
+        ///         <a href="https://linq2db.github.io/api/linq2db/LinqToDB.DataOptions.html">here</a>
+        ///     </para>
+        /// </param>
+        /// <param name="autoInitialize">
+        ///     <para>
+        ///         Should the SQL store table be initialized automatically.
+        ///     </para>
+        ///     <i>Default</i>: <c>false</c>
+        /// </param>
+        /// <param name="mode">
+        ///     <para>
+        ///         Determines which settings should be added by this method call.
+        ///     </para>
+        ///     <i>Default</i>: <see cref="PersistenceMode.Both" />
+        /// </param>
+        /// <param name="schemaName">
+        ///     <para>
+        ///         SQL schema name to table corresponding with persistent journal.
+        ///     </para>
+        ///     <b>Default</b>: <c>null</c>
+        /// </param>
+        /// <param name="journalBuilder">
+        ///     <para>
+        ///         An <see cref="Action{T}" /> used to configure an <see cref="AkkaPersistenceJournalBuilder" /> instance.
+        ///     </para>
+        ///     <i>Default</i>: <c>null</c>
+        /// </param>
+        /// <param name="pluginIdentifier">
+        ///     <para>
+        ///         The configuration identifier for the plugins
+        ///     </para>
+        ///     <i>Default</i>: <c>"sql"</c>
+        /// </param>
+        /// <param name="isDefaultPlugin">
+        ///     <para>
+        ///         A <c>bool</c> flag to set the plugin as the default persistence plugin for the <see cref="ActorSystem" />
+        ///     </para>
+        ///     <b>Default</b>: <c>true</c>
+        /// </param>
+        /// <param name="databaseMapping">
+        ///     <para>
+        ///         The <see cref="DatabaseMapping" /> to modify database table column mapping for this journal.
+        ///     </para>
+        ///     <b>NOTE</b>: This is used primarily for backward compatibility,
+        ///     you leave this empty for greenfield projects.
+        /// </param>
+        /// <param name="tagStorageMode">
+        ///     <para>
+        ///         Describe how tags are being stored inside the database. Setting this to
+        ///         <see cref="TagMode.Csv" /> will store the tags as a comma delimited value
+        ///         in a column named <c>tags</c> inside the event journal. Setting this to
+        ///         <see cref="TagMode.TagTable" /> will store the tags inside a separate
+        ///         tag table instead.
+        ///     </para>
+        ///     <b>NOTE</b>: This is used primarily for backward compatibility,
+        ///     you leave this empty for greenfield projects.
+        /// </param>
+        /// <param name="deleteCompatibilityMode">
+        ///     <para>
+        ///         If true, journal_metadata is created and used for deletes
+        ///         and max sequence number queries.
+        ///     </para>
+        ///     <b>NOTE</b>: This is used primarily for backward compatibility,
+        ///     you leave this empty for greenfield projects.
+        /// </param>
+        /// <param name="useWriterUuidColumn">
+        ///     <para>
+        ///         A flag to indicate if the writer_uuid column should be generated and be populated in run-time.
+        ///     </para>
+        ///     <b>Notes:</b>
+        ///     <list type="number">
+        ///         <item>
+        ///             The column will only be generated if auto-initialize is set to true.
+        ///         </item>
+        ///         <item>
+        ///             This feature is Akka.Persistence.Sql specific, setting this to true will break
+        ///             backward compatibility with databases generated by other Akka.Persistence plugins.
+        ///         </item>
+        ///         <item>
+        ///             <para>
+        ///                 To make this feature work with legacy plugins, you will have to alter the old
+        ///                 journal table:
+        ///             </para>
+        ///             <c>ALTER TABLE [journal_table_name] ADD [writer_uuid_column_name] VARCHAR(128);</c>
+        ///         </item>
+        ///         <item>
+        ///             If set to true, the code will not check for backward compatibility. It will expect
+        ///             that the `writer-uuid` column to be present inside the journal table.
+        ///         </item>
+        ///     </list>
+        /// </param>
+        /// <returns>
+        ///     The same <see cref="AkkaConfigurationBuilder" /> instance originally passed in.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     Thrown when <paramref name="journalBuilder" /> is set and <paramref name="mode" /> is set to
+        ///     <see cref="PersistenceMode.SnapshotStore" />
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when <paramref name="dataOptions"/> is null 
+        /// </exception>
+        public static AkkaConfigurationBuilder WithSqlPersistence(
+            this AkkaConfigurationBuilder builder,
+            DataOptions dataOptions,
+            PersistenceMode mode = PersistenceMode.Both,
+            string? schemaName = null,
+            Action<AkkaPersistenceJournalBuilder>? journalBuilder = null,
+            bool autoInitialize = true,
+            string pluginIdentifier = "sql",
+            bool isDefaultPlugin = true,
+            DatabaseMapping? databaseMapping = null,
+            TagMode? tagStorageMode = null,
+            bool? deleteCompatibilityMode = null,
+            bool? useWriterUuidColumn = null)
+        {
+            if (mode == PersistenceMode.SnapshotStore && journalBuilder is not null)
+                throw new Exception($"{nameof(journalBuilder)} can only be set when {nameof(mode)} is set to either {PersistenceMode.Both} or {PersistenceMode.Journal}");
+
+            if (dataOptions is null)
+                throw new ArgumentNullException(nameof(dataOptions), $"{nameof(dataOptions)} can not be null");
+            
+            var journalOpt = new SqlJournalOptions(isDefaultPlugin, pluginIdentifier)
+            {
+                AutoInitialize = autoInitialize,
+                TagStorageMode = tagStorageMode,
+                DeleteCompatibilityMode = deleteCompatibilityMode,
+                DataOptions = dataOptions,
+            };
+
+            if (databaseMapping is not null)
+                journalOpt.DatabaseOptions = databaseMapping.Value.JournalOption();
+
+            if (schemaName is not null)
+            {
+                journalOpt.DatabaseOptions ??= JournalDatabaseOptions.Default;
+                journalOpt.DatabaseOptions.SchemaName = schemaName;
+            }
+
+            if (useWriterUuidColumn is not null)
+            {
+                journalOpt.DatabaseOptions ??= JournalDatabaseOptions.Default;
+                journalOpt.DatabaseOptions.JournalTable ??= JournalTableOptions.Default;
+                journalOpt.DatabaseOptions.JournalTable.UseWriterUuidColumn = useWriterUuidColumn;
+            }
+
+            var adapters = new AkkaPersistenceJournalBuilder(journalOpt.Identifier, builder);
+            journalBuilder?.Invoke(adapters);
+            journalOpt.Adapters = adapters;
+
+            var snapshotOpt = new SqlSnapshotOptions(isDefaultPlugin, pluginIdentifier)
+            {
+                DataOptions = dataOptions,
+                AutoInitialize = autoInitialize,
+            };
+
+            if (databaseMapping is not null)
+                snapshotOpt.DatabaseOptions = databaseMapping.Value.SnapshotOption();
+
+            if (schemaName is not null)
+            {
+                snapshotOpt.DatabaseOptions ??= new SnapshotDatabaseOptions(DatabaseMapping.Default);
+                snapshotOpt.DatabaseOptions.SchemaName = schemaName;
+            }
+
+            return mode switch
+            {
+                PersistenceMode.Journal => builder.WithSqlPersistence(journalOpt, null),
+                PersistenceMode.SnapshotStore => builder.WithSqlPersistence(null, snapshotOpt),
+                PersistenceMode.Both => builder.WithSqlPersistence(journalOpt, snapshotOpt),
+                _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, "Invalid PersistenceMode defined."),
+            };
+        }
+        
         /// <summary>
         ///     Adds Akka.Persistence.Sql support to this <see cref="ActorSystem" />. At least one of the
         ///     configurator delegate needs to be populated else this method will throw an exception.
@@ -258,31 +432,6 @@ namespace Akka.Persistence.Sql.Hosting
         ///     </para>
         ///     <b>Default</b>: <c>true</c>
         /// </param>
-        /// <param name="dataOptions">
-        ///     <para>
-        ///         The custom <see cref="DataOptions"/> used for the connection to the database. If not provided,
-        ///         <see cref="DataOptionsExtensions.UseConnectionString(LinqToDB.DataOptions,string,string)"/> will be used.
-        ///     </para>
-        ///     <para>
-        ///         If provided, you must give enough information for linq2db to connect to the database.
-        ///         This includes setting the connection string and provider name again, if needed in your use case.
-        ///     </para>
-        ///     <para>
-        ///         The following settings will be always overriden by Akka.Persistence.Sql:
-        ///         <list type="number">
-        ///             <item>
-        ///                 MappingSchema
-        ///             </item>
-        ///             <item>
-        ///                 RetryPolicy
-        ///             </item>
-        ///         </list>
-        ///     </para>
-        ///     <para>
-        ///         DataOptions documentation can be read
-        ///         <a href="https://linq2db.github.io/api/linq2db/LinqToDB.DataOptions.html">here</a>
-        ///     </para>
-        /// </param>
         /// <returns>
         ///     The same <see cref="AkkaConfigurationBuilder" /> instance originally passed in.
         /// </returns>
@@ -294,8 +443,7 @@ namespace Akka.Persistence.Sql.Hosting
             this AkkaConfigurationBuilder builder,
             Action<SqlJournalOptions>? journalOptionConfigurator = null,
             Action<SqlSnapshotOptions>? snapshotOptionConfigurator = null,
-            bool isDefaultPlugin = true,
-            DataOptions? dataOptions = null)
+            bool isDefaultPlugin = true)
         {
             if (journalOptionConfigurator is null && snapshotOptionConfigurator is null)
                 throw new ArgumentException($"{nameof(journalOptionConfigurator)} and {nameof(snapshotOptionConfigurator)} could not both be null");
@@ -336,31 +484,6 @@ namespace Akka.Persistence.Sql.Hosting
         ///     </para>
         ///     <i>Default</i>: <c>null</c>
         /// </param>
-        /// <param name="dataOptions">
-        ///     <para>
-        ///         The custom <see cref="DataOptions"/> used for the connection to the database. If not provided,
-        ///         <see cref="DataOptionsExtensions.UseConnectionString(LinqToDB.DataOptions,string,string)"/> will be used.
-        ///     </para>
-        ///     <para>
-        ///         If provided, you must give enough information for linq2db to connect to the database.
-        ///         This includes setting the connection string and provider name again, if needed in your use case.
-        ///     </para>
-        ///     <para>
-        ///         The following settings will be always overriden by Akka.Persistence.Sql:
-        ///         <list type="number">
-        ///             <item>
-        ///                 MappingSchema
-        ///             </item>
-        ///             <item>
-        ///                 RetryPolicy
-        ///             </item>
-        ///         </list>
-        ///     </para>
-        ///     <para>
-        ///         DataOptions documentation can be read
-        ///         <a href="https://linq2db.github.io/api/linq2db/LinqToDB.DataOptions.html">here</a>
-        ///     </para>
-        /// </param>
         /// <returns>
         ///     The same <see cref="AkkaConfigurationBuilder" /> instance originally passed in.
         /// </returns>
@@ -370,18 +493,29 @@ namespace Akka.Persistence.Sql.Hosting
         public static AkkaConfigurationBuilder WithSqlPersistence(
             this AkkaConfigurationBuilder builder,
             SqlJournalOptions? journalOptions = null,
-            SqlSnapshotOptions? snapshotOptions = null,
-            DataOptions? dataOptions = null)
+            SqlSnapshotOptions? snapshotOptions = null)
         {
-            if (dataOptions != null)
+            if (journalOptions?.DataOptions is not null)
             {
-                if (builder.Setups.Any(s => s is DataOptionsSetup))
-                    throw new ArgumentException($"{nameof(DataOptionsSetup)} and {nameof(dataOptions)} could not both be set");
-
-                var setup = new DataOptionsSetup(dataOptions);
-                builder.AddSetup(setup);
+                if(builder.Setups.First(s => s is MultiDataOptionsSetup) is not MultiDataOptionsSetup setup)
+                {
+                    setup = new MultiDataOptionsSetup();
+                    builder.Setups.Add(setup);
+                }
+                setup.AddDataOptions(journalOptions.PluginId, journalOptions.DataOptions);
+                setup.AddDataOptions(journalOptions.QueryPluginId, journalOptions.DataOptions);
             }
 
+            if (snapshotOptions?.DataOptions is not null)
+            {
+                if(builder.Setups.First(s => s is MultiDataOptionsSetup) is not MultiDataOptionsSetup setup)
+                {
+                    setup = new MultiDataOptionsSetup();
+                    builder.Setups.Add(setup);
+                }
+                setup.AddDataOptions(snapshotOptions.PluginId, snapshotOptions.DataOptions);
+            }
+            
             return (journalOptions, snapshotOptions) switch
             {
                 (null, null) =>

--- a/src/Akka.Persistence.Sql.Hosting/HostingExtensions.cs
+++ b/src/Akka.Persistence.Sql.Hosting/HostingExtensions.cs
@@ -123,11 +123,25 @@ namespace Akka.Persistence.Sql.Hosting
         /// <param name="dataOptions">
         ///     <para>
         ///         The custom <see cref="DataOptions"/> used for the connection to the database. If not provided,
-        ///         <see cref="DataOptionsExtensions.UseConnectionString(LinqToDB.DataOptions,string,string)"/> will be used
-        ///         The MappingSchema will always be overridden by Akka.Persistence.Sql.
+        ///         <see cref="DataOptionsExtensions.UseConnectionString(LinqToDB.DataOptions,string,string)"/> will be used.
         ///     </para>
         ///     <para>
-        ///         Data option documentation can be read
+        ///         If provided, you must give enough information for linq2db to connect to the database.
+        ///         This includes setting the connection string and provider name again, if needed in your use case.
+        ///     </para>
+        ///     <para>
+        ///         The following settings will be always overriden by Akka.Persistence.Sql:
+        ///         <list type="number">
+        ///             <item>
+        ///                 MappingSchema
+        ///             </item>
+        ///             <item>
+        ///                 RetryPolicy
+        ///             </item>
+        ///         </list>
+        ///     </para>
+        ///     <para>
+        ///         DataOptions documentation can be read
         ///         <a href="https://linq2db.github.io/api/linq2db/LinqToDB.DataOptions.html">here</a>
         ///     </para>
         /// </param>
@@ -247,11 +261,25 @@ namespace Akka.Persistence.Sql.Hosting
         /// <param name="dataOptions">
         ///     <para>
         ///         The custom <see cref="DataOptions"/> used for the connection to the database. If not provided,
-        ///         <see cref="DataOptionsExtensions.UseConnectionString(LinqToDB.DataOptions,string,string)"/> will be used
-        ///         The MappingSchema will always be overridden by Akka.Persistence.Sql.
+        ///         <see cref="DataOptionsExtensions.UseConnectionString(LinqToDB.DataOptions,string,string)"/> will be used.
         ///     </para>
         ///     <para>
-        ///         Data option documentation can be read
+        ///         If provided, you must give enough information for linq2db to connect to the database.
+        ///         This includes setting the connection string and provider name again, if needed in your use case.
+        ///     </para>
+        ///     <para>
+        ///         The following settings will be always overriden by Akka.Persistence.Sql:
+        ///         <list type="number">
+        ///             <item>
+        ///                 MappingSchema
+        ///             </item>
+        ///             <item>
+        ///                 RetryPolicy
+        ///             </item>
+        ///         </list>
+        ///     </para>
+        ///     <para>
+        ///         DataOptions documentation can be read
         ///         <a href="https://linq2db.github.io/api/linq2db/LinqToDB.DataOptions.html">here</a>
         ///     </para>
         /// </param>
@@ -311,11 +339,25 @@ namespace Akka.Persistence.Sql.Hosting
         /// <param name="dataOptions">
         ///     <para>
         ///         The custom <see cref="DataOptions"/> used for the connection to the database. If not provided,
-        ///         <see cref="DataOptionsExtensions.UseConnectionString(LinqToDB.DataOptions,string,string)"/> will be used
-        ///         The MappingSchema will always be overridden by Akka.Persistence.Sql.
+        ///         <see cref="DataOptionsExtensions.UseConnectionString(LinqToDB.DataOptions,string,string)"/> will be used.
         ///     </para>
         ///     <para>
-        ///         Data option documentation can be read
+        ///         If provided, you must give enough information for linq2db to connect to the database.
+        ///         This includes setting the connection string and provider name again, if needed in your use case.
+        ///     </para>
+        ///     <para>
+        ///         The following settings will be always overriden by Akka.Persistence.Sql:
+        ///         <list type="number">
+        ///             <item>
+        ///                 MappingSchema
+        ///             </item>
+        ///             <item>
+        ///                 RetryPolicy
+        ///             </item>
+        ///         </list>
+        ///     </para>
+        ///     <para>
+        ///         DataOptions documentation can be read
         ///         <a href="https://linq2db.github.io/api/linq2db/LinqToDB.DataOptions.html">here</a>
         ///     </para>
         /// </param>

--- a/src/Akka.Persistence.Sql.Hosting/HostingExtensions.cs
+++ b/src/Akka.Persistence.Sql.Hosting/HostingExtensions.cs
@@ -497,7 +497,7 @@ namespace Akka.Persistence.Sql.Hosting
         {
             if (journalOptions?.DataOptions is not null)
             {
-                if(builder.Setups.First(s => s is MultiDataOptionsSetup) is not MultiDataOptionsSetup setup)
+                if(builder.Setups.FirstOrDefault(s => s is MultiDataOptionsSetup) is not MultiDataOptionsSetup setup)
                 {
                     setup = new MultiDataOptionsSetup();
                     builder.Setups.Add(setup);
@@ -508,7 +508,7 @@ namespace Akka.Persistence.Sql.Hosting
 
             if (snapshotOptions?.DataOptions is not null)
             {
-                if(builder.Setups.First(s => s is MultiDataOptionsSetup) is not MultiDataOptionsSetup setup)
+                if(builder.Setups.FirstOrDefault(s => s is MultiDataOptionsSetup) is not MultiDataOptionsSetup setup)
                 {
                     setup = new MultiDataOptionsSetup();
                     builder.Setups.Add(setup);

--- a/src/Akka.Persistence.Sql.Hosting/HostingExtensions.cs
+++ b/src/Akka.Persistence.Sql.Hosting/HostingExtensions.cs
@@ -124,6 +124,7 @@ namespace Akka.Persistence.Sql.Hosting
         ///     <para>
         ///         The custom <see cref="DataOptions"/> used for the connection to the database. If not provided,
         ///         <see cref="DataOptionsExtensions.UseConnectionString(LinqToDB.DataOptions,string,string)"/> will be used
+        ///         The MappingSchema will always be overridden by Akka.Persistence.Sql.
         ///     </para>
         ///     <para>
         ///         Data option documentation can be read
@@ -247,6 +248,7 @@ namespace Akka.Persistence.Sql.Hosting
         ///     <para>
         ///         The custom <see cref="DataOptions"/> used for the connection to the database. If not provided,
         ///         <see cref="DataOptionsExtensions.UseConnectionString(LinqToDB.DataOptions,string,string)"/> will be used
+        ///         The MappingSchema will always be overridden by Akka.Persistence.Sql.
         ///     </para>
         ///     <para>
         ///         Data option documentation can be read
@@ -310,6 +312,7 @@ namespace Akka.Persistence.Sql.Hosting
         ///     <para>
         ///         The custom <see cref="DataOptions"/> used for the connection to the database. If not provided,
         ///         <see cref="DataOptionsExtensions.UseConnectionString(LinqToDB.DataOptions,string,string)"/> will be used
+        ///         The MappingSchema will always be overridden by Akka.Persistence.Sql.
         ///     </para>
         ///     <para>
         ///         Data option documentation can be read

--- a/src/Akka.Persistence.Sql.Hosting/SqlJournalOptions.cs
+++ b/src/Akka.Persistence.Sql.Hosting/SqlJournalOptions.cs
@@ -149,15 +149,22 @@ namespace Akka.Persistence.Sql.Hosting
         
         protected override StringBuilder Build(StringBuilder sb)
         {
-            if (string.IsNullOrWhiteSpace(ConnectionString))
-                throw new ArgumentNullException(nameof(ConnectionString), $"{nameof(ConnectionString)} can not be null or empty.");
+            if (DataOptions is null)
+            {
+                if (string.IsNullOrWhiteSpace(ConnectionString))
+                    throw new ArgumentNullException(nameof(ConnectionString), $"{nameof(ConnectionString)} can not be null or empty.");
 
-            if (string.IsNullOrWhiteSpace(ProviderName))
-                throw new ArgumentNullException(nameof(ProviderName), $"{nameof(ProviderName)} can not be null or empty.");
+                if (string.IsNullOrWhiteSpace(ProviderName))
+                    throw new ArgumentNullException(nameof(ProviderName), $"{nameof(ProviderName)} can not be null or empty.");
+            }
 
             sb.AppendLine($"plugin-id = {PluginId.ToHocon()}");
-            sb.AppendLine($"connection-string = {ConnectionString.ToHocon()}");
-            sb.AppendLine($"provider-name = {ProviderName.ToHocon()}");
+            
+            if(ConnectionString is not null)
+                sb.AppendLine($"connection-string = {ConnectionString.ToHocon()}");
+            
+            if(ProviderName is not null)
+                sb.AppendLine($"provider-name = {ProviderName.ToHocon()}");
 
             if (DeleteCompatibilityMode is not null)
                 sb.AppendLine($"delete-compatibility-mode = {DeleteCompatibilityMode.ToHocon()}");
@@ -193,8 +200,13 @@ namespace Akka.Persistence.Sql.Hosting
         {
             sb.Append(queryPluginId).AppendLine("{");
             sb.AppendLine($"plugin-id = {QueryPluginId.ToHocon()}");
-            sb.AppendLine($"connection-string = {ConnectionString.ToHocon()}");
-            sb.AppendLine($"provider-name = {ProviderName.ToHocon()}");
+            
+            if(ConnectionString is not null)
+                sb.AppendLine($"connection-string = {ConnectionString.ToHocon()}");
+            
+            if(ProviderName is not null)
+                sb.AppendLine($"provider-name = {ProviderName.ToHocon()}");
+            
             sb.AppendLine($"write-plugin = {pluginId}");
                 
             if (DatabaseOptions is not null)

--- a/src/Akka.Persistence.Sql.Hosting/SqlJournalOptions.cs
+++ b/src/Akka.Persistence.Sql.Hosting/SqlJournalOptions.cs
@@ -10,6 +10,7 @@ using System.Text;
 using Akka.Hosting;
 using Akka.Persistence.Hosting;
 using Akka.Persistence.Sql.Config;
+using LinqToDB;
 
 namespace Akka.Persistence.Sql.Hosting
 {
@@ -114,6 +115,31 @@ namespace Akka.Persistence.Sql.Hosting
         ///     </para>
         /// </summary>
         public IsolationLevel? WriteIsolationLevel { get; set; }
+        
+        /// <summary>
+        ///     <para>
+        ///         The custom <see cref="DataOptions"/> used for the connection to the database for both event writes and query reads.
+        ///         If not provided, <see cref="DataOptionsExtensions.UseConnectionString(LinqToDB.DataOptions,string,string)"/>
+        ///         will be used.
+        ///     </para>
+        ///     <para>
+        ///         If provided, you must give enough information for linq2db to connect to the database.
+        ///         This includes setting the connection string and provider name again, if needed in your use case.
+        ///     </para>
+        ///     <para>
+        ///         The following settings will be always overriden by Akka.Persistence.Sql:
+        ///         <list type="number">
+        ///             <item>
+        ///                 MappingSchema
+        ///             </item>
+        ///         </list>
+        ///     </para>
+        ///     <para>
+        ///         DataOptions documentation can be read
+        ///         <a href="https://linq2db.github.io/api/linq2db/LinqToDB.DataOptions.html">here</a>
+        ///     </para>
+        /// </summary>
+        public DataOptions? DataOptions { get; set; }
 
         protected override Configuration.Config InternalDefaultConfig => Default;
 
@@ -129,6 +155,7 @@ namespace Akka.Persistence.Sql.Hosting
             if (string.IsNullOrWhiteSpace(ProviderName))
                 throw new ArgumentNullException(nameof(ProviderName), $"{nameof(ProviderName)} can not be null or empty.");
 
+            sb.AppendLine($"plugin-id = {PluginId.ToHocon()}");
             sb.AppendLine($"connection-string = {ConnectionString.ToHocon()}");
             sb.AppendLine($"provider-name = {ProviderName.ToHocon()}");
 
@@ -165,6 +192,7 @@ namespace Akka.Persistence.Sql.Hosting
         private StringBuilder BuildQueryConfig(StringBuilder sb, string queryPluginId, string pluginId)
         {
             sb.Append(queryPluginId).AppendLine("{");
+            sb.AppendLine($"plugin-id = {QueryPluginId.ToHocon()}");
             sb.AppendLine($"connection-string = {ConnectionString.ToHocon()}");
             sb.AppendLine($"provider-name = {ProviderName.ToHocon()}");
             sb.AppendLine($"write-plugin = {pluginId}");

--- a/src/Akka.Persistence.Sql.Hosting/SqlSnapshotOptions.cs
+++ b/src/Akka.Persistence.Sql.Hosting/SqlSnapshotOptions.cs
@@ -9,6 +9,7 @@ using System.Data;
 using System.Text;
 using Akka.Hosting;
 using Akka.Persistence.Hosting;
+using LinqToDB;
 
 namespace Akka.Persistence.Sql.Hosting
 {
@@ -77,6 +78,31 @@ namespace Akka.Persistence.Sql.Hosting
         ///     </para>
         /// </summary>
         public IsolationLevel? WriteIsolationLevel { get; set; }
+        
+        /// <summary>
+        ///     <para>
+        ///         The custom <see cref="DataOptions"/> used for the connection to the database for snapshot read and writes.
+        ///         If not provided, <see cref="DataOptionsExtensions.UseConnectionString(LinqToDB.DataOptions,string,string)"/>
+        ///         will be used.
+        ///     </para>
+        ///     <para>
+        ///         If provided, you must give enough information for linq2db to connect to the database.
+        ///         This includes setting the connection string and provider name again, if needed in your use case.
+        ///     </para>
+        ///     <para>
+        ///         The following settings will be always overriden by Akka.Persistence.Sql:
+        ///         <list type="number">
+        ///             <item>
+        ///                 MappingSchema
+        ///             </item>
+        ///         </list>
+        ///     </para>
+        ///     <para>
+        ///         DataOptions documentation can be read
+        ///         <a href="https://linq2db.github.io/api/linq2db/LinqToDB.DataOptions.html">here</a>
+        ///     </para>
+        /// </summary>
+        public DataOptions? DataOptions { get; set; }
 
         protected override Configuration.Config InternalDefaultConfig => Default;
 
@@ -88,6 +114,7 @@ namespace Akka.Persistence.Sql.Hosting
             if (string.IsNullOrWhiteSpace(ProviderName))
                 throw new ArgumentNullException(nameof(ProviderName), $"{nameof(ProviderName)} can not be null or empty.");
 
+            sb.AppendLine($"plugin-id = {PluginId.ToHocon()}");
             sb.AppendLine($"connection-string = {ConnectionString.ToHocon()}");
             sb.AppendLine($"provider-name = {ProviderName.ToHocon()}");
 

--- a/src/Akka.Persistence.Sql.Hosting/SqlSnapshotOptions.cs
+++ b/src/Akka.Persistence.Sql.Hosting/SqlSnapshotOptions.cs
@@ -108,15 +108,22 @@ namespace Akka.Persistence.Sql.Hosting
 
         protected override StringBuilder Build(StringBuilder sb)
         {
-            if (string.IsNullOrWhiteSpace(ConnectionString))
-                throw new ArgumentNullException(nameof(ConnectionString), $"{nameof(ConnectionString)} can not be null or empty.");
+            if (DataOptions is null)
+            {
+                if (string.IsNullOrWhiteSpace(ConnectionString))
+                    throw new ArgumentNullException(nameof(ConnectionString), $"{nameof(ConnectionString)} can not be null or empty.");
 
-            if (string.IsNullOrWhiteSpace(ProviderName))
-                throw new ArgumentNullException(nameof(ProviderName), $"{nameof(ProviderName)} can not be null or empty.");
+                if (string.IsNullOrWhiteSpace(ProviderName))
+                    throw new ArgumentNullException(nameof(ProviderName), $"{nameof(ProviderName)} can not be null or empty.");
+            }
 
             sb.AppendLine($"plugin-id = {PluginId.ToHocon()}");
-            sb.AppendLine($"connection-string = {ConnectionString.ToHocon()}");
-            sb.AppendLine($"provider-name = {ProviderName.ToHocon()}");
+            
+            if(ConnectionString is not null)
+                sb.AppendLine($"connection-string = {ConnectionString.ToHocon()}");
+            
+            if(ProviderName is not null)
+                sb.AppendLine($"provider-name = {ProviderName.ToHocon()}");
 
             if (DatabaseOptions is not null)
                 sb.AppendLine($"table-mapping = {DatabaseOptions.Mapping.Name().ToHocon()}");

--- a/src/Akka.Persistence.Sql.Tests/MySql/MySqlDataOptionsEndToEndSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests/MySql/MySqlDataOptionsEndToEndSpec.cs
@@ -1,0 +1,23 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="MySqlDataOptionsEndToEndSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Persistence.Sql.Tests.Common.Containers;
+using Akka.Persistence.Sql.Tests.Common.Internal.Xunit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Sql.Tests.MySql
+{
+#if !DEBUG
+    [SkipWindows]
+#endif
+    [Collection(nameof(MySqlPersistenceSpec))]
+    public class MySqlDataOptionsEndToEndSpec: SqlDataOptionsEndToEndSpecBase<MySqlContainer>
+    {
+        public MySqlDataOptionsEndToEndSpec(ITestOutputHelper output, MySqlContainer fixture) 
+            : base(nameof(MySqlDataOptionsEndToEndSpec), output, fixture) { }
+    }
+}

--- a/src/Akka.Persistence.Sql.Tests/PostgreSql/PostgreSqlDataOptionsEndToEndSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests/PostgreSql/PostgreSqlDataOptionsEndToEndSpec.cs
@@ -1,0 +1,23 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="PostgreSqlDataOptionsEndToEndSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Persistence.Sql.Tests.Common.Containers;
+using Akka.Persistence.Sql.Tests.Common.Internal.Xunit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Sql.Tests.PostgreSql
+{
+#if !DEBUG
+    [SkipWindows]
+#endif
+    [Collection(nameof(PostgreSqlPersistenceSpec))]
+    public class PostgreSqlDataOptionsEndToEndSpec: SqlDataOptionsEndToEndSpecBase<PostgreSqlContainer>
+    {
+        public PostgreSqlDataOptionsEndToEndSpec(ITestOutputHelper output, PostgreSqlContainer fixture) 
+            : base(nameof(PostgreSqlDataOptionsEndToEndSpec), output, fixture) { }
+    }
+}

--- a/src/Akka.Persistence.Sql.Tests/Settings/ReadJournalConfigSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests/Settings/ReadJournalConfigSpec.cs
@@ -294,7 +294,7 @@ namespace Akka.Persistence.Sql.Tests.Settings
             daoConfig.ReplayBatchSize.Should().Be(1000);
             daoConfig.Parallelism.Should().Be(3);
             daoConfig.MaxRowByRowSize.Should().Be(100);
-            daoConfig.SqlCommonCompatibilityMode.Should().BeTrue();
+            daoConfig.SqlCommonCompatibilityMode.Should().BeFalse();
         }
     }
 }

--- a/src/Akka.Persistence.Sql.Tests/SqlDataOptionsEndToEndSpecBase.cs
+++ b/src/Akka.Persistence.Sql.Tests/SqlDataOptionsEndToEndSpecBase.cs
@@ -1,0 +1,201 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="SqlDataOptionsEndToEndSpecBase.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Actor.Setup;
+using Akka.Configuration;
+using Akka.Event;
+using Akka.Persistence.Query;
+using Akka.Persistence.Sql.Config;
+using Akka.Persistence.Sql.Query;
+using Akka.Persistence.Sql.Tests.Common.Containers;
+using Akka.Streams;
+using Akka.Streams.TestKit;
+using Akka.TestKit;
+using Akka.TestKit.Xunit2;
+using Akka.TestKit.Xunit2.Internals;
+using FluentAssertions;
+using LanguageExt.UnitsOfMeasure;
+using LinqToDB;
+using Xunit;
+using Xunit.Abstractions;
+
+#nullable enable
+namespace Akka.Persistence.Sql.Tests
+{
+    public abstract class SqlDataOptionsEndToEndSpecBase<TContainer> : 
+        TestKitBase,
+        IClassFixture<TContainer>,
+        IAsyncLifetime 
+        where TContainer: class, ITestContainer
+    {
+        private static Configuration.Config Config() =>  ConfigurationFactory.ParseString(
+"""
+akka.persistence {
+    journal {
+        plugin = "akka.persistence.journal.sql"
+    }
+    snapshot-store {
+        plugin = "akka.persistence.snapshot-store.sql"
+    }
+}
+""")
+            .WithFallback(SqlPersistence.DefaultConfiguration);
+
+        private const string GetAll = "getAll";
+        private const string Ack = "ACK";
+        private const string SnapshotAck = "SnapACK";
+        private const string PId = "ac1";
+
+        private readonly string _name;
+        private readonly DataOptions _dataOptions;
+        private readonly ITestOutputHelper? _output;
+        private readonly TContainer _fixture;
+        private IActorRef? _persistenceActor;
+
+        protected SqlDataOptionsEndToEndSpecBase(string name, ITestOutputHelper? output, TContainer fixture) : base(new XunitAssertions(), null, name)
+        {
+            _name = name;
+            _dataOptions = new DataOptions()
+                .UseConnectionString(fixture.ProviderName, fixture.ConnectionString);
+            _fixture = fixture;
+            _output = output;
+        }
+
+        public async Task InitializeAsync()
+        {
+            await _fixture.InitializeAsync();
+            
+            var dataOptionsSetup = new MultiDataOptionsSetup();
+            dataOptionsSetup.AddDataOptions("akka.persistence.journal.sql", _dataOptions);
+            dataOptionsSetup.AddDataOptions("akka.persistence.query.journal.sql", _dataOptions);
+            dataOptionsSetup.AddDataOptions("akka.persistence.snapshot-store.sql", _dataOptions);
+
+            var setup = ActorSystemSetup.Create(
+                BootstrapSetup.Create().WithConfig(Config()),
+                dataOptionsSetup);
+            base.InitializeTest(null, setup, _name, null);
+            InitializeLogger(Sys);
+            
+            _persistenceActor = Sys.ActorOf(Props.Create(() => new MyPersistenceActor(PId)), "persistence-actor-1");
+        }
+
+        public async Task DisposeAsync()
+        {
+            await Sys.Terminate();
+            await _fixture.DisposeAsync();
+        }
+
+        /// <summary>
+        /// Initializes a new <see cref="TestOutputLogger"/> used to log messages.
+        /// </summary>
+        /// <param name="system">The actor system used to attach the logger</param>
+        private void InitializeLogger(ActorSystem system)
+        {
+            if (_output is null)
+                return;
+
+            var extSystem = (ExtendedActorSystem)system;
+            var logger = extSystem.SystemActorOf(Props.Create(() => new TestOutputLogger(_output)), "log-test");
+            logger.Ask<LoggerInitialized>(new InitializeLogger(system.EventStream), TimeSpan.FromSeconds(3))
+                .ConfigureAwait(false).GetAwaiter().GetResult();
+        }
+        
+        protected override void InitializeTest(ActorSystem system, ActorSystemSetup config, string actorSystemName, string testActorName)
+        {
+            // no-op, call after database are set up
+        }
+
+        [Fact]
+        public async Task Should_Start_ActorSystem_wth_Sql_Persistence()
+        {
+            var timeout = 3.Seconds();
+
+            // act
+            _persistenceActor.Tell(1);
+            ExpectMsg<string>(Ack);
+            _persistenceActor.Tell(2);
+            ExpectMsg<string>(Ack);
+            ExpectMsg<string>(SnapshotAck);
+            var snapshot = await _persistenceActor.Ask<int[]>(GetAll, timeout);
+
+            // assert
+            snapshot.Should().BeEquivalentTo(new[] { 1, 2 });
+
+            // kill + recreate actor with same PersistentId
+            await _persistenceActor.GracefulStop(timeout);
+            var myPersistentActor2 = Sys.ActorOf(Props.Create(() => new MyPersistenceActor(PId)), "persistence-actor-2");
+
+            var snapshot2 = await myPersistentActor2.Ask<int[]>(GetAll, timeout);
+            snapshot2.Should().BeEquivalentTo(new[] { 1, 2 });
+
+            // validate configs
+            var config = Sys.Settings.Config;
+            
+            var journalConfig = config.GetConfig("akka.persistence.journal");
+            journalConfig.GetString("plugin").Should().Be("akka.persistence.journal.sql");
+            journalConfig.GetString("sql.connection-string").Should().Be(string.Empty);
+            journalConfig.GetString("sql.provider-name").Should().Be(string.Empty);
+            
+            var snapshotConfig = config.GetConfig("akka.persistence.snapshot-store");
+            snapshotConfig.GetString("plugin").Should().Be("akka.persistence.snapshot-store.sql");
+            snapshotConfig.GetString("sql.connection-string").Should().Be(string.Empty);
+            snapshotConfig.GetString("sql.provider-name").Should().Be(string.Empty);
+
+            // validate that query is working
+            var readJournal = Sys.ReadJournalFor<SqlReadJournal>("akka.persistence.query.journal.sql");
+            var source = readJournal.AllEvents(Offset.NoOffset());
+            var probe = source.RunWith(this.SinkProbe<EventEnvelope>(), Sys.Materializer());
+            probe.Request(2);
+            probe.ExpectNext<EventEnvelope>(p => p.PersistenceId == PId && p.SequenceNr == 1L && p.Event.Equals(1));
+            probe.ExpectNext<EventEnvelope>(p => p.PersistenceId == PId && p.SequenceNr == 2L && p.Event.Equals(2));
+            await probe.CancelAsync();
+        }
+
+        private sealed class MyPersistenceActor : ReceivePersistentActor
+        {
+            private List<int> _values = new();
+            private IActorRef? _sender;
+
+            public MyPersistenceActor(string persistenceId)
+            {
+                PersistenceId = persistenceId;
+
+                Recover<SnapshotOffer>(
+                    offer =>
+                    {
+                        if (offer.Snapshot is IEnumerable<int> ints)
+                            _values = new List<int>(ints);
+                    });
+
+                Recover<int>(_values.Add);
+
+                Command<int>( i =>
+                {
+                    _sender = Sender;
+                    Persist(
+                        i,
+                        _ =>
+                        {
+                            _values.Add(i);
+                            if (LastSequenceNr % 2 == 0)
+                                SaveSnapshot(_values);
+                            _sender.Tell(Ack);
+                        });
+                });
+
+                Command<string>(str => str.Equals(GetAll), _ => Sender.Tell(_values.ToArray()));
+
+                Command<SaveSnapshotSuccess>(_ => _sender.Tell(SnapshotAck));
+            }
+
+            public override string PersistenceId { get; }
+        }
+    }
+}

--- a/src/Akka.Persistence.Sql.Tests/SqlServer/SqlServerDataOptionsEndToEndSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests/SqlServer/SqlServerDataOptionsEndToEndSpec.cs
@@ -1,0 +1,23 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="SqlServerDataOptionsEndToEndSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Persistence.Sql.Tests.Common.Containers;
+using Akka.Persistence.Sql.Tests.Common.Internal.Xunit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Sql.Tests.SqlServer
+{
+#if !DEBUG
+    [SkipWindows]
+#endif
+    [Collection(nameof(SqlServerPersistenceSpec))]
+    public class SqlServerDataOptionsEndToEndSpec: SqlDataOptionsEndToEndSpecBase<SqlServerContainer>
+    {
+        public SqlServerDataOptionsEndToEndSpec(ITestOutputHelper output, SqlServerContainer fixture) 
+            : base(nameof(SqlServerDataOptionsEndToEndSpec), output, fixture) { }
+    }
+}

--- a/src/Akka.Persistence.Sql.Tests/Sqlite/MsSqliteDataOptionsEndToEndSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests/Sqlite/MsSqliteDataOptionsEndToEndSpec.cs
@@ -1,0 +1,23 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="MsSqliteDataOptionsEndToEndSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Persistence.Sql.Tests.Common.Containers;
+using Akka.Persistence.Sql.Tests.Common.Internal.Xunit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Sql.Tests.Sqlite
+{
+#if !DEBUG
+    [SkipWindows]
+#endif
+    [Collection(nameof(MsSqlitePersistenceSpec))]
+    public class MsSqliteDataOptionsEndToEndSpec: SqlDataOptionsEndToEndSpecBase<MsSqliteContainer>
+    {
+        public MsSqliteDataOptionsEndToEndSpec(ITestOutputHelper output, MsSqliteContainer fixture) 
+            : base(nameof(MsSqliteDataOptionsEndToEndSpec), output, fixture) { }
+    }
+}

--- a/src/Akka.Persistence.Sql.Tests/Sqlite/SqliteDataOptionsEndToEndSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests/Sqlite/SqliteDataOptionsEndToEndSpec.cs
@@ -1,0 +1,23 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="SqliteDataOptionsEndToEndSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Persistence.Sql.Tests.Common.Containers;
+using Akka.Persistence.Sql.Tests.Common.Internal.Xunit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Sql.Tests.Sqlite
+{
+#if !DEBUG
+    [SkipWindows]
+#endif
+    [Collection(nameof(SqlitePersistenceSpec))]
+    public class SqliteDataOptionsEndToEndSpec: SqlDataOptionsEndToEndSpecBase<SqliteContainer>
+    {
+        public SqliteDataOptionsEndToEndSpec(ITestOutputHelper output, SqliteContainer fixture) 
+            : base(nameof(SqliteDataOptionsEndToEndSpec), output, fixture) { }
+    }
+}

--- a/src/Akka.Persistence.Sql/Config/BaseByteArrayJournalDaoConfig.cs
+++ b/src/Akka.Persistence.Sql/Config/BaseByteArrayJournalDaoConfig.cs
@@ -20,7 +20,7 @@ namespace Akka.Persistence.Sql.Config
             ReplayBatchSize = config.GetInt("replay-batch-size", 1000);
             Parallelism = config.GetInt("parallelism", 2);
             MaxRowByRowSize = config.GetInt("max-row-by-row-size", 100);
-            SqlCommonCompatibilityMode = config.GetBoolean("delete-compatibility-mode", true);
+            SqlCommonCompatibilityMode = config.GetBoolean("delete-compatibility-mode");
         }
 
         public bool PreferParametersOnMultiRowInsert { get; }

--- a/src/Akka.Persistence.Sql/Config/DataOptionsSetup.cs
+++ b/src/Akka.Persistence.Sql/Config/DataOptionsSetup.cs
@@ -11,7 +11,7 @@ namespace Akka.Persistence.Sql.Config
 {
     public sealed class DataOptionsSetup: Setup
     {
-        public DataOptions? DataOptions { get; set; }
+        public DataOptions? DataOptions { get; }
 
         public DataOptionsSetup(DataOptions dataOptions)
         {

--- a/src/Akka.Persistence.Sql/Config/DataOptionsSetup.cs
+++ b/src/Akka.Persistence.Sql/Config/DataOptionsSetup.cs
@@ -1,0 +1,45 @@
+// -----------------------------------------------------------------------
+//  <copyright file="DataOptionsSetup.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Actor.Setup;
+using LinqToDB;
+
+namespace Akka.Persistence.Sql.Config
+{
+    public sealed class DataOptionsSetup: Setup
+    {
+        public DataOptions? DataOptions { get; set; }
+
+        public DataOptionsSetup(DataOptions dataOptions)
+        {
+            DataOptions = dataOptions;
+        }
+
+        internal ReadJournalConfig Apply(ReadJournalConfig config)
+        {
+            if (DataOptions != null)
+                config = config.WithDataOptions(DataOptions);
+
+            return config;
+        }
+
+        internal JournalConfig Apply(JournalConfig config)
+        {
+            if (DataOptions != null)
+                config = config.WithDataOptions(DataOptions);
+
+            return config;
+        }
+
+        internal SnapshotConfig Apply(SnapshotConfig config)
+        {
+            if (DataOptions != null)
+                config = config.WithDataOptions(DataOptions);
+
+            return config;
+        }
+    }
+}

--- a/src/Akka.Persistence.Sql/Config/DataOptionsSetup.cs
+++ b/src/Akka.Persistence.Sql/Config/DataOptionsSetup.cs
@@ -11,7 +11,7 @@ namespace Akka.Persistence.Sql.Config
 {
     public sealed class DataOptionsSetup: Setup
     {
-        public DataOptions? DataOptions { get; }
+        private DataOptions? DataOptions { get; }
 
         public DataOptionsSetup(DataOptions dataOptions)
         {

--- a/src/Akka.Persistence.Sql/Config/EventJournalTableConfig.cs
+++ b/src/Akka.Persistence.Sql/Config/EventJournalTableConfig.cs
@@ -32,13 +32,15 @@ namespace Akka.Persistence.Sql.Config
             if (ReferenceEquals(this, other))
                 return true;
 
-            return Name == other.Name && Equals(ColumnNames, other.ColumnNames);
+            return Name == other.Name &&
+                   UseWriterUuidColumn == other.UseWriterUuidColumn &&
+                   ColumnNames.Equals(other.ColumnNames);
         }
 
-        public override bool Equals(object obj)
-            => ReferenceEquals(this, obj) || (obj is EventJournalTableConfig other && Equals(other));
+        public override bool Equals(object? obj)
+            => obj is not null && (ReferenceEquals(this, obj) || (obj is EventJournalTableConfig other && Equals(other)));
 
         public override int GetHashCode()
-            => HashCode.Combine(Name, ColumnNames);
+            => HashCode.Combine(Name, UseWriterUuidColumn, ColumnNames);
     }
 }

--- a/src/Akka.Persistence.Sql/Config/JournalConfig.cs
+++ b/src/Akka.Persistence.Sql/Config/JournalConfig.cs
@@ -6,6 +6,7 @@
 
 using System.Data;
 using Akka.Persistence.Sql.Extensions;
+using LinqToDB;
 
 namespace Akka.Persistence.Sql.Config
 {
@@ -32,6 +33,38 @@ namespace Akka.Persistence.Sql.Config
 
             ReadIsolationLevel = config.GetIsolationLevel("read-isolation-level");
             WriteIsolationLevel = config.GetIsolationLevel("write-isolation-level");
+        }
+
+        public JournalConfig(
+            string materializerDispatcher,
+            string connectionString,
+            string providerName,
+            JournalTableConfig tableConfig,
+            IPluginConfig pluginConfig,
+            BaseByteArrayJournalDaoConfig daoConfig,
+            string? useSharedDb,
+            bool useCloneConnection,
+            string defaultSerializer,
+            bool autoInitialize,
+            bool warnOnAutoInitializeFail,
+            IsolationLevel writeIsolationLevel,
+            IsolationLevel readIsolationLevel,
+            DataOptions? dataOptions)
+        {
+            MaterializerDispatcher = materializerDispatcher;
+            ConnectionString = connectionString;
+            ProviderName = providerName;
+            TableConfig = tableConfig;
+            PluginConfig = pluginConfig;
+            DaoConfig = daoConfig;
+            UseSharedDb = useSharedDb;
+            UseCloneConnection = useCloneConnection;
+            DefaultSerializer = defaultSerializer;
+            AutoInitialize = autoInitialize;
+            WarnOnAutoInitializeFail = warnOnAutoInitializeFail;
+            WriteIsolationLevel = writeIsolationLevel;
+            ReadIsolationLevel = readIsolationLevel;
+            DataOptions = dataOptions;
         }
 
         public string MaterializerDispatcher { get; }
@@ -64,6 +97,42 @@ namespace Akka.Persistence.Sql.Config
         public IsolationLevel WriteIsolationLevel { get; }
 
         public IsolationLevel ReadIsolationLevel { get; }
+
+        public DataOptions? DataOptions { get; }
+
+        public JournalConfig WithDataOptions(DataOptions dataOptions)
+            => Copy(dataOptions: dataOptions);
+
+        private JournalConfig Copy(
+            string? materializerDispatcher = null,
+            string? connectionString = null,
+            string? providerName = null,
+            JournalTableConfig? tableConfig = null,
+            IPluginConfig? pluginConfig = null,
+            BaseByteArrayJournalDaoConfig? daoConfig = null,
+            string? useSharedDb = null,
+            bool? useCloneConnection = null,
+            string? defaultSerializer = null,
+            bool? autoInitialize = null,
+            bool? warnOnAutoInitializeFail = null,
+            IsolationLevel? writeIsolationLevel = null,
+            IsolationLevel? readIsolationLevel = null,
+            DataOptions? dataOptions = null)
+            => new(
+                materializerDispatcher ?? MaterializerDispatcher,
+                connectionString ?? ConnectionString,
+                providerName ?? ProviderName,
+                tableConfig ?? TableConfig,
+                pluginConfig ?? PluginConfig,
+                daoConfig ?? DaoConfig,
+                useSharedDb ?? UseSharedDb,
+                useCloneConnection ?? UseCloneConnection,
+                defaultSerializer ?? DefaultSerializer,
+                autoInitialize ?? AutoInitialize,
+                warnOnAutoInitializeFail ?? WarnOnAutoInitializeFail,
+                writeIsolationLevel ?? WriteIsolationLevel,
+                readIsolationLevel ?? ReadIsolationLevel,
+                dataOptions ?? DataOptions);
     }
 
     public interface IProviderConfig
@@ -88,6 +157,8 @@ namespace Akka.Persistence.Sql.Config
         bool UseCloneConnection { get; }
 
         string DefaultSerializer { get; }
+
+        DataOptions? DataOptions { get; }
     }
 
     public interface IPluginConfig

--- a/src/Akka.Persistence.Sql/Config/JournalConfig.cs
+++ b/src/Akka.Persistence.Sql/Config/JournalConfig.cs
@@ -33,6 +33,8 @@ namespace Akka.Persistence.Sql.Config
 
             ReadIsolationLevel = config.GetIsolationLevel("read-isolation-level");
             WriteIsolationLevel = config.GetIsolationLevel("write-isolation-level");
+
+            DataOptions = null;
         }
 
         private JournalConfig(

--- a/src/Akka.Persistence.Sql/Config/JournalConfig.cs
+++ b/src/Akka.Persistence.Sql/Config/JournalConfig.cs
@@ -35,7 +35,7 @@ namespace Akka.Persistence.Sql.Config
             WriteIsolationLevel = config.GetIsolationLevel("write-isolation-level");
         }
 
-        public JournalConfig(
+        private JournalConfig(
             string materializerDispatcher,
             string connectionString,
             string providerName,

--- a/src/Akka.Persistence.Sql/Config/JournalConfig.cs
+++ b/src/Akka.Persistence.Sql/Config/JournalConfig.cs
@@ -14,6 +14,7 @@ namespace Akka.Persistence.Sql.Config
     {
         public JournalConfig(Configuration.Config config)
         {
+            PluginId = config.GetString("plugin-id");
             MaterializerDispatcher = config.GetString("materializer-dispatcher", "akka.actor.default-dispatcher");
             ConnectionString = config.GetString("connection-string");
             ProviderName = config.GetString("provider-name");
@@ -68,6 +69,8 @@ namespace Akka.Persistence.Sql.Config
             ReadIsolationLevel = readIsolationLevel;
             DataOptions = dataOptions;
         }
+        
+        public string? PluginId { get; }
 
         public string MaterializerDispatcher { get; }
 

--- a/src/Akka.Persistence.Sql/Config/JournalTableColumnNames.cs
+++ b/src/Akka.Persistence.Sql/Config/JournalTableColumnNames.cs
@@ -45,7 +45,7 @@ namespace Akka.Persistence.Sql.Config
 
         public string WriterUuid { get; }
 
-        public bool Equals(JournalTableColumnNames other)
+        public bool Equals(JournalTableColumnNames? other)
             => other is not null &&
                Ordering == other.Ordering &&
                Deleted == other.Deleted &&
@@ -55,10 +55,14 @@ namespace Akka.Persistence.Sql.Config
                Tags == other.Tags &&
                Message == other.Message &&
                Identifier == other.Identifier &&
-               Manifest == other.Manifest;
+               Manifest == other.Manifest &&
+               WriterUuid == other.WriterUuid;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
+            if(obj is null)
+                return false;
+            
             if (ReferenceEquals(this, obj))
                 return true;
 
@@ -77,6 +81,7 @@ namespace Akka.Persistence.Sql.Config
             hashCode.Add(Message);
             hashCode.Add(Identifier);
             hashCode.Add(Manifest);
+            hashCode.Add(WriterUuid);
             return hashCode.ToHashCode();
         }
     }

--- a/src/Akka.Persistence.Sql/Config/JournalTableConfig.cs
+++ b/src/Akka.Persistence.Sql/Config/JournalTableConfig.cs
@@ -56,8 +56,10 @@ namespace Akka.Persistence.Sql.Config
             if (ReferenceEquals(this, other))
                 return true;
 
-            return Equals(EventJournalTable, other.EventJournalTable) &&
-                   Equals(MetadataTable, other.MetadataTable) &&
+            return EventJournalTable.Equals(other.EventJournalTable) &&
+                   MetadataTable.Equals(other.MetadataTable) &&
+                   TagTable.Equals(other.TagTable) &&
+                   UseEventManifestColumn == other.UseEventManifestColumn &&
                    SchemaName == other.SchemaName;
         }
 
@@ -73,6 +75,6 @@ namespace Akka.Persistence.Sql.Config
         }
 
         public override int GetHashCode()
-            => HashCode.Combine(EventJournalTable, SchemaName, MetadataTable);
+            => HashCode.Combine(EventJournalTable, UseEventManifestColumn, SchemaName, MetadataTable, TagTable);
     }
 }

--- a/src/Akka.Persistence.Sql/Config/MetadataTableColumnNames.cs
+++ b/src/Akka.Persistence.Sql/Config/MetadataTableColumnNames.cs
@@ -21,7 +21,7 @@ namespace Akka.Persistence.Sql.Config
 
         public string SequenceNumber { get; }
 
-        public bool Equals(MetadataTableColumnNames other)
+        public bool Equals(MetadataTableColumnNames? other)
         {
             if (ReferenceEquals(null, other))
                 return false;
@@ -32,7 +32,7 @@ namespace Akka.Persistence.Sql.Config
             return PersistenceId == other.PersistenceId && SequenceNumber == other.SequenceNumber;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
                 return false;

--- a/src/Akka.Persistence.Sql/Config/MetadataTableConfig.cs
+++ b/src/Akka.Persistence.Sql/Config/MetadataTableConfig.cs
@@ -21,7 +21,7 @@ namespace Akka.Persistence.Sql.Config
 
         public MetadataTableColumnNames ColumnNames { get; }
 
-        public bool Equals(MetadataTableConfig other)
+        public bool Equals(MetadataTableConfig? other)
         {
             if (ReferenceEquals(null, other))
                 return false;
@@ -29,10 +29,10 @@ namespace Akka.Persistence.Sql.Config
             if (ReferenceEquals(this, other))
                 return true;
 
-            return Name == other.Name && Equals(ColumnNames, other.ColumnNames);
+            return Name == other.Name && ColumnNames.Equals(other.ColumnNames);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => ReferenceEquals(this, obj) || (obj is MetadataTableConfig other && Equals(other));
 
         public override int GetHashCode()

--- a/src/Akka.Persistence.Sql/Config/MultiDataOptionsSetup.cs
+++ b/src/Akka.Persistence.Sql/Config/MultiDataOptionsSetup.cs
@@ -1,0 +1,26 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="MultiDataOptionsSetup.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System.Collections.Generic;
+using Akka.Actor.Setup;
+using LinqToDB;
+
+namespace Akka.Persistence.Sql.Config
+{
+    public sealed class MultiDataOptionsSetup: Setup
+    {
+        private readonly Dictionary<string, DataOptions> _options = new ();
+
+        public void AddDataOptions(string pluginId, DataOptions dataOptions)
+            => _options[pluginId] = dataOptions;
+
+        public bool TryGetDataOptionsFor(string pluginId, out DataOptions dataOptions)
+            => _options.TryGetValue(pluginId, out dataOptions);
+
+        public void RemoveDataOptionsFor(string pluginId)
+            => _options.Remove(pluginId);
+    }
+}

--- a/src/Akka.Persistence.Sql/Config/ReadJournalConfig.cs
+++ b/src/Akka.Persistence.Sql/Config/ReadJournalConfig.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Data;
 using Akka.Persistence.Sql.Extensions;
+using LinqToDB;
 
 namespace Akka.Persistence.Sql.Config
 {
@@ -27,9 +28,44 @@ namespace Akka.Persistence.Sql.Config
             AddShutdownHook = config.GetBoolean("add-shutdown-hook", true);
             DefaultSerializer = config.GetString("serializer");
             ReadIsolationLevel = config.GetIsolationLevel("read-isolation-level");
+            DataOptions = null;
 
             // We don't do any writes in a read journal
             WriteIsolationLevel = IsolationLevel.Unspecified;
+        }
+
+        public ReadJournalConfig(
+            string connectionString,
+            string providerName,
+            string writePluginId,
+            JournalTableConfig tableConfig,
+            BaseByteArrayJournalDaoConfig daoConfig,
+            int maxBufferSize,
+            bool addShutdownHook,
+            TimeSpan refreshInterval,
+            JournalSequenceRetrievalConfig journalSequenceRetrievalConfiguration,
+            IPluginConfig pluginConfig,
+            string defaultSerializer,
+            IsolationLevel writeIsolationLevel,
+            IsolationLevel readIsolationLevel,
+            DataOptions? dataOptions,
+            bool useCloneConnection)
+        {
+            ConnectionString = connectionString;
+            ProviderName = providerName;
+            WritePluginId = writePluginId;
+            TableConfig = tableConfig;
+            DaoConfig = daoConfig;
+            MaxBufferSize = maxBufferSize;
+            AddShutdownHook = addShutdownHook;
+            RefreshInterval = refreshInterval;
+            JournalSequenceRetrievalConfiguration = journalSequenceRetrievalConfiguration;
+            PluginConfig = pluginConfig;
+            DefaultSerializer = defaultSerializer;
+            WriteIsolationLevel = writeIsolationLevel;
+            ReadIsolationLevel = readIsolationLevel;
+            DataOptions = dataOptions;
+            UseCloneConnection = useCloneConnection;
         }
 
         public string WritePluginId { get; }
@@ -61,5 +97,43 @@ namespace Akka.Persistence.Sql.Config
         public IsolationLevel WriteIsolationLevel { get; }
 
         public IsolationLevel ReadIsolationLevel { get; }
+
+        public DataOptions? DataOptions { get; }
+
+        public ReadJournalConfig WithDataOptions(DataOptions dataOptions)
+            => Copy(dataOptions: dataOptions);
+        
+        private ReadJournalConfig Copy(
+            string? connectionString = null,
+            string? providerName = null,
+            string? writePluginId = null,
+            JournalTableConfig? tableConfig = null,
+            BaseByteArrayJournalDaoConfig? daoConfig = null,
+            int? maxBufferSize = null,
+            bool? addShutdownHook = null,
+            TimeSpan? refreshInterval = null,
+            JournalSequenceRetrievalConfig? journalSequenceRetrievalConfiguration = null,
+            IPluginConfig? pluginConfig = null,
+            string? defaultSerializer = null,
+            IsolationLevel? writeIsolationLevel = null,
+            IsolationLevel? readIsolationLevel = null,
+            DataOptions? dataOptions = null,
+            bool? useCloneConnection = null)
+            => new(
+                connectionString ?? ConnectionString,
+                providerName ?? ProviderName,
+                writePluginId ?? WritePluginId,
+                tableConfig ?? TableConfig,
+                daoConfig ?? DaoConfig,
+                maxBufferSize ?? MaxBufferSize,
+                addShutdownHook ?? AddShutdownHook,
+                refreshInterval ?? RefreshInterval,
+                journalSequenceRetrievalConfiguration ?? JournalSequenceRetrievalConfiguration,
+                pluginConfig ?? PluginConfig,
+                defaultSerializer ?? DefaultSerializer,
+                writeIsolationLevel ?? WriteIsolationLevel,
+                readIsolationLevel ?? ReadIsolationLevel,
+                dataOptions ?? DataOptions,
+                useCloneConnection ?? UseCloneConnection);
     }
 }

--- a/src/Akka.Persistence.Sql/Config/ReadJournalConfig.cs
+++ b/src/Akka.Persistence.Sql/Config/ReadJournalConfig.cs
@@ -34,7 +34,7 @@ namespace Akka.Persistence.Sql.Config
             WriteIsolationLevel = IsolationLevel.Unspecified;
         }
 
-        public ReadJournalConfig(
+        private ReadJournalConfig(
             string connectionString,
             string providerName,
             string writePluginId,
@@ -102,7 +102,7 @@ namespace Akka.Persistence.Sql.Config
 
         public ReadJournalConfig WithDataOptions(DataOptions dataOptions)
             => Copy(dataOptions: dataOptions);
-        
+
         private ReadJournalConfig Copy(
             string? connectionString = null,
             string? providerName = null,

--- a/src/Akka.Persistence.Sql/Config/ReadJournalConfig.cs
+++ b/src/Akka.Persistence.Sql/Config/ReadJournalConfig.cs
@@ -15,6 +15,7 @@ namespace Akka.Persistence.Sql.Config
     {
         public ReadJournalConfig(Configuration.Config config)
         {
+            PluginId = config.GetString("plugin-id");
             ConnectionString = config.GetString("connection-string");
             ProviderName = config.GetString("provider-name");
             WritePluginId = config.GetString("write-plugin");
@@ -67,6 +68,8 @@ namespace Akka.Persistence.Sql.Config
             DataOptions = dataOptions;
             UseCloneConnection = useCloneConnection;
         }
+        
+        public string? PluginId { get; }
 
         public string WritePluginId { get; }
         

--- a/src/Akka.Persistence.Sql/Config/SnapshotConfig.cs
+++ b/src/Akka.Persistence.Sql/Config/SnapshotConfig.cs
@@ -6,6 +6,7 @@
 
 using System.Data;
 using Akka.Persistence.Sql.Extensions;
+using LinqToDB;
 
 namespace Akka.Persistence.Sql.Config
 {
@@ -39,6 +40,37 @@ namespace Akka.Persistence.Sql.Config
             WarnOnAutoInitializeFail = config.GetBoolean("warn-on-auto-init-fail");
             ReadIsolationLevel = config.GetIsolationLevel("read-isolation-level");
             WriteIsolationLevel = config.GetIsolationLevel("write-isolation-level");
+            DataOptions = null;
+        }
+
+        public SnapshotConfig(
+            SnapshotTableConfiguration tableConfig,
+            IPluginConfig pluginConfig,
+            string? useSharedDb,
+            string defaultSerializer,
+            string connectionString,
+            string providerName,
+            IDaoConfig daoConfig,
+            bool useCloneConnection,
+            bool autoInitialize,
+            bool warnOnAutoInitializeFail,
+            IsolationLevel writeIsolationLevel,
+            IsolationLevel readIsolationLevel,
+            DataOptions? dataOptions)
+        {
+            TableConfig = tableConfig;
+            PluginConfig = pluginConfig;
+            UseSharedDb = useSharedDb;
+            DefaultSerializer = defaultSerializer;
+            ConnectionString = connectionString;
+            ProviderName = providerName;
+            IDaoConfig = daoConfig;
+            UseCloneConnection = useCloneConnection;
+            AutoInitialize = autoInitialize;
+            WarnOnAutoInitializeFail = warnOnAutoInitializeFail;
+            WriteIsolationLevel = writeIsolationLevel;
+            ReadIsolationLevel = readIsolationLevel;
+            DataOptions = dataOptions;
         }
 
         public string? UseSharedDb { get; }
@@ -64,8 +96,42 @@ namespace Akka.Persistence.Sql.Config
 
         public string DefaultSerializer { get; }
 
+        public DataOptions? DataOptions { get; }
+
         public IsolationLevel WriteIsolationLevel { get; }
 
         public IsolationLevel ReadIsolationLevel { get; }
+
+        public SnapshotConfig WithDataOptions(DataOptions dataOptions)
+            => Copy(dataOptions: dataOptions);
+
+        private SnapshotConfig Copy(
+            SnapshotTableConfiguration? tableConfig = null,
+            IPluginConfig? pluginConfig = null,
+            string? useSharedDb = null,
+            string? defaultSerializer = null,
+            string? connectionString = null,
+            string? providerName = null,
+            IDaoConfig? daoConfig = null,
+            bool? useCloneConnection = false,
+            bool? autoInitialize = false,
+            bool? warnOnAutoInitializeFail = false,
+            IsolationLevel? writeIsolationLevel = null,
+            IsolationLevel? readIsolationLevel = null,
+            DataOptions? dataOptions = null)
+            => new(
+                tableConfig ?? TableConfig,
+                pluginConfig ?? PluginConfig,
+                useSharedDb ?? UseSharedDb,
+                defaultSerializer ?? DefaultSerializer,
+                connectionString ?? ConnectionString,
+                providerName ?? ProviderName,
+                daoConfig ?? IDaoConfig,
+                useCloneConnection ?? UseCloneConnection,
+                autoInitialize ?? AutoInitialize,
+                warnOnAutoInitializeFail ?? WarnOnAutoInitializeFail,
+                writeIsolationLevel ?? WriteIsolationLevel,
+                readIsolationLevel ?? ReadIsolationLevel,
+                dataOptions ?? DataOptions);
     }
 }

--- a/src/Akka.Persistence.Sql/Config/SnapshotConfig.cs
+++ b/src/Akka.Persistence.Sql/Config/SnapshotConfig.cs
@@ -43,7 +43,7 @@ namespace Akka.Persistence.Sql.Config
             DataOptions = null;
         }
 
-        public SnapshotConfig(
+        private SnapshotConfig(
             SnapshotTableConfiguration tableConfig,
             IPluginConfig pluginConfig,
             string? useSharedDb,

--- a/src/Akka.Persistence.Sql/Config/SnapshotConfig.cs
+++ b/src/Akka.Persistence.Sql/Config/SnapshotConfig.cs
@@ -113,9 +113,9 @@ namespace Akka.Persistence.Sql.Config
             string? connectionString = null,
             string? providerName = null,
             IDaoConfig? daoConfig = null,
-            bool? useCloneConnection = false,
-            bool? autoInitialize = false,
-            bool? warnOnAutoInitializeFail = false,
+            bool? useCloneConnection = null,
+            bool? autoInitialize = null,
+            bool? warnOnAutoInitializeFail = null,
             IsolationLevel? writeIsolationLevel = null,
             IsolationLevel? readIsolationLevel = null,
             DataOptions? dataOptions = null)

--- a/src/Akka.Persistence.Sql/Config/SnapshotConfig.cs
+++ b/src/Akka.Persistence.Sql/Config/SnapshotConfig.cs
@@ -31,6 +31,7 @@ namespace Akka.Persistence.Sql.Config
                 ? null
                 : dbConf;
 
+            PluginId = config.GetString("plugin-id");
             DefaultSerializer = config.GetString("serializer");
             ConnectionString = config.GetString("connection-string");
             ProviderName = config.GetString("provider-name");
@@ -72,6 +73,8 @@ namespace Akka.Persistence.Sql.Config
             ReadIsolationLevel = readIsolationLevel;
             DataOptions = dataOptions;
         }
+        
+        public string? PluginId { get; }
 
         public string? UseSharedDb { get; }
 

--- a/src/Akka.Persistence.Sql/Config/SnapshotTableColumnNames.cs
+++ b/src/Akka.Persistence.Sql/Config/SnapshotTableColumnNames.cs
@@ -8,7 +8,7 @@ using System;
 
 namespace Akka.Persistence.Sql.Config
 {
-    public class SnapshotTableColumnNames
+    public class SnapshotTableColumnNames: IEquatable<SnapshotTableColumnNames>
     {
         public SnapshotTableColumnNames(Configuration.Config config)
         {
@@ -35,5 +35,32 @@ namespace Akka.Persistence.Sql.Config
 
         public override int GetHashCode()
             => HashCode.Combine(PersistenceId, SequenceNumber, Created, Snapshot, Manifest, SerializerId);
+
+        public bool Equals(SnapshotTableColumnNames? other)
+        {
+            if (other is null)
+                return false;
+
+            if (ReferenceEquals(this, other))
+                return true;
+
+            return PersistenceId == other.PersistenceId && 
+                   SequenceNumber == other.SequenceNumber && 
+                   Created == other.Created && 
+                   Snapshot == other.Snapshot && 
+                   Manifest == other.Manifest && 
+                   SerializerId == other.SerializerId;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            if (obj is null)
+                return false;
+
+            if (ReferenceEquals(this, obj))
+                return true;
+
+            return obj is SnapshotTableColumnNames other && Equals(other);
+        }
     }
 }

--- a/src/Akka.Persistence.Sql/Config/SnapshotTableConfig.cs
+++ b/src/Akka.Persistence.Sql/Config/SnapshotTableConfig.cs
@@ -4,9 +4,11 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
+using System;
+
 namespace Akka.Persistence.Sql.Config
 {
-    public sealed class SnapshotTableConfig
+    public sealed class SnapshotTableConfig: IEquatable<SnapshotTableConfig>
     {
         public SnapshotTableConfig(Configuration.Config config)
         {
@@ -18,5 +20,22 @@ namespace Akka.Persistence.Sql.Config
         public string Name { get; }
 
         public SnapshotTableColumnNames ColumnNames { get; }
+
+        public bool Equals(SnapshotTableConfig? other)
+        {
+            if (other is null)
+                return false;
+
+            if (ReferenceEquals(this, other))
+                return true;
+
+            return Name == other.Name && ColumnNames.Equals(other.ColumnNames);
+        }
+
+        public override bool Equals(object? obj)
+            => obj is not null && (ReferenceEquals(this, obj) || obj is SnapshotTableConfig other && Equals(other));
+
+        public override int GetHashCode()
+            => HashCode.Combine(Name, ColumnNames);
     }
 }

--- a/src/Akka.Persistence.Sql/Config/SnapshotTableConfiguration.cs
+++ b/src/Akka.Persistence.Sql/Config/SnapshotTableConfiguration.cs
@@ -9,7 +9,7 @@ using Akka.Configuration;
 
 namespace Akka.Persistence.Sql.Config
 {
-    public class SnapshotTableConfiguration
+    public class SnapshotTableConfiguration: IEquatable<SnapshotTableConfiguration>
     {
         public SnapshotTableConfiguration(Configuration.Config config)
         {
@@ -32,6 +32,28 @@ namespace Akka.Persistence.Sql.Config
         public SnapshotTableConfig SnapshotTable { get; }
 
         public string? SchemaName { get; }
+
+        public bool Equals(SnapshotTableConfiguration? other)
+        {
+            if (other is null)
+                return false;
+
+            if (ReferenceEquals(this, other))
+                return true;
+
+            return SnapshotTable.Equals(other.SnapshotTable) && SchemaName == other.SchemaName;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            if (obj is null)
+                return false;
+
+            if (ReferenceEquals(this, obj))
+                return true;
+
+            return obj is SnapshotTableConfiguration other && Equals(other);
+        }
 
         public override int GetHashCode()
             => HashCode.Combine(SnapshotTable, SchemaName);

--- a/src/Akka.Persistence.Sql/Config/TagTableColumnNames.cs
+++ b/src/Akka.Persistence.Sql/Config/TagTableColumnNames.cs
@@ -28,7 +28,7 @@ namespace Akka.Persistence.Sql.Config
 
         public string PersistenceId { get; }
 
-        public bool Equals(TagTableColumnNames other)
+        public bool Equals(TagTableColumnNames? other)
         {
             if (ReferenceEquals(null, other))
                 return false;
@@ -39,7 +39,7 @@ namespace Akka.Persistence.Sql.Config
             return OrderingId == other.OrderingId;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(this, obj))
                 return true;
@@ -48,6 +48,6 @@ namespace Akka.Persistence.Sql.Config
         }
 
         public override int GetHashCode()
-            => HashCode.Combine(OrderingId, Tag);
+            => HashCode.Combine(OrderingId, Tag, SequenceNumber, PersistenceId);
     }
 }

--- a/src/Akka.Persistence.Sql/Config/TagTableConfig.cs
+++ b/src/Akka.Persistence.Sql/Config/TagTableConfig.cs
@@ -22,7 +22,7 @@ namespace Akka.Persistence.Sql.Config
 
         public TagTableColumnNames ColumnNames { get; }
 
-        public bool Equals(TagTableConfig other)
+        public bool Equals(TagTableConfig? other)
         {
             if (ReferenceEquals(null, other))
                 return false;
@@ -30,11 +30,14 @@ namespace Akka.Persistence.Sql.Config
             if (ReferenceEquals(this, other))
                 return true;
 
-            return Name == other.Name && Equals(ColumnNames, other.ColumnNames);
+            return Name == other.Name && ColumnNames.Equals(other.ColumnNames);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
+            if(obj is null)
+                return false;
+            
             if (ReferenceEquals(this, obj))
                 return true;
 

--- a/src/Akka.Persistence.Sql/Db/AkkaDataConnection.cs
+++ b/src/Akka.Persistence.Sql/Db/AkkaDataConnection.cs
@@ -12,7 +12,6 @@ using Akka.Persistence.Sql.Journal.Types;
 using Akka.Persistence.Sql.Snapshot;
 using LinqToDB;
 using LinqToDB.Data;
-using LinqToDB.Data.RetryPolicy;
 using LinqToDB.DataProvider;
 using LinqToDB.SchemaProvider;
 

--- a/src/Akka.Persistence.Sql/Db/AkkaDataConnection.cs
+++ b/src/Akka.Persistence.Sql/Db/AkkaDataConnection.cs
@@ -37,12 +37,6 @@ namespace Akka.Persistence.Sql.Db
 
         public IDataProvider DataProvider => _connection.DataProvider;
 
-        public IRetryPolicy? RetryPolicy
-        {
-            get => _connection.RetryPolicy;
-            set => _connection.RetryPolicy = value;
-        }
-
         public ValueTask DisposeAsync()
             => _connection.DisposeAsync();
 

--- a/src/Akka.Persistence.Sql/Db/AkkaPersistenceDataConnectionFactory.cs
+++ b/src/Akka.Persistence.Sql/Db/AkkaPersistenceDataConnectionFactory.cs
@@ -383,10 +383,9 @@ namespace Akka.Persistence.Sql.Db
         private static DataOptions BuildDataOptions<TTable>(IProviderConfig<TTable> config, MappingSchema mappingSchema)
         {
             // LinqToDB.Data.DataConnection.ConfigurationApplier extracts different combinations therefore we can't
-            // just override the connection string or the provider name. We assume that the passed DataOptions object
-            // has sufficient information to build a connection or else we use the provided config.
-            var options = config.DataOptions ?? new DataOptions().UseConnectionString(config.ProviderName, config.ConnectionString);
-            return options.UseMappingSchema(mappingSchema);
+            // just override the connection string
+            var options = config.DataOptions ?? new DataOptions().UseConnectionString(config.ConnectionString);
+            return options.UseMappingSchema(mappingSchema).UseProvider(config.ProviderName);
         }
 
         public AkkaDataConnection GetConnection()

--- a/src/Akka.Persistence.Sql/Db/AkkaPersistenceDataConnectionFactory.cs
+++ b/src/Akka.Persistence.Sql/Db/AkkaPersistenceDataConnectionFactory.cs
@@ -383,9 +383,10 @@ namespace Akka.Persistence.Sql.Db
         private static DataOptions BuildDataOptions<TTable>(IProviderConfig<TTable> config, MappingSchema mappingSchema)
         {
             // LinqToDB.Data.DataConnection.ConfigurationApplier extracts different combinations therefore we can't
-            // just override the connection string
-            var options = config.DataOptions ?? new DataOptions().UseConnectionString(config.ConnectionString);
-            return options.UseMappingSchema(mappingSchema).UseProvider(config.ProviderName);
+            // just override the connection string or the provider name. If data options are set, we assume that a valid
+            // connection can be created.
+            var options = config.DataOptions ?? new DataOptions().UseConnectionString(config.ProviderName, config.ConnectionString);
+            return options.UseMappingSchema(mappingSchema);
         }
 
         public AkkaDataConnection GetConnection()

--- a/src/Akka.Persistence.Sql/Journal/SqlWriteJournal.cs
+++ b/src/Akka.Persistence.Sql/Journal/SqlWriteJournal.cs
@@ -61,6 +61,11 @@ namespace Akka.Persistence.Sql.Journal
 
             var config = journalConfig.WithFallback(SqlPersistence.DefaultJournalConfiguration);
             _journalConfig = new JournalConfig(config);
+
+            var setup = Context.System.Settings.Setup.Get<DataOptionsSetup>();
+            if (setup.HasValue)
+                _journalConfig = setup.Value.Apply(_journalConfig);
+
             _useWriterUuid = _journalConfig.TableConfig.EventJournalTable.UseWriterUuidColumn;
         }
 

--- a/src/Akka.Persistence.Sql/Journal/SqlWriteJournal.cs
+++ b/src/Akka.Persistence.Sql/Journal/SqlWriteJournal.cs
@@ -62,9 +62,17 @@ namespace Akka.Persistence.Sql.Journal
             var config = journalConfig.WithFallback(SqlPersistence.DefaultJournalConfiguration);
             _journalConfig = new JournalConfig(config);
 
-            var setup = Context.System.Settings.Setup.Get<DataOptionsSetup>();
-            if (setup.HasValue)
-                _journalConfig = setup.Value.Apply(_journalConfig);
+            var setup = Context.System.Settings.Setup;
+            var singleSetup = setup.Get<DataOptionsSetup>();
+            if (singleSetup.HasValue)
+                _journalConfig = singleSetup.Value.Apply(_journalConfig);
+            
+            if (_journalConfig.PluginId is not null)
+            {
+                var multiSetup = setup.Get<MultiDataOptionsSetup>();
+                if (multiSetup.HasValue && multiSetup.Value.TryGetDataOptionsFor(_journalConfig.PluginId, out var dataOptions))
+                    _journalConfig = _journalConfig.WithDataOptions(dataOptions);
+            }
 
             _useWriterUuid = _journalConfig.TableConfig.EventJournalTable.UseWriterUuidColumn;
         }

--- a/src/Akka.Persistence.Sql/Query/SqlReadJournal.cs
+++ b/src/Akka.Persistence.Sql/Query/SqlReadJournal.cs
@@ -53,6 +53,11 @@ namespace Akka.Persistence.Sql.Query
             Configuration.Config config)
         {
             _readJournalConfig = new ReadJournalConfig(config);
+
+            var setup = system.Settings.Setup.Get<DataOptionsSetup>();
+            if (setup.HasValue)
+                _readJournalConfig = setup.Value.Apply(_readJournalConfig);
+
             _eventAdapters = Persistence.Instance.Apply(system).AdaptersFor(_readJournalConfig.WritePluginId);
             
             // Fix for https://github.com/akkadotnet/Akka.Persistence.Sql/issues/344

--- a/src/Akka.Persistence.Sql/Snapshot/SqlSnapshotStore.cs
+++ b/src/Akka.Persistence.Sql/Snapshot/SqlSnapshotStore.cs
@@ -34,6 +34,10 @@ namespace Akka.Persistence.Sql.Snapshot
             var config = snapshotConfig.WithFallback(SqlPersistence.DefaultSnapshotConfiguration);
             _settings = new SnapshotConfig(config);
 
+            var setup = Context.System.Settings.Setup.Get<DataOptionsSetup>();
+            if (setup.HasValue)
+                _settings = setup.Value.Apply(_settings);
+
             _dao = new ByteArraySnapshotDao(
                 connectionFactory: new AkkaPersistenceDataConnectionFactory(_settings),
                 snapshotConfig: _settings,

--- a/src/Akka.Persistence.Sql/persistence.conf
+++ b/src/Akka.Persistence.Sql/persistence.conf
@@ -48,6 +48,13 @@
       # Note that Linq2Db may use a lower number per round-trip in some cases.
       db-round-trip-max-batch-size = 1000
 
+      # This batch size controls the maximum number of rows that will be sent
+      # In a single round trip to the DB when tag table is used. This is different than the -actual- batch size,
+      # And intentionally set larger than batch-size,
+      # to help atomicwrites be faster
+      # Note that Linq2Db may use a lower number per round-trip in some cases.
+      db-round-trip-max-tag-batch-size = 1000
+
       # Linq2Db by default will use a built string for multi-row inserts
       # Somewhat counterintuitively, this is faster than using parameters in most cases,
       # But if you would prefer parameters, you can set this to true.

--- a/src/Akka.Persistence.Sql/persistence.conf
+++ b/src/Akka.Persistence.Sql/persistence.conf
@@ -2,10 +2,16 @@
   journal {
     sql {
       class = "Akka.Persistence.Sql.Journal.SqlWriteJournal, Akka.Persistence.Sql"
+      
+      # The full HOCON path of this plugin 
+      plugin-id = "akka.persistence.journal.sql"
+      
       plugin-dispatcher = "akka.persistence.dispatchers.default-plugin-dispatcher"
-      connection-string = "" # Connection String is Required!
+      
+      connection-string = "" # Connection String is Required if DataOptionsSetup is not being used
 
-      # Provider name is required, refer to LinqToDb.ProviderName for values
+      # Provider name is required if DataOptionsSetup is not being used. 
+      # Refer to LinqToDb.ProviderName for values.
       # Always use a specific version if possible to avoid provider detection performance penalty
       # Don't worry if your DB is newer than what is listed; just pick the newest one (if yours is still newer)
       provider-name = ""
@@ -298,13 +304,16 @@
       sql {
         class = "Akka.Persistence.Sql.Query.SqlReadJournalProvider, Akka.Persistence.Sql"
 
+        # The full HOCON path of this plugin 
+        plugin-id = "akka.persistence.query.journal.sql"
+      
         # You should specify your proper sql journal plugin configuration path here.
         write-plugin = ""
 
         max-buffer-size = 500 # Number of events to buffer at a time.
         refresh-interval = 1s # interval for refreshing
 
-        connection-string = "" # Connection String is Required!
+        connection-string = "" # Connection String is required if DataOptionsSetup is not being used
 
         # This setting dictates how journal event tags are being read from the database.
         # Valid values:
@@ -325,7 +334,7 @@
           ask-timeout = 1s
         }
 
-        # Provider name is required.
+        # Provider name is required if DataOptionsSetup is not being used.
         # Refer to LinqToDb.ProviderName for values
         # Always use a specific version if possible
         # To avoid provider detection performance penalty

--- a/src/Akka.Persistence.Sql/snapshot.conf
+++ b/src/Akka.Persistence.Sql/snapshot.conf
@@ -2,10 +2,16 @@
   snapshot-store {
     sql {
       class = "Akka.Persistence.Sql.Snapshot.SqlSnapshotStore, Akka.Persistence.Sql"
+      
+      # The full HOCON path of this plugin 
+      plugin-id = "akka.persistence.snapshot-store.sql"
+      
       plugin-dispatcher = "akka.persistence.dispatchers.default-plugin-dispatcher"
+      
+      # connection-string is required if DataOptionsSetup is not being used
       connection-string = ""
 
-      # Provider name is required.
+      # Provider name is required if DataOptionsSetup is not being used.
       # Refer to LinqToDb.ProviderName for values
       # Always use a specific version if possible
       # To avoid provider detection performance penalty


### PR DESCRIPTION
Fixes #18 

## Changes

Adds a DataOptionsSetup class to be able to configure custom DataOptions for [linq2db](https://github.com/linq2db/linq2db)

## Remarks

* I didn’t want to add whole new PersistenceSetup class, so it’s just a Setup for the DataOptions. Otherwise, there would be three ways to configure the plugin, and more testing would be necessary.

* If the data options are provided, the user must add the provider and the connection string again (if needed). Linq2Db checks for different configuration variations, and always adding the connection string and the provider name would exclude some configurations (like a connection factory).
[See here ](https://github.com/linq2db/linq2db/blob/89b1b78041d88cfe03829def11d9ff71870082de/Source/LinqToDB/Data/DataConnection.Configuration.cs#L501)
  
* In this first version I didn’t include a Multi Setup class, like AzureTableStorageMultiJournalSetup. Would this be a blocker to a PR?

* I didn’t include a test for this setup, because the configs are patched in the corresponding Journal/Snapshot classes. So I really don’t know where or how to put it. Do you have an advise on this?

* The `Copy` Methods and private constructors [like here](https://github.com/Astasian/Akka.Persistence.Sql/blob/1c4eeeb3792a52180552a45458a014bd3389167c/src/Akka.Persistence.Sql/Config/SnapshotConfig.cs#L108) could be replaced by records with `with` copying. But I didn't want to make any potential breaking changes.


## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Changes in public API reviewed, if any.
* [x] I have added website documentation for this feature.
