### PR TITLE
Update RELEASE_NOTES.md for 1.5.53 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+#### 1.5.53 October 14th 2025 ####
+
+* [Bump AkkaVersion and AkkaHostingVersion to 1.5.53](https://github.com/akkadotnet/akka.net/releases/tag/1.5.53)
+
 #### 1.5.51.1 October 2nd 2025 ####
 
 * [Fix health check registration bug in Akka.Hosting extensions](https://github.com/akkadotnet/Akka.Persistence.Sql/pull/549)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 #### 1.5.53 October 14th 2025 ####
 
+**Critical Bug Fix**
+
+This release fixes a critical regression introduced in v1.5.51.1 where `IWriteEventAdapter` and `IReadEventAdapter` instances were not being applied when loading events using `BySequenceNr` queries. This caused event tagging and other event adapter functionality to fail in production scenarios.
+
+* **[Fix EventAdapter regression from v1.5.51.1](https://github.com/akkadotnet/Akka.Persistence.Sql/issues/552)** - Event adapters configured via `WithSqlPersistence()` now work correctly when the method is called multiple times (e.g., once for default persistence with adapters, then again for sharding configuration). Fixed by upgrading to Akka.NET v1.5.53 which includes the fix from [Akka.Hosting#669](https://github.com/akkadotnet/Akka.Hosting/pull/669).
+* [Add runtime reproduction test for event adapter regression](https://github.com/akkadotnet/Akka.Persistence.Sql/pull/554)
 * [Bump AkkaVersion and AkkaHostingVersion to 1.5.53](https://github.com/akkadotnet/akka.net/releases/tag/1.5.53)
 
 #### 1.5.51.1 October 2nd 2025 ####

--- a/src/Directory.Generated.props
+++ b/src/Directory.Generated.props
@@ -1,7 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.5.51.1</VersionPrefix>
-    <PackageReleaseNotes>* [Fix health check registration bug in Akka.Hosting extensions](https://github.com/akkadotnet/Akka.Persistence.Sql/pull/549)
-* [Add Akka.Hosting health check documentation to README](https://github.com/akkadotnet/Akka.Persistence.Sql/pull/548)</PackageReleaseNotes>
+    <VersionPrefix>1.5.53</VersionPrefix>
+    <PackageReleaseNotes>* [Bump AkkaVersion and AkkaHostingVersion to 1.5.53](https://github.com/akkadotnet/akka.net/releases/tag/1.5.53)</PackageReleaseNotes>
   </PropertyGroup>
 </Project>

--- a/src/Directory.Generated.props
+++ b/src/Directory.Generated.props
@@ -1,6 +1,12 @@
 <Project>
   <PropertyGroup>
     <VersionPrefix>1.5.53</VersionPrefix>
-    <PackageReleaseNotes>* [Bump AkkaVersion and AkkaHostingVersion to 1.5.53](https://github.com/akkadotnet/akka.net/releases/tag/1.5.53)</PackageReleaseNotes>
+    <PackageReleaseNotes>**Critical Bug Fix**
+
+This release fixes a critical regression introduced in v1.5.51.1 where `IWriteEventAdapter` and `IReadEventAdapter` instances were not being applied when loading events using `BySequenceNr` queries. This caused event tagging and other event adapter functionality to fail in production scenarios.
+
+* **[Fix EventAdapter regression from v1.5.51.1](https://github.com/akkadotnet/Akka.Persistence.Sql/issues/552)** - Event adapters configured via `WithSqlPersistence()` now work correctly when the method is called multiple times (e.g., once for default persistence with adapters, then again for sharding configuration). Fixed by upgrading to Akka.NET v1.5.53 which includes the fix from [Akka.Hosting#669](https://github.com/akkadotnet/Akka.Hosting/pull/669).
+* [Add runtime reproduction test for event adapter regression](https://github.com/akkadotnet/Akka.Persistence.Sql/pull/554)
+* [Bump AkkaVersion and AkkaHostingVersion to 1.5.53](https://github.com/akkadotnet/akka.net/releases/tag/1.5.53)</PackageReleaseNotes>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary

Updates for the 1.5.53 release:
- Updated RELEASE_NOTES.md
- Bumped version to 1.5.53

## Changes

**Bug Fixes:**
- Fixed EventAdapter regression from v1.5.51.1 by upgrading to Akka.NET v1.5.53 ([#552](https://github.com/akkadotnet/Akka.Persistence.Sql/issues/552))

**Dependencies:**
- Upgraded Akka.NET to 1.5.53
- Upgraded Akka.Hosting to 1.5.53