### PR TITLE
Update RELEASE_NOTES.md for 1.5.42

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+#### 1.5.42 May 22nd 2025 ####
+
+* [Bump AkkaVersion to 1.5.42](https://github.com/akkadotnet/akka.net/releases/tag/1.5.42)
+* [Fix SqlServerRetryPolicy.GetNextDelay returns negative TimeSpan](https://github.com/akkadotnet/Akka.Persistence.Sql/pull/539)
+
 #### 1.5.40.1 April 7th 2025 ####
 
 * [Fix duplicate actor name for read journal sequencer actors](https://github.com/akkadotnet/Akka.Persistence.Sql/pull/531)


### PR DESCRIPTION
#### 1.5.42 May 22nd 2025 ####

* [Bump AkkaVersion to 1.5.42](https://github.com/akkadotnet/akka.net/releases/tag/1.5.42)
* [Fix SqlServerRetryPolicy.GetNextDelay returns negative TimeSpan](https://github.com/akkadotnet/Akka.Persistence.Sql/pull/539)