### PR TITLE
Update RELEASE_NOTES.md for 1.5.40 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
-#### 1.5.39 March 19th 2025 ####
+#### 1.5.40 March 19th 2025 ####
 
-Akka.Persistence.Sql 1.5.39 contains a mission-critical bugfix from Akka 1.5.39 that fixes the [`SelectAsync` `NullReferenceException` issue](https://github.com/akkadotnet/Akka.Persistence.Sql/issues/498) 
+Akka.Persistence.Sql 1.5.40 contains a mission-critical bugfix from Akka 1.5.40 that fixes the [`SelectAsync` `NullReferenceException` issue](https://github.com/akkadotnet/Akka.Persistence.Sql/issues/498) 
 
-* [Bump Akka version to 1.5.39](https://github.com/akkadotnet/akka.net/releases/tag/1.5.39)
-* [Bump Akka.Hosting version to 1.5.39](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.39)
+* [Bump Akka version to 1.5.40](https://github.com/akkadotnet/akka.net/releases/tag/1.5.40)
+* [Bump Akka.Hosting version to 1.5.40](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.40)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
-#### 1.5.38.1 March 11th 2025 ####
+#### 1.5.39 March 19th 2025 ####
 
-* [Fix `BaseByteArrayJournalDao` stream resiliency problem](https://github.com/akkadotnet/Akka.Persistence.Sql/issues/521)
+Akka.Persistence.Sql 1.5.39 contains a mission-critical bugfix from Akka 1.5.39 that fixes the [`SelectAsync` `NullReferenceException` issue](https://github.com/akkadotnet/Akka.Persistence.Sql/issues/498) 
+
+* [Bump Akka version to 1.5.39](https://github.com/akkadotnet/akka.net/releases/tag/1.5.39)
+* [Bump Akka.Hosting version to 1.5.39](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.39)


### PR DESCRIPTION
## 1.5.40 March 19th 2025 

Akka.Persistence.Sql 1.5.40 contains a mission-critical bugfix from Akka 1.5.40 that fixes the [`SelectAsync` `NullReferenceException` issue](https://github.com/akkadotnet/Akka.Persistence.Sql/issues/498) 

* [Bump Akka version to 1.5.40](https://github.com/akkadotnet/akka.net/releases/tag/1.5.40)
* [Bump Akka.Hosting version to 1.5.40](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.40)
