### PR TITLE
Add missing using keyword in snapshot-store DAO

### DIFF
--- a/src/Akka.Persistence.Sql/Snapshot/ByteArraySnapshotDao.cs
+++ b/src/Akka.Persistence.Sql/Snapshot/ByteArraySnapshotDao.cs
@@ -19,7 +19,7 @@ using LinqToDB;
 
 namespace Akka.Persistence.Sql.Snapshot
 {
-    public class ByteArraySnapshotDao : ISnapshotDao
+    public class ByteArraySnapshotDao : ISnapshotDao, IDisposable
     {
         private readonly AkkaPersistenceDataConnectionFactory _connectionFactory;
         private readonly ByteArrayDateTimeSnapshotSerializer _dateTimeSerializer;
@@ -54,7 +54,7 @@ namespace Akka.Persistence.Sql.Snapshot
             string persistenceId,
             CancellationToken cancellationToken)
         {
-            var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);
             await _connectionFactory.ExecuteWithTransactionAsync(
                 _writeIsolationLevel,
                 cts.Token,
@@ -82,7 +82,7 @@ namespace Akka.Persistence.Sql.Snapshot
             long maxSequenceNr,
             CancellationToken cancellationToken)
         {
-            var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);
             await _connectionFactory.ExecuteWithTransactionAsync(
                 _writeIsolationLevel,
                 cts.Token,
@@ -116,7 +116,7 @@ namespace Akka.Persistence.Sql.Snapshot
             DateTime maxTimestamp,
             CancellationToken cancellationToken)
         {
-            var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);
             await _connectionFactory.ExecuteWithTransactionAsync(
                 _writeIsolationLevel,
                 cts.Token,
@@ -151,7 +151,7 @@ namespace Akka.Persistence.Sql.Snapshot
             DateTime maxTimestamp,
             CancellationToken cancellationToken)
         {
-            var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);
             await _connectionFactory.ExecuteWithTransactionAsync(
                 _writeIsolationLevel,
                 cts.Token,
@@ -186,7 +186,7 @@ namespace Akka.Persistence.Sql.Snapshot
             string persistenceId,
             CancellationToken cancellationToken)
         {
-            var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);
             return await _connectionFactory.ExecuteWithTransactionAsync(
                 _readIsolationLevel,
                 cts.Token,
@@ -224,7 +224,7 @@ namespace Akka.Persistence.Sql.Snapshot
             DateTime timestamp,
             CancellationToken cancellationToken)
         {
-            var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);
             return await _connectionFactory.ExecuteWithTransactionAsync(
                 _readIsolationLevel,
                 cts.Token,
@@ -268,7 +268,7 @@ namespace Akka.Persistence.Sql.Snapshot
             long sequenceNr,
             CancellationToken cancellationToken)
         {
-            var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);
             return await _connectionFactory.ExecuteWithTransactionAsync(
                 _readIsolationLevel,
                 cts.Token,
@@ -313,7 +313,7 @@ namespace Akka.Persistence.Sql.Snapshot
             DateTime timestamp,
             CancellationToken cancellationToken)
         {
-            var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);
             return await _connectionFactory.ExecuteWithTransactionAsync(
                 _readIsolationLevel,
                 cts.Token,
@@ -360,7 +360,7 @@ namespace Akka.Persistence.Sql.Snapshot
             DateTime timestamp,
             CancellationToken cancellationToken)
         {
-            var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);
             await _connectionFactory.ExecuteWithTransactionAsync(
                 _writeIsolationLevel,
                 cts.Token,
@@ -403,7 +403,7 @@ namespace Akka.Persistence.Sql.Snapshot
             object snapshot,
             CancellationToken cancellationToken)
         {
-            var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);
             await _connectionFactory.ExecuteWithTransactionAsync(
                 _writeIsolationLevel,
                 cts.Token,
@@ -442,6 +442,12 @@ namespace Akka.Persistence.Sql.Snapshot
             {
                 await connection.CreateTableAsync<LongSnapshotRow>(TableOptions.CreateIfNotExists, footer);
             }
+        }
+
+        public void Dispose()
+        {
+            _shutdownCts.Cancel();
+            _shutdownCts.Dispose();
         }
     }
 }

--- a/src/Akka.Persistence.Sql/Snapshot/SqlSnapshotStore.cs
+++ b/src/Akka.Persistence.Sql/Snapshot/SqlSnapshotStore.cs
@@ -64,6 +64,12 @@ namespace Akka.Persistence.Sql.Snapshot
             BecomeStacked(WaitingForInitialization);
         }
 
+        protected override void PostStop()
+        {
+            _dao.Dispose();
+            base.PostStop();
+        }
+
         private bool WaitingForInitialization(object message)
         {
             switch (message)


### PR DESCRIPTION
Memory leak caused by `CancellationTokenSource` has been observed in the snapshot store DAO.

## Changes

Add missing `using` keyword in `ByteArraySnapshotDao` to make sure that all `CancellationTokenSource` are disposed properly.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).

### Latest `dev` Benchmarks 

Benchmark was done by continuously creating new `ReceivePersistentActor` at the rate of 50 actors per second for 5 minutes. Memory snapshot were taken using Jetbrains DotMemory using API before and after the actor creation spam and were compared to check for memory leak.

![image](https://github.com/user-attachments/assets/da5d6157-f5a9-455a-b269-89ed0b56840f)

### This PR's Benchmarks

![image](https://github.com/user-attachments/assets/97426b07-949a-4e65-9e04-20d1bcb503ba)
