### PR TITLE
Postgres: Use GENERATED AS IDENTITY if version is greater than 10

### DIFF
--- a/src/Akka.Persistence.Sql/Db/AkkaPersistenceDataConnectionFactory.cs
+++ b/src/Akka.Persistence.Sql/Db/AkkaPersistenceDataConnectionFactory.cs
@@ -150,6 +150,13 @@ namespace Akka.Persistence.Sql.Db
                     .HasDbType("INTEGER");
             }
 
+            if (providerName.Equals(ProviderName.PostgreSQL15))
+            {
+                rowBuilder
+                    .Member(r => r.Ordering)
+                    .HasDbType("BIGINT GENERATED ALWAYS AS IDENTITY");
+            }
+
             if (journalConfig.UseWriterUuidColumn)
             {
                 rowBuilder


### PR DESCRIPTION
## Changes

Change journal table ordering column to `BigInt Generated Always As Identity`