### PR TITLE
Fix: Use windows-2022 explicitly in release pipeline

### DIFF
--- a/build-system/windows-release.yaml
+++ b/build-system/windows-release.yaml
@@ -1,5 +1,5 @@
 pool:
-  vmImage: windows-latest
+  vmImage: windows-2022
   demands: Cmd
 
 trigger:


### PR DESCRIPTION
Azure DevOps has a known bug where `windows-latest` still resolves to `windows-2019` in some cases.

This change explicitly uses `windows-2022` to work around the issue.