### PR TITLE
Fix `SqlServerRetryPolicy` `GetNextDelay` returning negative `TimeSpan`

### DIFF
--- a/src/Akka.Persistence.Sql/Db/AkkaPersistenceDataConnectionFactory.cs
+++ b/src/Akka.Persistence.Sql/Db/AkkaPersistenceDataConnectionFactory.cs
@@ -79,7 +79,7 @@ namespace Akka.Persistence.Sql.Db
             _useCloneDataConnection = config.UseCloneConnection;
 
             if (_opts.RetryPolicyOptions.RetryPolicy is null && _opts.ConnectionOptions.ProviderName!.ToLowerInvariant().StartsWith("sqlserver"))
-                _opts = _opts.WithOptions( _opts.RetryPolicyOptions with { RetryPolicy = new SqlServerRetryPolicy() } );
+                _opts = _opts.WithOptions( _opts.RetryPolicyOptions with { RetryPolicy = new AkkaSqlServerRetryPolicy() } );
 
             _cloneConnection = new Lazy<AkkaDataConnection>(
                 () => new AkkaDataConnection(

--- a/src/Akka.Persistence.Sql/Db/AkkaSqlServerRetryPolicy.cs
+++ b/src/Akka.Persistence.Sql/Db/AkkaSqlServerRetryPolicy.cs
@@ -1,0 +1,31 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="CustomSqlServerRetryPolicy.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using LinqToDB.DataProvider.SqlServer;
+
+namespace Akka.Persistence.Sql.Db;
+
+public class AkkaSqlServerRetryPolicy: SqlServerRetryPolicy
+{
+    public AkkaSqlServerRetryPolicy() { }
+    public AkkaSqlServerRetryPolicy(int maxRetryCount) : base(maxRetryCount) { }
+    public AkkaSqlServerRetryPolicy(
+        int maxRetryCount,
+        TimeSpan maxRetryDelay,
+        double randomFactor,
+        double exponentialBase,
+        TimeSpan coefficient,
+        ICollection<int>? errorNumbersToAdd) 
+        : base(maxRetryCount, maxRetryDelay, randomFactor, exponentialBase, coefficient, errorNumbersToAdd) { }
+
+    protected override TimeSpan? GetNextDelay(Exception lastException)
+    {
+        var nextDelay = base.GetNextDelay(lastException);
+        return nextDelay is { TotalMilliseconds: < 0 } ? TimeSpan.Zero : nextDelay;
+    } 
+}


### PR DESCRIPTION
Fixes https://github.com/linq2db/linq2db/issues/4913

## Changes

Make sure that `GetNextDelay()` does not return a negative milliseconds value