### PR TITLE
Update RELEASE_NOTES.md for 1.5.30 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-#### 1.5.30 October 3rd 2024 ####
+#### 1.5.30 October 4th 2024 ####
 
 * [Bump Akka to 1.5.30](https://github.com/akkadotnet/akka.net/releases/tag/1.5.30)
 * [Bump Akka.Hosting to v1.5.30](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.30)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
-#### 1.5.29 October 3rd 2024 ####
+#### 1.5.30 October 3rd 2024 ####
 
-* [Bump Akka to 1.5.29](https://github.com/akkadotnet/akka.net/releases/tag/1.5.29)
-* [Bump Akka.Hosting to v1.5.29](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.29)
+* [Bump Akka to 1.5.30](https://github.com/akkadotnet/akka.net/releases/tag/1.5.30)
+* [Bump Akka.Hosting to v1.5.30](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.30)
 * [PostgreSql: Use BIGINT for ordering column if PostgreSql version is greater than 10](https://github.com/akkadotnet/Akka.Persistence.Sql/pull/459)
 
 #### 1.5.28 September 9th 2024 ####


### PR DESCRIPTION
## 1.5.30 October 4th 2024

* [Bump Akka to 1.5.30](https://github.com/akkadotnet/akka.net/releases/tag/1.5.30)
* [Bump Akka.Hosting to v1.5.30](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.30)
* [PostgreSql: Use BIGINT for ordering column if PostgreSql version is greater than 10](https://github.com/akkadotnet/Akka.Persistence.Sql/pull/459)