### PR TITLE
Fix flaky Linux SQLite CI tests

### DIFF
--- a/src/Akka.Persistence.Sql.Tests.Common/Containers/MsSqliteContainer.cs
+++ b/src/Akka.Persistence.Sql.Tests.Common/Containers/MsSqliteContainer.cs
@@ -47,10 +47,11 @@ namespace Akka.Persistence.Sql.Tests.Common.Containers
         {
             GenerateDatabaseName();
 
+            _heldConnection ??= new List<SqliteConnection>();
             var conn = new SqliteConnection(ConnectionString);
             await conn.OpenAsync();
 
-            _heldConnection!.Add(conn);
+            _heldConnection.Add(conn);
         }
 
         public async Task DisposeAsync()

--- a/src/Akka.Persistence.Sql.Tests.Common/Containers/SqliteContainer.cs
+++ b/src/Akka.Persistence.Sql.Tests.Common/Containers/SqliteContainer.cs
@@ -46,10 +46,11 @@ namespace Akka.Persistence.Sql.Tests.Common.Containers
         {
             GenerateDatabaseName();
 
+            _heldConnection ??= new List<SQLiteConnection>();
             var conn = new SQLiteConnection(ConnectionString);
             await conn.OpenAsync();
 
-            _heldConnection!.Add(conn);
+            _heldConnection.Add(conn);
         }
 
         public async Task DisposeAsync()

--- a/src/Akka.Persistence.Sql.Tests/SqlDataOptionsEndToEndSpecBase.cs
+++ b/src/Akka.Persistence.Sql.Tests/SqlDataOptionsEndToEndSpecBase.cs
@@ -45,6 +45,7 @@ akka.persistence {
         plugin = "akka.persistence.snapshot-store.sql"
     }
 }
+akka.test.single-expect-default = 10s
 """)
             .WithFallback(SqlPersistence.DefaultConfiguration);
 
@@ -89,7 +90,8 @@ akka.persistence {
         public async Task DisposeAsync()
         {
             await Sys.Terminate();
-            await _fixture.DisposeAsync();
+            // Do NOT call _fixture.DisposeAsync() here - xUnit manages the collection fixture lifecycle.
+            // Disposing the shared fixture destroys in-memory databases for all other test classes in the collection.
         }
 
         /// <summary>

--- a/src/Akka.Persistence.Sql.Tests/SqlEndToEndSpecBase.cs
+++ b/src/Akka.Persistence.Sql.Tests/SqlEndToEndSpecBase.cs
@@ -57,6 +57,7 @@ akka.persistence {
         }
     }
 }
+akka.test.single-expect-default = 10s
 """;
 
         private const string GetAll = "getAll";

--- a/src/Akka.Persistence.Sql.Tests/Sqlite/SqliteEndToEndSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests/Sqlite/SqliteEndToEndSpec.cs
@@ -10,7 +10,7 @@ using Xunit.Abstractions;
 
 namespace Akka.Persistence.Sql.Tests.Sqlite
 {
-    [CollectionDefinition(nameof(SqlitePersistenceSpec), DisableParallelization = true)]
+    [Collection(nameof(SqlitePersistenceSpec))]
     public class SqliteEndToEndSpec: SqlEndToEndSpecBase<SqliteContainer>
     {
         public SqliteEndToEndSpec(ITestOutputHelper output, SqliteContainer fixture) : base(output, fixture) { }


### PR DESCRIPTION
## Summary

Fixes #574

The "Linux - SQLite" CI job has been failing consistently across PRs (#571, #572) while all other jobs pass. Three interacting bugs were identified:

### Bug 1 (Primary): `SqlDataOptionsEndToEndSpecBase.DisposeAsync()` destroys the shared collection fixture

`DisposeAsync()` called `_fixture.DisposeAsync()`, which closes all held SQLite connections and sets `_heldConnection = null`. This destroys every in-memory database in the collection fixture, causing all subsequent test classes (~24 classes) to fail.

**Why Linux-only:** `SqliteDataOptionsEndToEndSpec` and `MsSqliteDataOptionsEndToEndSpec` have `[SkipWindows]` (active in Release config). On Windows CI the destructive dispose never runs. On Linux it poisons the fixture.

**Fix:** Removed `_fixture.DisposeAsync()` call — xUnit manages collection fixture lifecycle.

### Bug 2: `SqliteEndToEndSpec` uses `[CollectionDefinition]` instead of `[Collection]`

It accidentally *defines* the collection instead of *joining* it, creating a duplicate `CollectionDefinition` with the real one in `SqlitePersistenceSpec.cs`. Compare with `MsSqliteEndToEndSpec` which correctly uses `[Collection]`.

**Fix:** Changed to `[Collection(nameof(SqlitePersistenceSpec))]`.

### Bug 3: Container `InitializeDbAsync()` not defensive against null state

`_heldConnection!.Add(conn)` would NRE if the fixture had been prematurely disposed. 

**Fix:** Added `_heldConnection ??= new List<>()` to both `SqliteContainer` and `MsSqliteContainer`.

## Test plan

- [x] `dotnet build` succeeds with 0 errors
- [x] All 310 SQLite tests pass in Release config on Linux (306 passed, 4 skipped)
- [x] DataOptions end-to-end tests specifically verified passing
- [ ] CI validates full test matrix including the previously-failing Linux SQLite job