### PR TITLE
Upgrade to Akka.NET v1.5.66 and fix WriteMessagesAsync off-context Self access

### DIFF
--- a/src/Akka.Persistence.Sql.Hosting.Tests/Akka.Persistence.Sql.Hosting.Tests.csproj
+++ b/src/Akka.Persistence.Sql.Hosting.Tests/Akka.Persistence.Sql.Hosting.Tests.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="Akka" />
-        <PackageReference Include="Akka.Hosting.TestKit" />
+        <PackageReference Include="Akka.Hosting.TestKit.Xunit2" />
         
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
     </ItemGroup>

--- a/src/Akka.Persistence.Sql.Tests.Common/Akka.Persistence.Sql.Tests.Common.csproj
+++ b/src/Akka.Persistence.Sql.Tests.Common/Akka.Persistence.Sql.Tests.Common.csproj
@@ -9,7 +9,8 @@
     <PackageReference Include="Akka.Cluster.Sharding" />
     <PackageReference Include="Akka.Hosting" />
     <PackageReference Include="Akka.Persistence.Sql.Compat.Common" />
-    <PackageReference Include="Akka.Persistence.TCK" />
+    <PackageReference Include="Akka.Persistence.TCK.Xunit2" />
+    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Akka.Persistence.TestKit" />
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/src/Akka.Persistence.Sql.Tests.Common/Query/BaseAllEventsSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests.Common/Query/BaseAllEventsSpec.cs
@@ -51,7 +51,7 @@ akka.persistence.journal.plugin = ""akka.persistence.journal.sql""
 akka.persistence.journal.auto-start-journals = [ ""akka.persistence.journal.sql"" ]
 akka.persistence.journal.sql {{
     event-adapters {{
-        color-tagger  = ""Akka.Persistence.TCK.Query.ColorFruitTagger, Akka.Persistence.TCK""
+        color-tagger  = ""Akka.Persistence.TCK.Query.ColorFruitTagger, Akka.Persistence.TCK.Xunit2""
     }}
     event-adapter-bindings = {{
         ""System.String"" = color-tagger

--- a/src/Akka.Persistence.Sql.Tests.Common/Query/BaseCurrentAllEventsSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests.Common/Query/BaseCurrentAllEventsSpec.cs
@@ -51,7 +51,7 @@ akka.persistence.journal.plugin = ""akka.persistence.journal.sql""
 akka.persistence.journal.auto-start-journals = [ ""akka.persistence.journal.sql"" ]
 akka.persistence.journal.sql {{
     event-adapters {{
-        color-tagger  = ""Akka.Persistence.TCK.Query.ColorFruitTagger, Akka.Persistence.TCK""
+        color-tagger  = ""Akka.Persistence.TCK.Query.ColorFruitTagger, Akka.Persistence.TCK.Xunit2""
     }}
     event-adapter-bindings = {{
         ""System.String"" = color-tagger

--- a/src/Akka.Persistence.Sql.Tests.Common/Query/BaseCurrentEventsByTagSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests.Common/Query/BaseCurrentEventsByTagSpec.cs
@@ -53,7 +53,7 @@ akka.persistence.journal.plugin = ""akka.persistence.journal.sql""
 akka.persistence.journal.auto-start-journals = [ ""akka.persistence.journal.sql"" ]
 akka.persistence.journal.sql {{
     event-adapters {{
-        color-tagger  = ""Akka.Persistence.TCK.Query.ColorFruitTagger, Akka.Persistence.TCK""
+        color-tagger  = ""Akka.Persistence.TCK.Query.ColorFruitTagger, Akka.Persistence.TCK.Xunit2""
     }}
     event-adapter-bindings = {{
         ""System.String"" = color-tagger

--- a/src/Akka.Persistence.Sql.Tests.Common/Query/BaseEventsByTagSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests.Common/Query/BaseEventsByTagSpec.cs
@@ -53,7 +53,7 @@ akka.persistence.journal.plugin = ""akka.persistence.journal.sql""
 akka.persistence.journal.auto-start-journals = [ ""akka.persistence.journal.sql"" ]
 akka.persistence.journal.sql {{
     event-adapters {{
-      color-tagger  = ""Akka.Persistence.TCK.Query.ColorFruitTagger, Akka.Persistence.TCK""
+      color-tagger  = ""Akka.Persistence.TCK.Query.ColorFruitTagger, Akka.Persistence.TCK.Xunit2""
     }}
     event-adapter-bindings = {{
       ""System.String"" = color-tagger

--- a/src/Akka.Persistence.Sql.Tests.Common/Query/BasePersistenceIdsSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests.Common/Query/BasePersistenceIdsSpec.cs
@@ -49,10 +49,10 @@ namespace Akka.Persistence.Sql.Tests.Common.Query
 akka.loglevel = INFO
 akka.actor{{
     serializers{{
-        persistence-tck-test=""Akka.Persistence.TCK.Serialization.TestSerializer,Akka.Persistence.TCK""
+        persistence-tck-test=""Akka.Persistence.TCK.Serialization.TestSerializer,Akka.Persistence.TCK.Xunit2""
     }}
     serialization-bindings {{
-        ""Akka.Persistence.TCK.Serialization.TestPayload,Akka.Persistence.TCK"" = persistence-tck-test
+        ""Akka.Persistence.TCK.Serialization.TestPayload,Akka.Persistence.TCK.Xunit2"" = persistence-tck-test
     }}
 }}
 akka.persistence {{

--- a/src/Akka.Persistence.Sql.Tests.Common/Query/Bugfix344Spec.cs
+++ b/src/Akka.Persistence.Sql.Tests.Common/Query/Bugfix344Spec.cs
@@ -69,7 +69,7 @@ namespace Akka.Persistence.Sql.Tests.Common.Query
                       akka.persistence.journal.plugin = "akka.persistence.journal.sql"
                       akka.persistence.journal.sql {
                           event-adapters {
-                              color-tagger  = "Akka.Persistence.TCK.Query.ColorFruitTagger, Akka.Persistence.TCK"
+                              color-tagger  = "Akka.Persistence.TCK.Query.ColorFruitTagger, Akka.Persistence.TCK.Xunit2"
                           }
                           event-adapter-bindings = {
                               "System.String" = color-tagger

--- a/src/Akka.Persistence.Sql.Tests.Common/TaskExtensions.cs
+++ b/src/Akka.Persistence.Sql.Tests.Common/TaskExtensions.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Akka.TestKit.Extensions
+{
+    public static class TaskExtensions
+    {
+        public static async Task<T> ShouldCompleteWithin<T>(this Task<T> task, TimeSpan timeout)
+        {
+            if (task != await Task.WhenAny(task, Task.Delay(timeout)))
+                throw new TimeoutException($"Task did not complete within {timeout}.");
+            return await task;
+        }
+
+        public static async Task ShouldCompleteWithin(this Task task, TimeSpan timeout)
+        {
+            if (task != await Task.WhenAny(task, Task.Delay(timeout)))
+                throw new TimeoutException($"Task did not complete within {timeout}.");
+            await task;
+        }
+    }
+}

--- a/src/Akka.Persistence.Sql.Tests/Query/QueryThrottleSpecsBase.cs
+++ b/src/Akka.Persistence.Sql.Tests/Query/QueryThrottleSpecsBase.cs
@@ -94,7 +94,7 @@ akka {
             auto-start-journals = [ "akka.persistence.journal.sql" ]
             sql {
                 event-adapters {
-                    color-tagger  = "Akka.Persistence.TCK.Query.ColorFruitTagger, Akka.Persistence.TCK"
+                    color-tagger  = "Akka.Persistence.TCK.Query.ColorFruitTagger, Akka.Persistence.TCK.Xunit2"
                 }
                 event-adapter-bindings = {
                     "System.String" = color-tagger

--- a/src/Akka.Persistence.Sql/Journal/SqlWriteJournal.cs
+++ b/src/Akka.Persistence.Sql/Journal/SqlWriteJournal.cs
@@ -43,7 +43,6 @@ namespace Akka.Persistence.Sql.Journal
         [Obsolete(message: "Use SqlPersistence.DefaultConfiguration or SqlPersistence.Get(ActorSystem).DefaultConfig instead")]
         public static readonly Configuration.Config DefaultConfiguration = SqlPersistence.DefaultConfiguration;
 
-        private readonly IActorRef _self;
         private readonly JournalConfig _journalConfig;
         private readonly ILoggingAdapter _log;
         private readonly CancellationTokenSource _pendingWriteCts;
@@ -57,7 +56,6 @@ namespace Akka.Persistence.Sql.Journal
 
         public SqlWriteJournal(Configuration.Config journalConfig)
         {
-            _self = Self;
             _log = Context.GetLogger();
             _pendingWriteCts = new CancellationTokenSource();
 
@@ -229,11 +227,12 @@ namespace Akka.Persistence.Sql.Journal
             var future = _journal!.AsyncWriteMessages(messagesList, cancellationToken, currentTime);
 
             _writeInProgress[persistenceId] = future;
+            var self = Self;
 
             // When we are done, we want to send a 'WriteFinished' so that
             // Sequence Number reads won't block/await/etc.
             future.ContinueWith(
-                continuationAction: p => _self.Tell(new WriteFinished(persistenceId, p)),
+                continuationAction: p => self.Tell(new WriteFinished(persistenceId, p)),
                 cancellationToken: _pendingWriteCts.Token,
                 continuationOptions: TaskContinuationOptions.ExecuteSynchronously,
                 scheduler: TaskScheduler.Default);

--- a/src/Akka.Persistence.Sql/Journal/SqlWriteJournal.cs
+++ b/src/Akka.Persistence.Sql/Journal/SqlWriteJournal.cs
@@ -43,6 +43,7 @@ namespace Akka.Persistence.Sql.Journal
         [Obsolete(message: "Use SqlPersistence.DefaultConfiguration or SqlPersistence.Get(ActorSystem).DefaultConfig instead")]
         public static readonly Configuration.Config DefaultConfiguration = SqlPersistence.DefaultConfiguration;
 
+        private readonly IActorRef _self;
         private readonly JournalConfig _journalConfig;
         private readonly ILoggingAdapter _log;
         private readonly CancellationTokenSource _pendingWriteCts;
@@ -56,6 +57,7 @@ namespace Akka.Persistence.Sql.Journal
 
         public SqlWriteJournal(Configuration.Config journalConfig)
         {
+            _self = Self;
             _log = Context.GetLogger();
             _pendingWriteCts = new CancellationTokenSource();
 
@@ -227,12 +229,11 @@ namespace Akka.Persistence.Sql.Journal
             var future = _journal!.AsyncWriteMessages(messagesList, cancellationToken, currentTime);
 
             _writeInProgress[persistenceId] = future;
-            var self = Self;
 
             // When we are done, we want to send a 'WriteFinished' so that
             // Sequence Number reads won't block/await/etc.
             future.ContinueWith(
-                continuationAction: p => self.Tell(new WriteFinished(persistenceId, p)),
+                continuationAction: p => _self.Tell(new WriteFinished(persistenceId, p)),
                 cancellationToken: _pendingWriteCts.Token,
                 continuationOptions: TaskContinuationOptions.ExecuteSynchronously,
                 scheduler: TaskScheduler.Default);

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <AkkaVersion>1.5.62</AkkaVersion>
-    <AkkaHostingVersion>1.5.62</AkkaHostingVersion>
+    <AkkaVersion>1.5.66</AkkaVersion>
+    <AkkaHostingVersion>1.5.65</AkkaHostingVersion>
     <FluentMigratorVersion>5.2.0</FluentMigratorVersion>
     <SqliteVersion>1.0.118</SqliteVersion>
     <MicrosoftSqliteVersion>8.0.7</MicrosoftSqliteVersion>
@@ -17,7 +17,7 @@
     <PackageVersion Include="Akka.Persistence" Version="$(AkkaVersion)" />
     <PackageVersion Include="Akka.Persistence.Hosting" Version="$(AkkaHostingVersion)" />
     <PackageVersion Include="Akka.Persistence.Sql.Compat.Common" Version="0.1.0" />
-    <PackageVersion Include="Akka.Persistence.TCK" Version="$(AkkaVersion)" />
+    <PackageVersion Include="Akka.Persistence.TCK.Xunit2" Version="$(AkkaVersion)" />
     <PackageVersion Include="Akka.Persistence.TestKit" Version="$(AkkaVersion)" />
     <PackageVersion Include="Akka.Persistence.Query" Version="$(AkkaVersion)" />
     <PackageVersion Include="Akka.Serialization.Hyperion" Version="$(AkkaVersion)" />
@@ -67,7 +67,7 @@
   </ItemGroup>
   <!-- Test dependencies -->
   <ItemGroup>
-    <PackageVersion Include="Akka.Hosting.TestKit" Version="$(AkkaHostingVersion)" />
+    <PackageVersion Include="Akka.Hosting.TestKit.Xunit2" Version="$(AkkaHostingVersion)" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="Docker.DotNet" Version="3.125.15" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <AkkaVersion>1.5.66</AkkaVersion>
+    <AkkaVersion>1.5.67</AkkaVersion>
     <AkkaHostingVersion>1.5.65</AkkaHostingVersion>
     <FluentMigratorVersion>5.2.0</FluentMigratorVersion>
     <SqliteVersion>1.0.118</SqliteVersion>


### PR DESCRIPTION
## Summary

- **Fix `SqlWriteJournal.WriteMessagesAsync` crash with Akka.NET v1.5.66**: v1.5.66 calls `await Task.Yield()` before `WriteMessagesAsync` (PR akkadotnet/akka.net#8163), moving execution off the actor context. `SqlWriteJournal` was capturing `Self` inside `WriteMessagesAsync`, which now throws `NotSupportedException: There is no active ActorContext`. Fixed by capturing `Self` as a field during construction.
- **Upgrade Akka.NET dependency from 1.5.62 → 1.5.66**, Akka.Hosting from 1.5.62 → 1.5.65
- **Update test infrastructure** for xUnit 2/3 split (v1.5.63+): switch to `Akka.Persistence.TCK.Xunit2` and `Akka.Hosting.TestKit.Xunit2`, add direct FluentAssertions 6.12.1 dependency, add local `ShouldCompleteWithin` extension, update HOCON assembly-qualified type names

### Related issues
- Filed akkadotnet/akka.net#8187 — the `.Xunit2` compat packages ship with different assembly names than their non-suffixed counterparts, breaking assembly-qualified type names in HOCON configs

## Test plan

- [x] Reproduced `NotSupportedException: There is no active ActorContext` on all 16 SQLite journal TCK tests before fix
- [x] All 16 SQLite journal TCK tests pass after fix
- [x] Full SQLite test suite passes (156 passed, 2 skipped, 0 failed)
- [ ] CI/CD pipeline passes
- [ ] Verify no regressions in SQL Server / PostgreSQL / MySQL tests (requires Docker)