### PR TITLE
Bump AkkaVersion to 1.5.67 and AkkaHostingVersion to 1.5.65

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <AkkaVersion>1.5.64</AkkaVersion>
-    <AkkaHostingVersion>1.5.64</AkkaHostingVersion>
+    <AkkaVersion>1.5.67</AkkaVersion>
+    <AkkaHostingVersion>1.5.65</AkkaHostingVersion>
     <FluentMigratorVersion>5.2.0</FluentMigratorVersion>
     <SqliteVersion>1.0.118</SqliteVersion>
     <MicrosoftSqliteVersion>8.0.7</MicrosoftSqliteVersion>


### PR DESCRIPTION
## Summary
- Bumps `AkkaVersion` from 1.5.64 to 1.5.67 (includes revert of the `Task.Yield` change in `AsyncWriteJournal.ExecuteBatch` that caused regressions in persistence plugins)
- Bumps `AkkaHostingVersion` from 1.5.64 to 1.5.65

## Test plan
- [x] All 306 SQLite tests pass locally (4 skipped, 0 failed)
- [ ] CI/CD pipeline passes