### PR TITLE
Bump Akka.NET to 1.5.59

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+#### 1.5.59 January 26th 2026 ####
+
+* [Bump Akka.NET to 1.5.59](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)
+* [Bump Akka.Hosting to 1.5.59](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.59)
+
 #### 1.5.55.1 October 29th 2025 ####
 
 **Improved API**

--- a/src/Directory.Generated.props
+++ b/src/Directory.Generated.props
@@ -1,31 +1,7 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.5.55.1</VersionPrefix>
-    <PackageReleaseNotes>**Improved API**
-
-This release introduces the simplified Akka.Hosting 1.5.55.1 API for connectivity health checks, eliminating redundant parameter passing:
-
-**New Simplified API (Recommended):**
-```csharp
-journalBuilder: journal =>
-{
-    journal.WithConnectivityCheck(); // Options automatically accessed from builder
-}
-```
-
-**Previous API (Still Supported):**
-```csharp
-journalBuilder: journal =>
-{
-    journal.WithConnectivityCheck(journalOptions); // Explicit parameter passing
-}
-```
-
-The new API automatically accesses options from `builder.Options`, making the code cleaner and less error-prone. The previous API is marked as `[Obsolete]` but remains functional for backward compatibility.
-
-* Update `WithConnectivityCheck()` extension methods to use simplified Akka.Hosting 1.5.55.1 API pattern
-* Add comprehensive integration tests for simplified API
-* Update documentation with examples for both API styles
-* Bump AkkaHostingVersion to 1.5.55.1</PackageReleaseNotes>
+    <VersionPrefix>1.5.59</VersionPrefix>
+    <PackageReleaseNotes>* [Bump Akka.NET to 1.5.59](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)
+* [Bump Akka.Hosting to 1.5.59](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.59)</PackageReleaseNotes>
   </PropertyGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <AkkaVersion>1.5.55</AkkaVersion>
-    <AkkaHostingVersion>1.5.55.1</AkkaHostingVersion>
+    <AkkaVersion>1.5.59</AkkaVersion>
+    <AkkaHostingVersion>1.5.59</AkkaHostingVersion>
     <FluentMigratorVersion>5.2.0</FluentMigratorVersion>
     <SqliteVersion>1.0.118</SqliteVersion>
     <MicrosoftSqliteVersion>8.0.7</MicrosoftSqliteVersion>


### PR DESCRIPTION
## Summary
- Upgrade Akka.NET to 1.5.59
- Upgrade Akka.Hosting to 1.5.59

## Changes
- [Akka.NET 1.5.59 Release Notes](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)
- [Akka.Hosting 1.5.59 Release Notes](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.59)