### PR TITLE
docs: set the correct default value for `autoInitialize`

### DIFF
--- a/src/Akka.Persistence.Sql.Hosting/HostingExtensions.cs
+++ b/src/Akka.Persistence.Sql.Hosting/HostingExtensions.cs
@@ -29,7 +29,7 @@ namespace Akka.Persistence.Sql.Hosting
         ///     <para>
         ///         Should the SQL store table be initialized automatically.
         ///     </para>
-        ///     <i>Default</i>: <c>false</c>
+        ///     <i>Default</i>: <c>true</c>
         /// </param>
         /// <param name="providerName">
         ///     A string constant defining the database type to connect to, valid values are defined inside
@@ -244,7 +244,7 @@ namespace Akka.Persistence.Sql.Hosting
         ///     <para>
         ///         Should the SQL store table be initialized automatically.
         ///     </para>
-        ///     <i>Default</i>: <c>false</c>
+        ///     <i>Default</i>: <c>true</c>
         /// </param>
         /// <param name="mode">
         ///     <para>


### PR DESCRIPTION
## Changes

Fixes an issue with the XML doc for `HostingExtensions`, it says `autoInitialize` defaults to `false`, when it actually defaults to `true`.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).