### PR TITLE
Implement query throttling

### DIFF
--- a/src/Akka.Persistence.Sql.Hosting/HostingExtensions.cs
+++ b/src/Akka.Persistence.Sql.Hosting/HostingExtensions.cs
@@ -118,6 +118,9 @@ namespace Akka.Persistence.Sql.Hosting
         ///         </item>
         ///     </list>
         /// </param>
+        /// <param name="maxConcurrentQueries">
+        ///     Determines how many queries are allowed to run in parallel at any given time
+        /// </param>
         /// <returns>
         ///     The same <see cref="AkkaConfigurationBuilder" /> instance originally passed in.
         /// </returns>
@@ -142,7 +145,8 @@ namespace Akka.Persistence.Sql.Hosting
             DatabaseMapping? databaseMapping = null,
             TagMode? tagStorageMode = null,
             bool? deleteCompatibilityMode = null,
-            bool? useWriterUuidColumn = null)
+            bool? useWriterUuidColumn = null,
+            int? maxConcurrentQueries = null)
         {
             if (mode == PersistenceMode.SnapshotStore && journalBuilder is not null)
                 throw new Exception($"{nameof(journalBuilder)} can only be set when {nameof(mode)} is set to either {PersistenceMode.Both} or {PersistenceMode.Journal}");
@@ -160,6 +164,7 @@ namespace Akka.Persistence.Sql.Hosting
                 AutoInitialize = autoInitialize,
                 TagStorageMode = tagStorageMode,
                 DeleteCompatibilityMode = deleteCompatibilityMode,
+                MaxConcurrentQueries = maxConcurrentQueries,
             };
 
             if (databaseMapping is not null)
@@ -323,6 +328,9 @@ namespace Akka.Persistence.Sql.Hosting
         ///         </item>
         ///     </list>
         /// </param>
+        /// <param name="maxConcurrentQueries">
+        ///     Determines how many queries are allowed to run in parallel at any given time
+        /// </param>
         /// <returns>
         ///     The same <see cref="AkkaConfigurationBuilder" /> instance originally passed in.
         /// </returns>
@@ -345,7 +353,8 @@ namespace Akka.Persistence.Sql.Hosting
             DatabaseMapping? databaseMapping = null,
             TagMode? tagStorageMode = null,
             bool? deleteCompatibilityMode = null,
-            bool? useWriterUuidColumn = null)
+            bool? useWriterUuidColumn = null,
+            int? maxConcurrentQueries = null)
         {
             if (mode == PersistenceMode.SnapshotStore && journalBuilder is not null)
                 throw new Exception($"{nameof(journalBuilder)} can only be set when {nameof(mode)} is set to either {PersistenceMode.Both} or {PersistenceMode.Journal}");
@@ -359,6 +368,7 @@ namespace Akka.Persistence.Sql.Hosting
                 TagStorageMode = tagStorageMode,
                 DeleteCompatibilityMode = deleteCompatibilityMode,
                 DataOptions = dataOptions,
+                MaxConcurrentQueries = maxConcurrentQueries,
             };
 
             if (databaseMapping is not null)

--- a/src/Akka.Persistence.Sql.Hosting/SqlJournalOptions.cs
+++ b/src/Akka.Persistence.Sql.Hosting/SqlJournalOptions.cs
@@ -141,7 +141,22 @@ namespace Akka.Persistence.Sql.Hosting
         /// </summary>
         public DataOptions? DataOptions { get; set; }
         
+        /// <summary>
+        ///     <para>
+        ///         Determines how many queries are allowed to run in parallel at any given time
+        ///     </para>
+        ///     <b>Default</b>: 100
+        /// </summary>
         public int? MaxConcurrentQueries { get; set; }
+        
+        /// <summary>
+        ///     <para>
+        ///         How long should a query request stays in queue when it is being throttled before
+        ///         signaling an operation timeout
+        ///     </para>
+        ///     <b>Default</b>: 3 seconds
+        /// </summary>
+        public TimeSpan? QueryThrottleTimeout { get; set; }
 
         protected override Configuration.Config InternalDefaultConfig => Default;
 
@@ -228,6 +243,9 @@ namespace Akka.Persistence.Sql.Hosting
             
             if(MaxConcurrentQueries is not null)
                 sb.AppendLine($"max-concurrent-queries = {MaxConcurrentQueries.ToHocon()}");
+            
+            if(QueryThrottleTimeout is not null)
+                sb.AppendLine($"query-throttle-timeout = {QueryThrottleTimeout.Value.ToHocon()}");
             
             sb.AppendLine($"serializer = {Serializer.ToHocon()}");
             

--- a/src/Akka.Persistence.Sql.Hosting/SqlJournalOptions.cs
+++ b/src/Akka.Persistence.Sql.Hosting/SqlJournalOptions.cs
@@ -140,6 +140,8 @@ namespace Akka.Persistence.Sql.Hosting
         ///     </para>
         /// </summary>
         public DataOptions? DataOptions { get; set; }
+        
+        public int? MaxConcurrentQueries { get; set; }
 
         protected override Configuration.Config InternalDefaultConfig => Default;
 
@@ -223,6 +225,9 @@ namespace Akka.Persistence.Sql.Hosting
 
             if (QueryRefreshInterval is not null)
                 sb.AppendLine($"refresh-interval = {QueryRefreshInterval.ToHocon()}");
+            
+            if(MaxConcurrentQueries is not null)
+                sb.AppendLine($"max-concurrent-queries = {MaxConcurrentQueries.ToHocon()}");
             
             sb.AppendLine($"serializer = {Serializer.ToHocon()}");
             

--- a/src/Akka.Persistence.Sql.Tests/Query/MsSqlite/Csv/MsSqliteQueryThrottleSpecs.cs
+++ b/src/Akka.Persistence.Sql.Tests/Query/MsSqlite/Csv/MsSqliteQueryThrottleSpecs.cs
@@ -1,0 +1,22 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="MsSqliteQueryThrottleSpecs.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Persistence.Sql.Config;
+using Akka.Persistence.Sql.Tests.Common.Containers;
+using Akka.Persistence.Sql.Tests.Sqlite;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Sql.Tests.Query.MsSqlite.Csv;
+
+[Collection(nameof(MsSqlitePersistenceSpec))]
+public class MsSqliteQueryThrottleSpecs: QueryThrottleSpecsBase<MsSqliteContainer>
+{
+    public MsSqliteQueryThrottleSpecs(ITestOutputHelper output, MsSqliteContainer fixture)
+        : base(TagMode.Csv, output, nameof(MsSqliteAllEventsSpec), fixture)
+    {
+    }
+}

--- a/src/Akka.Persistence.Sql.Tests/Query/MsSqlite/TagTable/MsSqliteQueryThrottleSpecs.cs
+++ b/src/Akka.Persistence.Sql.Tests/Query/MsSqlite/TagTable/MsSqliteQueryThrottleSpecs.cs
@@ -1,0 +1,22 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="MsSqliteQueryThrottleSpecs.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Persistence.Sql.Config;
+using Akka.Persistence.Sql.Tests.Common.Containers;
+using Akka.Persistence.Sql.Tests.Sqlite;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Sql.Tests.Query.MsSqlite.TagTable;
+
+[Collection(nameof(MsSqlitePersistenceSpec))]
+public class MsSqliteQueryThrottleSpecs: QueryThrottleSpecsBase<MsSqliteContainer>
+{
+    public MsSqliteQueryThrottleSpecs(ITestOutputHelper output, MsSqliteContainer fixture)
+        : base(TagMode.TagTable, output, nameof(Csv.MsSqliteAllEventsSpec), fixture)
+    {
+    }
+}

--- a/src/Akka.Persistence.Sql.Tests/Query/MySql/Csv/MySqlQueryThrottleSpecs.cs
+++ b/src/Akka.Persistence.Sql.Tests/Query/MySql/Csv/MySqlQueryThrottleSpecs.cs
@@ -1,0 +1,22 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="MySqlQueryThrottleSpecs.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Persistence.Sql.Config;
+using Akka.Persistence.Sql.Tests.Common.Containers;
+using Akka.Persistence.Sql.Tests.MySql;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Sql.Tests.Query.MySql.Csv;
+
+[Collection(nameof(MySqlPersistenceSpec))]
+public class MySqlQueryThrottleSpecs: QueryThrottleSpecsBase<MySqlContainer>
+{
+    public MySqlQueryThrottleSpecs(ITestOutputHelper output, MySqlContainer fixture)
+        : base(TagMode.Csv, output, nameof(MySqlAllEventsSpec), fixture)
+    {
+    }
+}

--- a/src/Akka.Persistence.Sql.Tests/Query/MySql/TagTable/MySqlQueryThrottleSpecs.cs
+++ b/src/Akka.Persistence.Sql.Tests/Query/MySql/TagTable/MySqlQueryThrottleSpecs.cs
@@ -1,0 +1,22 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="MySqlQueryThrottleSpecs.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Persistence.Sql.Config;
+using Akka.Persistence.Sql.Tests.Common.Containers;
+using Akka.Persistence.Sql.Tests.MySql;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Sql.Tests.Query.MySql.TagTable;
+
+[Collection(nameof(MySqlPersistenceSpec))]
+public class MySqlQueryThrottleSpecs: QueryThrottleSpecsBase<MySqlContainer>
+{
+    public MySqlQueryThrottleSpecs(ITestOutputHelper output, MySqlContainer fixture)
+        : base(TagMode.TagTable, output, nameof(Csv.MySqlAllEventsSpec), fixture)
+    {
+    }
+}

--- a/src/Akka.Persistence.Sql.Tests/Query/PostgreSql/Csv/PostgreSqlQueryThrottleSpecs.cs
+++ b/src/Akka.Persistence.Sql.Tests/Query/PostgreSql/Csv/PostgreSqlQueryThrottleSpecs.cs
@@ -1,0 +1,22 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="PostgreSqlQueryThrottleSpecs.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Persistence.Sql.Config;
+using Akka.Persistence.Sql.Tests.Common.Containers;
+using Akka.Persistence.Sql.Tests.PostgreSql;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Sql.Tests.Query.PostgreSql.Csv;
+
+[Collection(nameof(PostgreSqlPersistenceSpec))]
+public class PostgreSqlQueryThrottleSpecs: QueryThrottleSpecsBase<PostgreSqlContainer>
+{
+    public PostgreSqlQueryThrottleSpecs(ITestOutputHelper output, PostgreSqlContainer fixture)
+        : base(TagMode.Csv, output, nameof(PostgreSqlAllEventsSpec), fixture)
+    {
+    }
+}

--- a/src/Akka.Persistence.Sql.Tests/Query/PostgreSql/TagTable/PostgreSqlQueryThrottleSpecs.cs
+++ b/src/Akka.Persistence.Sql.Tests/Query/PostgreSql/TagTable/PostgreSqlQueryThrottleSpecs.cs
@@ -1,0 +1,22 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="PostgreSqlQueryThrottleSpecs.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Persistence.Sql.Config;
+using Akka.Persistence.Sql.Tests.Common.Containers;
+using Akka.Persistence.Sql.Tests.PostgreSql;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Sql.Tests.Query.PostgreSql.TagTable;
+
+[Collection(nameof(PostgreSqlPersistenceSpec))]
+public class PostgreSqlQueryThrottleSpecs: QueryThrottleSpecsBase<PostgreSqlContainer>
+{
+    public PostgreSqlQueryThrottleSpecs(ITestOutputHelper output, PostgreSqlContainer fixture)
+        : base(TagMode.TagTable, output, nameof(Csv.PostgreSqlAllEventsSpec), fixture)
+    {
+    }
+}

--- a/src/Akka.Persistence.Sql.Tests/Query/QueryThrottleSpecsBase.cs
+++ b/src/Akka.Persistence.Sql.Tests/Query/QueryThrottleSpecsBase.cs
@@ -1,0 +1,402 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="QueryThrottleSpecsBase.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Event;
+using Akka.Persistence.Query;
+using Akka.Persistence.Sql.Config;
+using Akka.Persistence.Sql.Db;
+using Akka.Persistence.Sql.Journal.Dao;
+using Akka.Persistence.Sql.Journal.Types;
+using Akka.Persistence.Sql.Query;
+using Akka.Persistence.Sql.Query.Dao;
+using Akka.Persistence.Sql.Tests.Common.Containers;
+using Akka.Persistence.TCK;
+using Akka.Streams;
+using Akka.Streams.TestKit;
+using Akka.TestKit;
+using Akka.TestKit.Extensions;
+using Akka.Util;
+using FluentAssertions;
+using FluentAssertions.Extensions;
+using Xunit;
+using Xunit.Abstractions;
+
+using static FluentAssertions.FluentActions;
+
+namespace Akka.Persistence.Sql.Tests.Query;
+
+public abstract class QueryThrottleSpecsBase<T> : PluginSpec where T : ITestContainer
+{
+    private TestProbe _senderProbe;
+    private TestProbe _throttlerProbe;
+    private ActorMaterializer _materializer;
+
+    protected QueryThrottleSpecsBase(TagMode tagMode, ITestOutputHelper output, string name, T fixture)
+        : base(FromConfig(Config(tagMode, fixture)), name, output)
+    {
+        // Force start read journal
+        _ = Journal;
+
+        _senderProbe = CreateTestProbe();
+        _throttlerProbe = CreateTestProbe();
+        _materializer = Sys.Materializer();
+    }
+
+    protected IActorRef Journal => Extension.JournalFor(null);
+
+    protected BaseByteReadArrayJournalDao ReadJournalDao
+    {
+        get
+        {
+            var sysConfig = Sys.Settings.Config;
+            var readJournalConfig = new ReadJournalConfig(sysConfig.GetConfig(SqlReadJournal.Identifier));
+            var connFact = new AkkaPersistenceDataConnectionFactory(readJournalConfig);
+            return new ByteArrayReadJournalDao(
+                scheduler: Sys.Scheduler.Advanced,
+                materializer: _materializer,
+                connectionFactory: connFact,
+                readJournalConfig: readJournalConfig,
+                serializer: new ByteArrayJournalSerializer(
+                    journalConfig: readJournalConfig,
+                    serializer: Sys.Serialization,
+                    separator: readJournalConfig.PluginConfig.TagSeparator,
+                    writerUuid: null),
+                _throttlerProbe,
+                default);
+        }
+    }
+
+    protected override bool SupportsSerialization => true;
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private static Configuration.Config Config(TagMode tagMode, T fixture)
+    {
+        if (!fixture.InitializeDbAsync().Wait(10.Seconds()))
+            throw new Exception("Failed to clean up database in 10 seconds");
+
+        return ConfigurationFactory.ParseString(
+$$"""
+akka {
+    loglevel = INFO
+    persistence {
+        journal {
+            plugin = "akka.persistence.journal.sql"
+            auto-start-journals = [ "akka.persistence.journal.sql" ]
+            sql {
+                event-adapters {
+                    color-tagger  = "Akka.Persistence.TCK.Query.ColorFruitTagger, Akka.Persistence.TCK"
+                }
+                event-adapter-bindings = {
+                    "System.String" = color-tagger
+                }
+                provider-name = "{{fixture.ProviderName}}"
+                tag-write-mode = "{{tagMode}}"
+                connection-string = "{{fixture.ConnectionString}}"
+            }
+        }
+        query.journal.sql {
+            provider-name = "{{fixture.ProviderName}}"
+            connection-string = "{{fixture.ConnectionString}}"
+            tag-read-mode = "{{tagMode}}"
+            refresh-interval = 1s
+        }
+    }
+}
+akka.test.single-expect-default = 10s
+""")
+            .WithFallback(SqlPersistence.DefaultConfiguration);
+    }
+
+    protected async Task WriteMessagesAsync(int from, int to, string pid, IActorRef sender, string writerGuid)
+    {
+        var messages = Enumerable.Range(from, to - 1)
+            .Select(i =>
+                i == to - 1
+                    ? new AtomicWrite(new[] {Persistent(i), Persistent(i + 1)}.ToImmutableList<IPersistentRepresentation>())
+                    : new AtomicWrite(Persistent(i)));
+        var probe = CreateTestProbe();
+
+        Journal.Tell(new WriteMessages(messages, probe.Ref, ActorInstanceId));
+
+        await probe.ExpectMsgAsync<WriteMessagesSuccessful>();
+        for (var i = from; i <= to; i++)
+        {
+            var n = i;
+            await probe.ExpectMsgAsync<WriteMessageSuccess>(m =>
+                    m.Persistent.Payload.ToString() == ("a-" + n) && m.Persistent.SequenceNr == n &&
+                    m.Persistent.PersistenceId == Pid);
+        }
+
+        return;
+
+        Persistent Persistent(long i)
+            => new("a-" + i, i, pid, string.Empty, false, sender, writerGuid);
+    }
+
+    [Fact(DisplayName = "BaseByteReadArrayJournalDao.AllPersistenceIdsSource should respect throttling")]
+    public virtual async Task AllPersistenceIdsSourceThrottleTest()
+    {
+        await WriteMessagesAsync(1, 5, Pid, _senderProbe.Ref, WriterGuid);
+        
+        var dao = ReadJournalDao;
+        var probe = dao.AllPersistenceIdsSource(long.MaxValue)
+            .RunWith(this.SinkProbe<string>(), _materializer);
+
+        await probe.ExpectSubscriptionAsync().ShouldCompleteWithin(1.Seconds());
+        await probe.RequestAsync(100);
+        await _throttlerProbe.ExpectMsgAsync<RequestQueryStart>();
+        var streamActor = _throttlerProbe.LastSender;
+        
+        await probe.ExpectNoMsgAsync(200.Milliseconds());
+        streamActor.Tell(QueryStartGranted.Instance);
+        
+        await probe.ExpectNextAsync(Pid, 1.Seconds());
+        await probe.ExpectCompleteAsync();
+    }
+
+    [Fact(DisplayName = "BaseByteReadArrayJournalDao.EventsByTag should respect throttling")]
+    public virtual async Task EventsByTagThrottleTest()
+    {
+        var a = Sys.ActorOf(Query.TestActor.Props("a"));
+        var b = Sys.ActorOf(Query.TestActor.Props("b"));
+
+        a.Tell("hello");
+        await ExpectMsgAsync("hello-done");
+        a.Tell("a green apple");
+        await ExpectMsgAsync("a green apple-done");
+        b.Tell("a black car");
+        await ExpectMsgAsync("a black car-done");
+        a.Tell("something else");
+        await ExpectMsgAsync("something else-done");
+        a.Tell("a green banana");
+        await ExpectMsgAsync("a green banana-done");
+        b.Tell("a green leaf");
+        await ExpectMsgAsync("a green leaf-done");
+
+        var dao = ReadJournalDao;
+        var probe = dao.EventsByTag("green", 0, long.MaxValue, long.MaxValue)
+            .RunWith(this.SinkProbe<Try<(IPersistentRepresentation, string[], long)>>(), _materializer);
+
+        await probe.ExpectSubscriptionAsync().ShouldCompleteWithin(1.Seconds());
+        await probe.RequestAsync(10);
+        await _throttlerProbe.ExpectMsgAsync<RequestQueryStart>();
+        var streamActor = _throttlerProbe.LastSender;
+        
+        await probe.ExpectNoMsgAsync(200.Milliseconds());
+        streamActor.Tell(QueryStartGranted.Instance);
+
+        await ValidateRepresentation(probe, "a", 2L, "a green apple", "apple", "green");
+        await ValidateRepresentation(probe, "a", 4L, "a green banana", "banana", "green");
+        await ValidateRepresentation(probe, "b", 2L, "a green leaf", "green");
+        await probe.ExpectCompleteAsync();
+        return;
+
+        async Task ValidateRepresentation(TestSubscriber.Probe<Try<(IPersistentRepresentation, string[], long)>> p, string persistenceId, long sequenceNr, object payload, params string[] tags)
+        {
+            var next = await p.ExpectNextAsync(1.Seconds());
+            next.IsSuccess.Should().BeTrue();
+            var (representation, elemTags, _) = next.Get();
+            representation.PersistenceId.Should().Be(persistenceId);
+            representation.SequenceNr.Should().Be(sequenceNr);
+            representation.Payload.Should().Be(payload);
+            elemTags.Should().BeEquivalentTo(tags);
+        }
+    }
+
+    [Fact(DisplayName = "BaseByteReadArrayJournalDao.Events should respect throttling")]
+    public virtual async Task EventsThrottleTest()
+    {
+        await WriteMessagesAsync(1, 5, Pid, _senderProbe.Ref, WriterGuid);
+
+        var dao = ReadJournalDao;
+        var probe = dao.Events(0, long.MaxValue, long.MaxValue)
+            .RunWith(this.SinkProbe<Try<(IPersistentRepresentation, string[], long)>>(), _materializer);
+
+        await probe.ExpectSubscriptionAsync().ShouldCompleteWithin(1.Seconds());
+        await probe.RequestAsync(10);
+        await _throttlerProbe.ExpectMsgAsync<RequestQueryStart>();
+        var streamActor = _throttlerProbe.LastSender;
+        
+        await probe.ExpectNoMsgAsync(200.Milliseconds());
+        streamActor.Tell(QueryStartGranted.Instance);
+
+        await ValidateRepresentation(probe, Pid, 1L, "a-1");
+        await ValidateRepresentation(probe, Pid, 2L, "a-2");
+        await ValidateRepresentation(probe, Pid, 3L, "a-3");
+        await ValidateRepresentation(probe, Pid, 4L, "a-4");
+        await ValidateRepresentation(probe, Pid, 5L, "a-5");
+        await probe.ExpectCompleteAsync();
+        return;
+
+        async Task ValidateRepresentation(TestSubscriber.Probe<Try<(IPersistentRepresentation, string[], long)>> p, string persistenceId, long sequenceNr, object payload, params string[] tags)
+        {
+            var next = await p.ExpectNextAsync(1.Seconds());
+            next.IsSuccess.Should().BeTrue();
+            var (representation, elemTags, _) = next.Get();
+            representation.PersistenceId.Should().Be(persistenceId);
+            representation.SequenceNr.Should().Be(sequenceNr);
+            representation.Payload.Should().Be(payload);
+            elemTags.Should().BeEquivalentTo(tags);
+        }
+    }
+
+    [Fact(DisplayName = "BaseByteReadArrayJournalDao.Messages should respect throttling")]
+    public virtual async Task MessagesThrottleTest()
+    {
+        await WriteMessagesAsync(1, 5, Pid, _senderProbe.Ref, WriterGuid);
+        
+        var dao = ReadJournalDao;
+        var source = await dao.Messages(Pid, 0, long.MaxValue, long.MaxValue);
+        var probe = source
+            .RunWith(this.SinkProbe<Try<ReplayCompletion>>(), _materializer);
+
+        await probe.ExpectSubscriptionAsync().ShouldCompleteWithin(1.Seconds());
+        await probe.RequestAsync(10);
+        await _throttlerProbe.ExpectMsgAsync<RequestQueryStart>();
+        var streamActor = _throttlerProbe.LastSender;
+        
+        await probe.ExpectNoMsgAsync(200.Milliseconds());
+        streamActor.Tell(QueryStartGranted.Instance);
+
+        await ValidateReplay(probe, Pid, 1L, "a-1");
+        await ValidateReplay(probe, Pid, 2L, "a-2");
+        await ValidateReplay(probe, Pid, 3L, "a-3");
+        await ValidateReplay(probe, Pid, 4L, "a-4");
+        await ValidateReplay(probe, Pid, 5L, "a-5");
+        await probe.ExpectCompleteAsync();
+
+        return;
+        
+        async Task ValidateReplay(TestSubscriber.Probe<Try<ReplayCompletion>> p, string persistenceId, long sequenceNr, object payload)
+        {
+            var next = await p.ExpectNextAsync();
+            next.IsSuccess.Should().BeTrue();
+            var completion = next.Get();
+            completion.Representation.PersistenceId.Should().Be(persistenceId);
+            completion.Representation.SequenceNr.Should().Be(sequenceNr);
+            completion.Representation.Payload.Should().Be(payload);
+        }
+    }
+
+    [Fact(DisplayName = "BaseByteReadArrayJournalDao.JournalSequence should respect throttling")]
+    public virtual async Task JournalSequenceThrottleTest()
+    {
+        await WriteMessagesAsync(1, 5, Pid, _senderProbe.Ref, WriterGuid);
+        
+        var dao = ReadJournalDao;
+        var probe = dao.JournalSequence(0, long.MaxValue)
+            .RunWith(this.SinkProbe<long>(), _materializer);
+
+        await probe.ExpectSubscriptionAsync().ShouldCompleteWithin(1.Seconds());
+        await probe.RequestAsync(10);
+        await _throttlerProbe.ExpectMsgAsync<RequestQueryStart>();
+        var streamActor = _throttlerProbe.LastSender;
+        
+        await probe.ExpectNoMsgAsync(200.Milliseconds());
+        streamActor.Tell(QueryStartGranted.Instance);
+
+        await probe.ExpectNextAsync(1, 1.Seconds());
+        await probe.ExpectNextAsync(2, 1.Seconds());
+        await probe.ExpectNextAsync(3, 1.Seconds());
+        await probe.ExpectNextAsync(4, 1.Seconds());
+        await probe.ExpectNextAsync(5, 1.Seconds());
+        await probe.ExpectCompleteAsync();
+    }
+    
+    [Fact(DisplayName = "BaseByteReadArrayJournalDao.MaxJournalSequenceAsync should respect throttling")]
+    public virtual async Task MaxJournalSequenceAsyncThrottleTest()
+    {
+        await WriteMessagesAsync(1, 5, Pid, _senderProbe.Ref, WriterGuid);
+        
+        var dao = ReadJournalDao;
+        var task = dao.MaxJournalSequenceAsync();
+
+        await _throttlerProbe.ExpectMsgAsync<RequestQueryStart>();
+        var streamActor = _throttlerProbe.LastSender;
+
+        await Awaiting(async () => await task.WaitAsync(200.Milliseconds()))
+            .Should().ThrowAsync<TimeoutException>();
+        streamActor.Tell(QueryStartGranted.Instance);
+
+        (await task).Should().Be(5);
+    }
+    
+    
+}
+
+internal class TestActor : UntypedPersistentActor
+{
+    public static Props Props(string persistenceId) => Actor.Props.Create(() => new TestActor(persistenceId));
+
+    public sealed class DeleteCommand
+    {
+        public DeleteCommand(long toSequenceNr)
+        {
+            ToSequenceNr = toSequenceNr;
+        }
+
+        public long ToSequenceNr { get; }
+    }
+
+    public TestActor(string persistenceId)
+    {
+        PersistenceId = persistenceId;
+    }
+
+    public override string PersistenceId { get; }
+
+    protected override void OnRecover(object message)
+    {
+    }
+
+    protected override void OnCommand(object message)
+    {
+        switch (message)
+        {
+            case DeleteCommand delete:
+                DeleteMessages(delete.ToSequenceNr);
+                Become(WhileDeleting(Sender)); // need to wait for delete ACK to return
+                break;
+            case string cmd:
+                var sender = Sender;
+                Persist(cmd, e => sender.Tell($"{e}-done"));
+                break;
+        }
+    }
+
+    protected Receive WhileDeleting(IActorRef originalSender)
+    {
+        return message =>
+        {
+            switch (message)
+            {
+                case DeleteMessagesSuccess success:
+                    originalSender.Tell($"{success.ToSequenceNr}-deleted");
+                    Become(OnCommand);
+                    Stash.UnstashAll();
+                    break;
+                case DeleteMessagesFailure failure:
+                    Log.Error(failure.Cause, "Failed to delete messages to sequence number [{0}].", failure.ToSequenceNr);
+                    originalSender.Tell($"{failure.ToSequenceNr}-deleted-failed");
+                    Become(OnCommand);
+                    Stash.UnstashAll();
+                    break;
+                default:
+                    Stash.Stash();
+                    break;
+            }
+
+            return true;
+        };
+    }
+}

--- a/src/Akka.Persistence.Sql.Tests/Query/SqlServer/Csv/SqlServerQueryThrottleSpecs.cs
+++ b/src/Akka.Persistence.Sql.Tests/Query/SqlServer/Csv/SqlServerQueryThrottleSpecs.cs
@@ -1,0 +1,22 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="SqlServerQueryThrottleSpecs.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Persistence.Sql.Config;
+using Akka.Persistence.Sql.Tests.Common.Containers;
+using Akka.Persistence.Sql.Tests.SqlServer;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Sql.Tests.Query.SqlServer.Csv;
+
+[Collection(nameof(SqlServerPersistenceSpec))]
+public class SqlServerQueryThrottleSpecs: QueryThrottleSpecsBase<SqlServerContainer>
+{
+    public SqlServerQueryThrottleSpecs(ITestOutputHelper output, SqlServerContainer fixture)
+        : base(TagMode.Csv, output, nameof(SqlServerAllEventsSpec), fixture)
+    {
+    }
+}

--- a/src/Akka.Persistence.Sql.Tests/Query/SqlServer/TagTable/SqlServerQueryThrottleSpecs.cs
+++ b/src/Akka.Persistence.Sql.Tests/Query/SqlServer/TagTable/SqlServerQueryThrottleSpecs.cs
@@ -1,0 +1,22 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="SqlServerQueryThrottleSpecs.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Persistence.Sql.Config;
+using Akka.Persistence.Sql.Tests.Common.Containers;
+using Akka.Persistence.Sql.Tests.SqlServer;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Sql.Tests.Query.SqlServer.TagTable;
+
+[Collection(nameof(SqlServerPersistenceSpec))]
+public class SqlServerQueryThrottleSpecs: QueryThrottleSpecsBase<SqlServerContainer>
+{
+    public SqlServerQueryThrottleSpecs(ITestOutputHelper output, SqlServerContainer fixture)
+        : base(TagMode.TagTable, output, nameof(Csv.SqlServerAllEventsSpec), fixture)
+    {
+    }
+}

--- a/src/Akka.Persistence.Sql.Tests/Query/Sqlite/Csv/SqliteQueryThrottleSpecs.cs
+++ b/src/Akka.Persistence.Sql.Tests/Query/Sqlite/Csv/SqliteQueryThrottleSpecs.cs
@@ -1,0 +1,22 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="SqliteQueryThrottleSpecs.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Persistence.Sql.Config;
+using Akka.Persistence.Sql.Tests.Common.Containers;
+using Akka.Persistence.Sql.Tests.Sqlite;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Sql.Tests.Query.Sqlite.Csv;
+
+[Collection(nameof(SqlitePersistenceSpec))]
+public class SqliteQueryThrottleSpecs: QueryThrottleSpecsBase<SqliteContainer>
+{
+    public SqliteQueryThrottleSpecs(ITestOutputHelper output, SqliteContainer fixture)
+        : base(TagMode.Csv, output, nameof(SqliteAllEventsSpec), fixture)
+    {
+    }
+}

--- a/src/Akka.Persistence.Sql.Tests/Query/Sqlite/TagTable/SqliteQueryThrottleSpecs.cs
+++ b/src/Akka.Persistence.Sql.Tests/Query/Sqlite/TagTable/SqliteQueryThrottleSpecs.cs
@@ -1,0 +1,22 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="SqliteQueryThrottleSpecs.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Persistence.Sql.Config;
+using Akka.Persistence.Sql.Tests.Common.Containers;
+using Akka.Persistence.Sql.Tests.Sqlite;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Sql.Tests.Query.Sqlite.TagTable;
+
+[Collection(nameof(SqlitePersistenceSpec))]
+public class SqliteQueryThrottleSpecs: QueryThrottleSpecsBase<SqliteContainer>
+{
+    public SqliteQueryThrottleSpecs(ITestOutputHelper output, SqliteContainer fixture)
+        : base(TagMode.TagTable, output, nameof(Csv.SqliteAllEventsSpec), fixture)
+    {
+    }
+}

--- a/src/Akka.Persistence.Sql/Config/ReadJournalConfig.cs
+++ b/src/Akka.Persistence.Sql/Config/ReadJournalConfig.cs
@@ -29,6 +29,7 @@ namespace Akka.Persistence.Sql.Config
             AddShutdownHook = config.GetBoolean("add-shutdown-hook", true);
             DefaultSerializer = config.GetString("serializer");
             ReadIsolationLevel = config.GetIsolationLevel("read-isolation-level");
+            MaxConcurrentQueries = config.GetInt("max-concurrent-queries", 100);
             DataOptions = null;
 
             // We don't do any writes in a read journal
@@ -36,6 +37,7 @@ namespace Akka.Persistence.Sql.Config
         }
 
         private ReadJournalConfig(
+            string? pluginId,
             string connectionString,
             string providerName,
             string writePluginId,
@@ -50,8 +52,10 @@ namespace Akka.Persistence.Sql.Config
             IsolationLevel writeIsolationLevel,
             IsolationLevel readIsolationLevel,
             DataOptions? dataOptions,
-            bool useCloneConnection)
+            bool useCloneConnection,
+            int maxConcurrentQueries)
         {
+            PluginId = pluginId ?? SqlPersistence.QueryConfigPath;
             ConnectionString = connectionString;
             ProviderName = providerName;
             WritePluginId = writePluginId;
@@ -67,9 +71,10 @@ namespace Akka.Persistence.Sql.Config
             ReadIsolationLevel = readIsolationLevel;
             DataOptions = dataOptions;
             UseCloneConnection = useCloneConnection;
+            MaxConcurrentQueries = maxConcurrentQueries;
         }
         
-        public string? PluginId { get; }
+        public string PluginId { get; }
 
         public string WritePluginId { get; }
         
@@ -102,11 +107,17 @@ namespace Akka.Persistence.Sql.Config
         public IsolationLevel ReadIsolationLevel { get; }
 
         public DataOptions? DataOptions { get; }
+        
+        public int MaxConcurrentQueries { get; }
 
         public ReadJournalConfig WithDataOptions(DataOptions dataOptions)
             => Copy(dataOptions: dataOptions);
 
+        public ReadJournalConfig WithPluginId(string pluginId)
+            => Copy(pluginId: pluginId);
+
         private ReadJournalConfig Copy(
+            string? pluginId = null,
             string? connectionString = null,
             string? providerName = null,
             string? writePluginId = null,
@@ -121,8 +132,10 @@ namespace Akka.Persistence.Sql.Config
             IsolationLevel? writeIsolationLevel = null,
             IsolationLevel? readIsolationLevel = null,
             DataOptions? dataOptions = null,
-            bool? useCloneConnection = null)
+            bool? useCloneConnection = null,
+            int? maxConcurrentQueries = null)
             => new(
+                pluginId ?? PluginId,
                 connectionString ?? ConnectionString,
                 providerName ?? ProviderName,
                 writePluginId ?? WritePluginId,
@@ -137,6 +150,7 @@ namespace Akka.Persistence.Sql.Config
                 writeIsolationLevel ?? WriteIsolationLevel,
                 readIsolationLevel ?? ReadIsolationLevel,
                 dataOptions ?? DataOptions,
-                useCloneConnection ?? UseCloneConnection);
+                useCloneConnection ?? UseCloneConnection,
+                maxConcurrentQueries ?? MaxConcurrentQueries);
     }
 }

--- a/src/Akka.Persistence.Sql/Config/ReadJournalConfig.cs
+++ b/src/Akka.Persistence.Sql/Config/ReadJournalConfig.cs
@@ -30,6 +30,7 @@ namespace Akka.Persistence.Sql.Config
             DefaultSerializer = config.GetString("serializer");
             ReadIsolationLevel = config.GetIsolationLevel("read-isolation-level");
             MaxConcurrentQueries = config.GetInt("max-concurrent-queries", 100);
+            QueryThrottleTimeout = config.GetTimeSpan("query-throttle-timeout", TimeSpan.FromSeconds(3));
             DataOptions = null;
 
             // We don't do any writes in a read journal
@@ -53,7 +54,8 @@ namespace Akka.Persistence.Sql.Config
             IsolationLevel readIsolationLevel,
             DataOptions? dataOptions,
             bool useCloneConnection,
-            int maxConcurrentQueries)
+            int maxConcurrentQueries,
+            TimeSpan queryThrottleTimeout)
         {
             PluginId = pluginId ?? SqlPersistence.QueryConfigPath;
             ConnectionString = connectionString;
@@ -72,6 +74,7 @@ namespace Akka.Persistence.Sql.Config
             DataOptions = dataOptions;
             UseCloneConnection = useCloneConnection;
             MaxConcurrentQueries = maxConcurrentQueries;
+            QueryThrottleTimeout = queryThrottleTimeout;
         }
         
         public string PluginId { get; }
@@ -109,6 +112,8 @@ namespace Akka.Persistence.Sql.Config
         public DataOptions? DataOptions { get; }
         
         public int MaxConcurrentQueries { get; }
+        
+        public TimeSpan QueryThrottleTimeout { get; }
 
         public ReadJournalConfig WithDataOptions(DataOptions dataOptions)
             => Copy(dataOptions: dataOptions);
@@ -133,7 +138,8 @@ namespace Akka.Persistence.Sql.Config
             IsolationLevel? readIsolationLevel = null,
             DataOptions? dataOptions = null,
             bool? useCloneConnection = null,
-            int? maxConcurrentQueries = null)
+            int? maxConcurrentQueries = null,
+            TimeSpan? queryThrottleTimeout = null)
             => new(
                 pluginId ?? PluginId,
                 connectionString ?? ConnectionString,
@@ -151,6 +157,7 @@ namespace Akka.Persistence.Sql.Config
                 readIsolationLevel ?? ReadIsolationLevel,
                 dataOptions ?? DataOptions,
                 useCloneConnection ?? UseCloneConnection,
-                maxConcurrentQueries ?? MaxConcurrentQueries);
+                maxConcurrentQueries ?? MaxConcurrentQueries,
+                queryThrottleTimeout ?? QueryThrottleTimeout);
     }
 }

--- a/src/Akka.Persistence.Sql/Properties/FriendsOf.cs
+++ b/src/Akka.Persistence.Sql/Properties/FriendsOf.cs
@@ -7,3 +7,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Akka.Persistence.Sql.Tests.Common")]
+[assembly: InternalsVisibleTo("Akka.Persistence.Sql.Tests")]

--- a/src/Akka.Persistence.Sql/Query/Dao/BaseByteReadArrayJournalDao.cs
+++ b/src/Akka.Persistence.Sql/Query/Dao/BaseByteReadArrayJournalDao.cs
@@ -213,9 +213,7 @@ namespace Akka.Persistence.Sql.Query.Dao
         public async Task<long> MaxJournalSequenceAsync()
         {
             return await ConnectionFactory.ExecuteQueryWithTransactionAsync(
-                _dbStateHolder.QueryPermitter,
-                ReadIsolationLevel,
-                ShutdownToken,
+                _dbStateHolder,
                 async (connection, token) =>
                 {
                     // persistence-jdbc does not filter deleted here.

--- a/src/Akka.Persistence.Sql/Query/Dao/ByteArrayReadJournalDao.cs
+++ b/src/Akka.Persistence.Sql/Query/Dao/ByteArrayReadJournalDao.cs
@@ -6,6 +6,7 @@
 
 using System.Threading;
 using Akka.Actor;
+using Akka.Event;
 using Akka.Persistence.Sql.Config;
 using Akka.Persistence.Sql.Db;
 using Akka.Persistence.Sql.Journal.Types;
@@ -22,7 +23,8 @@ namespace Akka.Persistence.Sql.Query.Dao
             AkkaPersistenceDataConnectionFactory connectionFactory,
             ReadJournalConfig readJournalConfig,
             FlowPersistentRepresentationSerializer<JournalRow> serializer,
+            IActorRef queryPermitter,
             CancellationToken token)
-            : base(scheduler, materializer, connectionFactory, readJournalConfig, serializer, token) { }
+            : base(scheduler, materializer, connectionFactory, readJournalConfig, serializer, queryPermitter, token) { }
     }
 }

--- a/src/Akka.Persistence.Sql/Query/Dao/DbStateHolder.cs
+++ b/src/Akka.Persistence.Sql/Query/Dao/DbStateHolder.cs
@@ -4,6 +4,7 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
+using System;
 using System.Data;
 using System.Threading;
 using Akka.Actor;
@@ -23,19 +24,22 @@ namespace Akka.Persistence.Sql.Query.Dao
         public readonly CancellationToken ShutdownToken;
         public readonly TagMode Mode;
         public readonly IActorRef QueryPermitter;
+        public readonly TimeSpan QueryThrottleTimeout;
         
         public DbStateHolder(
             AkkaPersistenceDataConnectionFactory connectionFactory,
             IsolationLevel isolationLevel, 
             CancellationToken shutdownToken, 
             TagMode mode,
-            IActorRef queryPermitter)
+            IActorRef queryPermitter,
+            TimeSpan queryThrottleTimeout)
         {
             ConnectionFactory = connectionFactory;
             IsolationLevel = isolationLevel;
             ShutdownToken = shutdownToken;
             Mode = mode;
             QueryPermitter = queryPermitter;
+            QueryThrottleTimeout = queryThrottleTimeout;
         }
     }
 }

--- a/src/Akka.Persistence.Sql/Query/Dao/DbStateHolder.cs
+++ b/src/Akka.Persistence.Sql/Query/Dao/DbStateHolder.cs
@@ -6,6 +6,8 @@
 
 using System.Data;
 using System.Threading;
+using Akka.Actor;
+using Akka.Event;
 using Akka.Persistence.Sql.Config;
 using Akka.Persistence.Sql.Db;
 
@@ -20,17 +22,20 @@ namespace Akka.Persistence.Sql.Query.Dao
         public readonly IsolationLevel IsolationLevel;
         public readonly CancellationToken ShutdownToken;
         public readonly TagMode Mode;
+        public readonly IActorRef QueryPermitter;
+        
         public DbStateHolder(
             AkkaPersistenceDataConnectionFactory connectionFactory,
             IsolationLevel isolationLevel, 
             CancellationToken shutdownToken, 
-            TagMode mode
-        )
+            TagMode mode,
+            IActorRef queryPermitter)
         {
             ConnectionFactory = connectionFactory;
             IsolationLevel = isolationLevel;
             ShutdownToken = shutdownToken;
             Mode = mode;
+            QueryPermitter = queryPermitter;
         }
     }
 }

--- a/src/Akka.Persistence.Sql/Query/QueryThrottler.cs
+++ b/src/Akka.Persistence.Sql/Query/QueryThrottler.cs
@@ -1,0 +1,120 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="QueryThrottler.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2024 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2024 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Akka.Actor;
+using Akka.Event;
+using Akka.Pattern;
+
+namespace Akka.Persistence.Sql.Query;
+
+/// <summary>
+/// Request token from throttler
+/// </summary>
+internal sealed class RequestQueryStart
+{
+    public static readonly RequestQueryStart Instance = new();
+    private RequestQueryStart() { }
+}
+
+/// <summary>
+/// Token request granted
+/// </summary>
+internal sealed class QueryStartGranted
+{
+    public static readonly QueryStartGranted Instance = new();
+    private QueryStartGranted() { }
+}
+
+/// <summary>
+/// Return token to throttler
+/// </summary>
+internal sealed class ReturnQueryStart
+{
+    public static readonly ReturnQueryStart Instance = new();
+    private ReturnQueryStart() { }
+}
+
+/// <summary>
+/// Token bucket throttler that grants queries permissions to run each iteration
+/// </summary>
+/// <remarks>
+/// Works identically to the RecoveryPermitter built into Akka.Persistence.
+/// </remarks>
+internal sealed class QueryThrottler : ReceiveActor
+{
+    private readonly LinkedList<IActorRef> _pending = new();
+    private readonly ILoggingAdapter _log = Context.GetLogger();
+    private int _usedPermits;
+    private int _maxPendingStats;
+
+    public QueryThrottler(int maxPermits)
+    {
+        MaxPermits = maxPermits;
+        
+        Receive<RequestQueryStart>(_ =>
+        {
+            Context.Watch(Sender);
+            if (_usedPermits >= MaxPermits)
+            {
+                if (_pending.Count == 0)
+                    _log.Debug("Exceeded max-concurrent-queries[{0}]. First pending {1}", MaxPermits, Sender);
+                _pending.AddLast(Sender);
+                _maxPendingStats = Math.Max(_maxPendingStats, _pending.Count);
+            }
+            else
+            {
+                QueryStartGranted(Sender);   
+            }
+        });
+        
+        Receive<ReturnQueryStart>(_ =>
+        {
+            ReturnQueryPermit(Sender);
+        });
+        
+        Receive<Terminated>(terminated =>
+        {
+            if (!_pending.Remove(terminated.ActorRef))
+            {
+                ReturnQueryPermit(terminated.ActorRef);
+            }
+        });
+    }
+
+    public int MaxPermits { get; }
+    
+    private void QueryStartGranted(IActorRef actorRef)
+    {
+        _usedPermits++;
+        actorRef.Tell(Query.QueryStartGranted.Instance);
+    }
+    
+    private void ReturnQueryPermit(IActorRef actorRef)
+    {
+        _usedPermits--;
+        Context.Unwatch(actorRef);
+
+        if (_usedPermits < 0)
+            throw new IllegalStateException("Permits must not be negative");
+
+        if (_pending.Count > 0)
+        {
+            var popRef = _pending.First?.Value;
+            _pending.RemoveFirst();
+            QueryStartGranted(popRef);
+        }
+
+        if (_pending.Count != 0 || _maxPendingStats <= 0)
+            return;
+        
+        if(_log.IsDebugEnabled)
+            _log.Debug("Drained pending recovery permit requests, max in progress was [{0}], still [{1}] in progress", _usedPermits + _maxPendingStats, _usedPermits);
+        _maxPendingStats = 0;
+    }
+}

--- a/src/Akka.Persistence.Sql/Query/QueryThrottler.cs
+++ b/src/Akka.Persistence.Sql/Query/QueryThrottler.cs
@@ -103,9 +103,9 @@ internal sealed class QueryThrottler : ReceiveActor
         if (_usedPermits < 0)
             throw new IllegalStateException("Permits must not be negative");
 
-        if (_pending.Count > 0)
+        var popRef = _pending.First?.Value;
+        if (popRef is not null)
         {
-            var popRef = _pending.First?.Value;
             _pending.RemoveFirst();
             QueryStartGranted(popRef);
         }

--- a/src/Akka.Persistence.Sql/persistence.conf
+++ b/src/Akka.Persistence.Sql/persistence.conf
@@ -320,6 +320,9 @@
         max-buffer-size = 500 # Number of events to buffer at a time.
         refresh-interval = 1s # interval for refreshing
 
+        # Determines how many queries are allowed to run in parallel at any given time
+        max-concurrent-queries = 100
+
         connection-string = "" # Connection String is required if DataOptionsSetup is not being used
 
         # This setting dictates how journal event tags are being read from the database.

--- a/src/Akka.Persistence.Sql/persistence.conf
+++ b/src/Akka.Persistence.Sql/persistence.conf
@@ -322,6 +322,10 @@
 
         # Determines how many queries are allowed to run in parallel at any given time
         max-concurrent-queries = 100
+        
+        # How long should a query request stays in queue when it is being throttled before
+        # signaling an operation timeout
+        query-throttle-timeout = 3s
 
         connection-string = "" # Connection String is required if DataOptionsSetup is not being used
 


### PR DESCRIPTION
Implement query throttling scheme, similar to https://github.com/akkadotnet/akka.net/pull/6436

## Changes

* [x] Add new `akka.persistence.query.journal.sql.max-concurrent-queries` HOCON setting
* [x] Port `QueryThrottler` class
* [x] Make sure that all query DB operations are guarded by throttle permit
* [x] Add Hosting implementation
* [x] Add unit test