### PR TITLE
compare unadapted event count to batch size when determining if there are any more events to read

### DIFF
--- a/src/Akka.Persistence.Sql/Query/SqlReadJournal.cs
+++ b/src/Akka.Persistence.Sql/Query/SqlReadJournal.cs
@@ -226,7 +226,7 @@ namespace Akka.Persistence.Sql.Query
 
             return _readJournalDao
                 .Events(offset, latestOrdering.Max, max)
-                .AlsoToMaterialized(Sink.Aggregate(0L, (count, _) => count + 1), Keep.Right)
+                .AlsoToMaterialized(Sink.Aggregate<Try<(IPersistentRepresentation, string[], long)>, long>(0L, (readCount, _) => readCount + 1), Keep.Right)
                 .SelectAsync(1, r => Task.FromResult(r.Get()))
                 .SelectMany(
                     a =>
@@ -367,15 +367,14 @@ namespace Akka.Persistence.Sql.Query
                                     GetMaxOrderingId.Instance,
                                     askTimeout);
 
-                            var (xsTask, readCountTask) = CurrentJournalEvents(uf.offset, batchSize, queryUntil)
+                            var readBatch = CurrentJournalEvents(uf.offset, batchSize, queryUntil)
                                 .ToMaterialized(Sink.Seq<EventEnvelope>(), Keep.Both)
                                 .Run(_mat);
 
-                            await Task.WhenAll(xsTask, readCountTask);
-                            var xs = xsTask.Result;
-                            var readCount = readCountTask.Result;
+                            var rawReadCount = await readBatch.Item1;
+                            var xs = await readBatch.Item2;
 
-                            var hasMoreEvents = readCount == batchSize;
+                            var hasMoreEvents = rawReadCount == batchSize;
 
                             var nextControl = FlowControlEnum.Unknown;
                             if (terminateAfterOffset.HasValue)

--- a/src/Akka.Persistence.Sql/Query/SqlReadJournal.cs
+++ b/src/Akka.Persistence.Sql/Query/SqlReadJournal.cs
@@ -219,13 +219,14 @@ namespace Akka.Persistence.Sql.Query
                             timestamp: r.representation.Timestamp, 
                             tags: r.tags));
 
-        private Source<EventEnvelope, NotUsed> CurrentJournalEvents(long offset, long max, MaxOrderingId latestOrdering)
+        private Source<EventEnvelope, Task<long>> CurrentJournalEvents(long offset, long max, MaxOrderingId latestOrdering)
         {
             if (latestOrdering.Max < offset)
-                return Source.Empty<EventEnvelope>();
+                return Source.Empty<EventEnvelope>().MapMaterializedValue(_ => Task.FromResult(0L));
 
             return _readJournalDao
                 .Events(offset, latestOrdering.Max, max)
+                .AlsoToMaterialized(Sink.Aggregate(0L, (count, _) => count + 1), Keep.Right)
                 .SelectAsync(1, r => Task.FromResult(r.Get()))
                 .SelectMany(
                     a =>
@@ -366,10 +367,15 @@ namespace Akka.Persistence.Sql.Query
                                     GetMaxOrderingId.Instance,
                                     askTimeout);
 
-                            var xs = await CurrentJournalEvents(uf.offset, batchSize, queryUntil)
-                                .RunWith(Sink.Seq<EventEnvelope>(), _mat);
+                            var (xsTask, readCountTask) = CurrentJournalEvents(uf.offset, batchSize, queryUntil)
+                                .ToMaterialized(Sink.Seq<EventEnvelope>(), Keep.Both)
+                                .Run(_mat);
 
-                            var hasMoreEvents = xs.Count == batchSize;
+                            await Task.WhenAll(xsTask, readCountTask);
+                            var xs = xsTask.Result;
+                            var readCount = readCountTask.Result;
+
+                            var hasMoreEvents = readCount == batchSize;
 
                             var nextControl = FlowControlEnum.Unknown;
                             if (terminateAfterOffset.HasValue)


### PR DESCRIPTION
Fixes #
https://github.com/akkadotnet/Akka.Persistence.Sql/issues/502

## Changes

Please provide a brief description of the changes here.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [ ] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [ ] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [ ] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed, if any.
* [ ] I have added website documentation for this feature.

### Latest `dev` Benchmarks 

Include data from the [relevant benchmark](https://getakka.net/community/contributing/index.html#improve-performance) prior to this change here.

### This PR's Benchmarks

Include data from after this change here.
