### PR TITLE
Improve journal delete performance

### DIFF
--- a/src/Akka.Persistence.Sql/Db/AkkaPersistenceDataConnectionFactory.cs
+++ b/src/Akka.Persistence.Sql/Db/AkkaPersistenceDataConnectionFactory.cs
@@ -42,7 +42,7 @@ namespace Akka.Persistence.Sql.Db
 
             _useCloneDataConnection = config.UseCloneConnection;
 
-            if (_opts.RetryPolicyOptions.RetryPolicy is null && _opts.ConnectionOptions.ProviderName!.ToLowerInvariant().StartsWith("sqlserver"))
+            if (_opts.RetryPolicyOptions.RetryPolicy is null && _opts.RetryPolicyOptions.Factory is null && _opts.ConnectionOptions.ProviderName!.ToLowerInvariant().StartsWith("sqlserver"))
                 _opts = _opts.WithOptions( _opts.RetryPolicyOptions with { RetryPolicy = new SqlServerRetryPolicy() } );
             
             _cloneConnection = new Lazy<AkkaDataConnection>(

--- a/src/Akka.Persistence.Sql/Journal/Dao/BaseByteArrayJournalDao.cs
+++ b/src/Akka.Persistence.Sql/Journal/Dao/BaseByteArrayJournalDao.cs
@@ -119,6 +119,9 @@ namespace Akka.Persistence.Sql.Journal.Dao
             {
                 maxMarkedDeletion = await MaxMarkedForDeletionMaxPersistenceIdQuery(connection, persistenceId, maxSequenceNr).FirstOrDefaultAsync(ShutdownToken);
             }
+
+            if (maxMarkedDeletion is 0)
+                return;
             
             await ConnectionFactory.ExecuteWithTransactionAsync(
                 WriteIsolationLevel,

--- a/src/Akka.Persistence.Sql/Journal/Dao/BaseByteArrayJournalDao.cs
+++ b/src/Akka.Persistence.Sql/Journal/Dao/BaseByteArrayJournalDao.cs
@@ -112,22 +112,34 @@ namespace Akka.Persistence.Sql.Journal.Dao
 
         public async Task Delete(string persistenceId, long maxSequenceNr)
         {
+            long maxMarkedDeletion;
+
+            // no need to use transaction
+            await using (var connection = ConnectionFactory.GetConnection())
+            {
+                maxMarkedDeletion = await MaxMarkedForDeletionMaxPersistenceIdQuery(connection, persistenceId, maxSequenceNr).FirstOrDefaultAsync(ShutdownToken);
+            }
+            
             await ConnectionFactory.ExecuteWithTransactionAsync(
                 WriteIsolationLevel,
                 ShutdownToken,
                 async (connection, token) =>
                 {
-                    await connection
-                        .GetTable<JournalRow>()
+                    var journalTable = connection.GetTable<JournalRow>();
+                    await journalTable
                         .Where(
                             r =>
                                 r.PersistenceId == persistenceId &&
-                                r.SequenceNumber <= maxSequenceNr)
+                                r.SequenceNumber == maxMarkedDeletion)
                         .Set(r => r.Deleted, true)
                         .UpdateAsync(token);
 
-                    var maxMarkedDeletion =
-                        await MaxMarkedForDeletionMaxPersistenceIdQuery(connection, persistenceId).FirstOrDefaultAsync(token);
+                    await journalTable
+                        .Where(
+                            r =>
+                                r.PersistenceId == persistenceId &&
+                                r.SequenceNumber < maxMarkedDeletion)
+                        .DeleteAsync(token);
 
                     if (JournalConfig.DaoConfig.SqlCommonCompatibilityMode)
                     {
@@ -146,19 +158,7 @@ namespace Akka.Persistence.Sql.Journal.Dao
                                     SequenceNumber = maxMarkedDeletion,
                                 },
                                 token: token);
-                    }
 
-                    await connection
-                        .GetTable<JournalRow>()
-                        .Where(
-                            r =>
-                                r.PersistenceId == persistenceId &&
-                                r.SequenceNumber <= maxSequenceNr &&
-                                r.SequenceNumber < maxMarkedDeletion)
-                        .DeleteAsync(token);
-
-                    if (JournalConfig.DaoConfig.SqlCommonCompatibilityMode)
-                    {
                         await connection
                             .GetTable<JournalMetaData>()
                             .Where(
@@ -174,7 +174,7 @@ namespace Akka.Persistence.Sql.Journal.Dao
                             .GetTable<JournalTagRow>()
                             .Where(
                                 r =>
-                                    r.SequenceNumber <= maxSequenceNr &&
+                                    r.SequenceNumber < maxMarkedDeletion &&
                                     r.PersistenceId == persistenceId)
                             .DeleteAsync(token);
                     }
@@ -436,10 +436,11 @@ namespace Akka.Persistence.Sql.Journal.Dao
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static IQueryable<long> MaxMarkedForDeletionMaxPersistenceIdQuery(
             AkkaDataConnection connection,
-            string persistenceId)
+            string persistenceId, 
+            long maxSequenceNr)
             => connection
                 .GetTable<JournalRow>()
-                .Where(r => r.PersistenceId == persistenceId && r.Deleted)
+                .Where(r => r.PersistenceId == persistenceId && r.SequenceNumber <= maxSequenceNr)
                 .OrderByDescending(r => r.SequenceNumber)
                 .Select(r => r.SequenceNumber)
                 .Take(1);


### PR DESCRIPTION
> [!NOTE]
>
> These changes are safe because we're using transactions, the old JVM implementation queries were designed that way because they have to account for possible non-transaction delete failures.
> We need transaction guarantee because we have to write to multiple tables to support backward compatibility and tag table indexing.

## Changes

Optimize event journal delete code
* Shorten the codes living inside the transaction block
* Optimize SQL query