### PR TITLE
Fix flaky SqliteEndToEndSpec by properly shutting down ActorSystem

### DIFF
--- a/src/Akka.Persistence.Sql.Tests/SqlEndToEndSpecBase.cs
+++ b/src/Akka.Persistence.Sql.Tests/SqlEndToEndSpecBase.cs
@@ -85,8 +85,16 @@ akka.persistence {
             _persistenceActor = Sys.ActorOf(Props.Create(() => new MyPersistenceActor(PId)), "persistence-actor-1");
         }
 
-        public Task DisposeAsync()
-            => Task.CompletedTask;
+        public async Task DisposeAsync()
+        {
+            // Properly shut down the actor system to ensure all streams, actors, and materializers
+            // are terminated before the SQLite in-memory database connection is closed.
+            // Without this, there's a race condition where:
+            // 1. xUnit disposes SqliteContainer, closing the in-memory database
+            // 2. Actor system continues running, streams try to query
+            // 3. "no such table" or "Materializer has been shut down" errors occur
+            await Sys.Terminate();
+        }
 
         /// <summary>
         /// Initializes a new <see cref="TestOutputLogger"/> used to log messages.


### PR DESCRIPTION
## Summary
- Fixed flaky `SqliteEndToEndSpec` that intermittently failed with "no such table: journal" error
- Root cause: `DisposeAsync()` returned `Task.CompletedTask` without shutting down the actor system
- This caused a race condition where xUnit disposed the SQLite in-memory database while the actor system was still running

## Changes
- Added proper `await Sys.Terminate()` in `DisposeAsync()` to ensure all streams, actors, and materializers are terminated before the database connection closes

## Test plan
- [x] Verified fix with 5 consecutive successful test runs (10 total test executions)
- [x] All SQLite end-to-end tests pass consistently

Fixes #565