### PR TITLE
Bump linq2db to 5.4.1.9 to fix assembly binding conflict

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -32,7 +32,7 @@
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="LanguageExt.Core" Version="4.4.9" />
-    <PackageVersion Include="linq2db" Version="5.4.1" />
+    <PackageVersion Include="linq2db" Version="5.4.1.9" />
     <PackageVersion Include="FluentMigrator" Version="$(FluentMigratorVersion)" />
     <PackageVersion Include="FluentMigrator.Runner" Version="$(FluentMigratorVersion)" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

Fixes #567

- Bumps `linq2db` from `5.4.1` to `5.4.1.9` in `Directory.Packages.props` to resolve assembly binding failures

### Root Cause

The linq2db project has `<Version>5.0.0.0</Version>` [hardcoded in `Directory.Build.props`](https://github.com/linq2db/linq2db/blob/v5.4.1.9/Directory.Build.props#L3) since v5.0.0. Their CI pipeline uses [`SetVersion.ps1`](https://github.com/linq2db/linq2db/blob/v5.4.1/Build/SetVersion.ps1) to patch this value at build time — for v5.4.1, CI set it to `5.4.1`, producing AssemblyVersion `5.4.1.0`.

However, the `5.4.1.9` package (published October 2025) was built **without** the CI version patching step — verified by the `InformationalVersion` in the shipped DLL (`5.0.0.0+6b676b55...`) which references commit [`6b676b55`](https://github.com/linq2db/linq2db/commit/6b676b55ac2814ee12ef73a45537b7414f65c15c). As a result, it shipped with the unpatched AssemblyVersion `5.0.0.0`:

| NuGet Package | AssemblyVersion | FileVersion |
|---|---|---|
| `linq2db 5.4.1` | `5.4.1.0` | `5.4.1` |
| `linq2db 5.4.1.9` | `5.0.0.0` | `5.0.0.0` |

Our packages were compiled against `5.4.1` (AssemblyVersion `5.4.1.0`). When a user's project resolved the newer `5.4.1.9` via NuGet (satisfying `>= 5.4.1`), .NET refused to bind because `5.0.0.0 < 5.4.1.0`.

Recompiling against `5.4.1.9` makes our assembly reference `linq2db, Version=5.0.0.0`, which resolves the mismatch.

## Test plan

- [x] `dotnet build` succeeds with 0 errors
- [x] Verified compiled DLL references `linq2db, Version=5.0.0.0` (not `5.4.1.0`)
- [x] All 310 SQLite tests pass (306 passed, 4 skipped)
- [ ] CI validates full test matrix (SqlServer, PostgreSQL, MySQL)