### PR TITLE
Release 1.5.51.1

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+#### 1.5.51.1 October 2nd 2025 ####
+
+* [Fix health check registration bug in Akka.Hosting extensions](https://github.com/akkadotnet/Akka.Persistence.Sql/pull/549)
+* [Add Akka.Hosting health check documentation to README](https://github.com/akkadotnet/Akka.Persistence.Sql/pull/548)
+
 #### 1.5.51 October 1st 2025 ####
 
 * [Bump AkkaVersion and AkkaHostingVersion to 1.5.51](https://github.com/akkadotnet/akka.net/releases/tag/1.5.51)

--- a/src/Directory.Generated.props
+++ b/src/Directory.Generated.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.5.51</VersionPrefix>
-    <PackageReleaseNotes>* [Bump AkkaVersion and AkkaHostingVersion to 1.5.51](https://github.com/akkadotnet/akka.net/releases/tag/1.5.51)</PackageReleaseNotes>
+    <VersionPrefix>1.5.51.1</VersionPrefix>
+    <PackageReleaseNotes>* [Fix health check registration bug in Akka.Hosting extensions](https://github.com/akkadotnet/Akka.Persistence.Sql/pull/549)
+* [Add Akka.Hosting health check documentation to README](https://github.com/akkadotnet/Akka.Persistence.Sql/pull/548)</PackageReleaseNotes>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Release 1.5.51.1

### Changes

* [Fix health check registration bug in Akka.Hosting extensions](https://github.com/akkadotnet/Akka.Persistence.Sql/pull/549)
* [Add Akka.Hosting health check documentation to README](https://github.com/akkadotnet/Akka.Persistence.Sql/pull/548)

This patch release fixes a critical bug in the health check registration for Akka.Hosting extensions and adds documentation for the health check features.