### PR TITLE
spike: FromEnd (last-N) query offset — design validation (DO NOT MERGE)

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -7,11 +7,22 @@
     <!-- Temporary solution until Akka.Persistence.Sql.Exporter can publish NuGet packages -->
     <!-- Manually added nuget package built from the Akka.Persistence.Sql.Exporter repo -->
     <add key="Data compatibility feed" value="./nuget" />
+
+    <!-- SPIKE ONLY: local feed (sibling of the repo) for unreleased Akka core with the FromEnd query offset -->
+    <add key="local-spike" value="../local-nupkgs" />
   </packageSources>
 
   <packageSourceMapping>
     <packageSource key="Data compatibility feed">
       <package pattern="Akka.Persistence.Sql.Compat.Common" />
+    </packageSource>
+
+    <!-- SPIKE ONLY: these exact IDs resolve to the local FromEnd spike build -->
+    <packageSource key="local-spike">
+      <package pattern="Akka" />
+      <package pattern="Akka.Streams" />
+      <package pattern="Akka.Persistence" />
+      <package pattern="Akka.Persistence.Query" />
     </packageSource>
 
     <packageSource key="nuget.org">

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -8,21 +8,11 @@
     <!-- Manually added nuget package built from the Akka.Persistence.Sql.Exporter repo -->
     <add key="Data compatibility feed" value="./nuget" />
 
-    <!-- SPIKE ONLY: local feed (sibling of the repo) for unreleased Akka core with the FromEnd query offset -->
-    <add key="local-spike" value="../local-nupkgs" />
   </packageSources>
 
   <packageSourceMapping>
     <packageSource key="Data compatibility feed">
       <package pattern="Akka.Persistence.Sql.Compat.Common" />
-    </packageSource>
-
-    <!-- SPIKE ONLY: these exact IDs resolve to the local FromEnd spike build -->
-    <packageSource key="local-spike">
-      <package pattern="Akka" />
-      <package pattern="Akka.Streams" />
-      <package pattern="Akka.Persistence" />
-      <package pattern="Akka.Persistence.Query" />
     </packageSource>
 
     <packageSource key="nuget.org">

--- a/src/Akka.Persistence.Sql.Tests.Common/Query/BaseFromEndOffsetSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests.Common/Query/BaseFromEndOffsetSpec.cs
@@ -1,0 +1,64 @@
+// -----------------------------------------------------------------------
+//  <copyright file="BaseFromEndOffsetSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Persistence.Query;
+using Akka.Persistence.Sql.Config;
+using Akka.Persistence.Sql.Query;
+using Akka.Persistence.Sql.Tests.Common.Containers;
+using Akka.Persistence.Sql.Utility;
+using Akka.Persistence.TCK.Query;
+using Akka.TestKit.Extensions;
+using FluentAssertions.Extensions;
+using Xunit;
+
+namespace Akka.Persistence.Sql.Tests.Common.Query
+{
+    public abstract class BaseFromEndOffsetSpec<T> : FromEndOffsetSpec where T : ITestContainer
+    {
+        protected BaseFromEndOffsetSpec(TagMode tagMode, ITestOutputHelper output, string name, T fixture)
+            : base(Config(tagMode, fixture), name, output)
+        {
+            ReadJournal = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
+
+            var journal = Persistence.Instance.Apply(Sys).JournalFor(null);
+            journal.Ask<Initialized>(IsInitialized.Instance).Wait(3.Seconds());
+        }
+
+        private static Akka.Configuration.Config Config(TagMode tagMode, T fixture)
+        {
+            if (!fixture.InitializeDbAsync().Wait(10.Seconds()))
+                throw new Exception("Failed to clean up database in 10 seconds");
+
+            return ConfigurationFactory.ParseString(
+                    $@"
+akka.loglevel = INFO
+akka.persistence.journal.plugin = ""akka.persistence.journal.sql""
+akka.persistence.journal.auto-start-journals = [ ""akka.persistence.journal.sql"" ]
+akka.persistence.journal.sql {{
+    event-adapters {{
+        color-tagger  = ""Akka.Persistence.TCK.Query.ColorFruitTagger, Akka.Persistence.TCK""
+    }}
+    event-adapter-bindings = {{
+        ""System.String"" = color-tagger
+    }}
+    provider-name = ""{fixture.ProviderName}""
+    tag-write-mode = ""{tagMode}""
+    connection-string = ""{fixture.ConnectionString}""
+}}
+akka.persistence.query.journal.sql {{
+    provider-name = ""{fixture.ProviderName}""
+    connection-string = ""{fixture.ConnectionString}""
+    tag-read-mode = ""{tagMode}""
+    refresh-interval = 200ms
+}}
+akka.test.single-expect-default = 10s")
+                .WithFallback(SqlPersistence.DefaultConfiguration);
+        }
+    }
+}

--- a/src/Akka.Persistence.Sql.Tests/Query/MsSqlite/Csv/MsSqliteFromEndOffsetSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests/Query/MsSqlite/Csv/MsSqliteFromEndOffsetSpec.cs
@@ -1,0 +1,21 @@
+// -----------------------------------------------------------------------
+//  <copyright file="MsSqliteFromEndOffsetSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Persistence.Sql.Config;
+using Akka.Persistence.Sql.Tests.Common.Containers;
+using Akka.Persistence.Sql.Tests.Common.Query;
+using Akka.Persistence.Sql.Tests.Sqlite;
+using Xunit;
+
+namespace Akka.Persistence.Sql.Tests.Query.MsSqlite.Csv
+{
+    [Collection(nameof(MsSqlitePersistenceSpec))]
+    public class MsSqliteFromEndOffsetSpec : BaseFromEndOffsetSpec<MsSqliteContainer>
+    {
+        public MsSqliteFromEndOffsetSpec(ITestOutputHelper output, MsSqliteContainer fixture)
+            : base(TagMode.Csv, output, nameof(MsSqliteFromEndOffsetSpec), fixture) { }
+    }
+}

--- a/src/Akka.Persistence.Sql.Tests/Query/MsSqlite/MsSqliteFromEndSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests/Query/MsSqlite/MsSqliteFromEndSpec.cs
@@ -1,0 +1,109 @@
+// -----------------------------------------------------------------------
+//  <copyright file="MsSqliteFromEndSpec.cs" company="Akka.NET Project">
+//      SPIKE ONLY: validates the FromEnd ("last N events") query offset against a real SQL backend.
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using Akka.Actor;
+using Akka.Persistence;
+using Akka.Persistence.Query;
+using Akka.Persistence.Sql.Config;
+using Akka.Persistence.Sql.Tests.Common.Containers;
+using Akka.Persistence.Sql.Tests.Common.Query;
+using Akka.Persistence.Sql.Tests.Sqlite;
+using Akka.Streams.Dsl;
+using Akka.Streams.TestKit;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Persistence.Sql.Tests.Query.MsSqlite
+{
+    // minimal persistent actor: persists string commands (tagged "green"/"apple" by the configured ColorFruitTagger)
+    internal sealed class FromEndTestActor : UntypedPersistentActor
+    {
+        public static Props Props(string persistenceId) => Actor.Props.Create(() => new FromEndTestActor(persistenceId));
+
+        public FromEndTestActor(string persistenceId) => PersistenceId = persistenceId;
+
+        public override string PersistenceId { get; }
+
+        protected override void OnRecover(object message) { }
+
+        protected override void OnCommand(object message)
+        {
+            if (message is string s)
+            {
+                var sender = Sender;
+                Persist(s, e => sender.Tell($"{e}-done"));
+            }
+        }
+    }
+
+    [Collection(nameof(MsSqlitePersistenceSpec))]
+    public class MsSqliteFromEndSpec : BaseCurrentEventsByTagSpec<MsSqliteContainer>
+    {
+        public MsSqliteFromEndSpec(ITestOutputHelper output, MsSqliteContainer fixture)
+            : base(TagMode.TagTable, output, nameof(MsSqliteFromEndSpec), fixture)
+        {
+        }
+
+        [Fact]
+        public void CurrentEventsByTag_with_FromEnd_should_return_only_the_last_N_events()
+        {
+            var queries = (ICurrentEventsByTagQuery)ReadJournal;
+
+            var a = Sys.ActorOf(FromEndTestActor.Props("from-end-a"));
+            for (var i = 1; i <= 10; i++)
+            {
+                a.Tell($"a green apple {i}");
+                ExpectMsg($"a green apple {i}-done");
+            }
+
+            WaitForGreen(queries, 10);
+
+            var probe = queries
+                .CurrentEventsByTag("green", Offset.FromEnd(3))
+                .RunWith(this.SinkProbe<EventEnvelope>(), Materializer);
+
+            probe.Request(10);
+            probe.ExpectNext<EventEnvelope>(e => e.SequenceNr == 8L);
+            probe.ExpectNext<EventEnvelope>(e => e.SequenceNr == 9L);
+            probe.ExpectNext<EventEnvelope>(e => e.SequenceNr == 10L);
+            probe.ExpectComplete();
+        }
+
+        [Fact]
+        public void CurrentEventsByTag_with_FromEnd_larger_than_total_should_return_all_events()
+        {
+            var queries = (ICurrentEventsByTagQuery)ReadJournal;
+
+            var a = Sys.ActorOf(FromEndTestActor.Props("from-end-b"));
+            for (var i = 1; i <= 5; i++)
+            {
+                a.Tell($"a green apple {i}");
+                ExpectMsg($"a green apple {i}-done");
+            }
+
+            WaitForGreen(queries, 5);
+
+            var probe = queries
+                .CurrentEventsByTag("green", Offset.FromEnd(100))
+                .RunWith(this.SinkProbe<EventEnvelope>(), Materializer);
+
+            probe.Request(10);
+            for (var i = 1L; i <= 5L; i++)
+                probe.ExpectNext<EventEnvelope>(e => e.SequenceNr == i);
+            probe.ExpectComplete();
+        }
+
+        private void WaitForGreen(ICurrentEventsByTagQuery queries, int expected)
+            => AwaitConditionAsync(async () =>
+            {
+                var all = await queries
+                    .CurrentEventsByTag("green", Offset.NoOffset())
+                    .RunWith(Sink.Seq<EventEnvelope>(), Materializer);
+                return all.Count >= expected;
+            }, TimeSpan.FromSeconds(15)).GetAwaiter().GetResult();
+    }
+}

--- a/src/Akka.Persistence.Sql.Tests/Query/MsSqlite/TagTable/MsSqliteFromEndOffsetSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests/Query/MsSqlite/TagTable/MsSqliteFromEndOffsetSpec.cs
@@ -1,0 +1,21 @@
+// -----------------------------------------------------------------------
+//  <copyright file="MsSqliteFromEndOffsetSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Persistence.Sql.Config;
+using Akka.Persistence.Sql.Tests.Common.Containers;
+using Akka.Persistence.Sql.Tests.Common.Query;
+using Akka.Persistence.Sql.Tests.Sqlite;
+using Xunit;
+
+namespace Akka.Persistence.Sql.Tests.Query.MsSqlite.TagTable
+{
+    [Collection(nameof(MsSqlitePersistenceSpec))]
+    public class MsSqliteFromEndOffsetSpec : BaseFromEndOffsetSpec<MsSqliteContainer>
+    {
+        public MsSqliteFromEndOffsetSpec(ITestOutputHelper output, MsSqliteContainer fixture)
+            : base(TagMode.TagTable, output, nameof(MsSqliteFromEndOffsetSpec), fixture) { }
+    }
+}

--- a/src/Akka.Persistence.Sql.Tests/Query/MySql/Csv/MySqlFromEndOffsetSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests/Query/MySql/Csv/MySqlFromEndOffsetSpec.cs
@@ -1,0 +1,27 @@
+// -----------------------------------------------------------------------
+//  <copyright file="MySqlFromEndOffsetSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Persistence.Sql.Config;
+using Akka.Persistence.Sql.Tests.Common.Containers;
+using Akka.Persistence.Sql.Tests.Common.Query;
+using Akka.Persistence.Sql.Tests.MySql;
+using Xunit;
+#if !DEBUG
+using Akka.Persistence.Sql.Tests.Common.Internal.Xunit;
+#endif
+
+namespace Akka.Persistence.Sql.Tests.Query.MySql.Csv
+{
+#if !DEBUG
+    [SkipWindows]
+#endif
+    [Collection(nameof(MySqlPersistenceSpec))]
+    public class MySqlFromEndOffsetSpec : BaseFromEndOffsetSpec<MySqlContainer>
+    {
+        public MySqlFromEndOffsetSpec(ITestOutputHelper output, MySqlContainer fixture)
+            : base(TagMode.Csv, output, nameof(MySqlFromEndOffsetSpec), fixture) { }
+    }
+}

--- a/src/Akka.Persistence.Sql.Tests/Query/MySql/TagTable/MySqlFromEndOffsetSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests/Query/MySql/TagTable/MySqlFromEndOffsetSpec.cs
@@ -1,0 +1,27 @@
+// -----------------------------------------------------------------------
+//  <copyright file="MySqlFromEndOffsetSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Persistence.Sql.Config;
+using Akka.Persistence.Sql.Tests.Common.Containers;
+using Akka.Persistence.Sql.Tests.Common.Query;
+using Akka.Persistence.Sql.Tests.MySql;
+using Xunit;
+#if !DEBUG
+using Akka.Persistence.Sql.Tests.Common.Internal.Xunit;
+#endif
+
+namespace Akka.Persistence.Sql.Tests.Query.MySql.TagTable
+{
+#if !DEBUG
+    [SkipWindows]
+#endif
+    [Collection(nameof(MySqlPersistenceSpec))]
+    public class MySqlFromEndOffsetSpec : BaseFromEndOffsetSpec<MySqlContainer>
+    {
+        public MySqlFromEndOffsetSpec(ITestOutputHelper output, MySqlContainer fixture)
+            : base(TagMode.TagTable, output, nameof(MySqlFromEndOffsetSpec), fixture) { }
+    }
+}

--- a/src/Akka.Persistence.Sql.Tests/Query/PostgreSql/Csv/PostgreSqlFromEndOffsetSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests/Query/PostgreSql/Csv/PostgreSqlFromEndOffsetSpec.cs
@@ -1,0 +1,27 @@
+// -----------------------------------------------------------------------
+//  <copyright file="PostgreSqlFromEndOffsetSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Persistence.Sql.Config;
+using Akka.Persistence.Sql.Tests.Common.Containers;
+using Akka.Persistence.Sql.Tests.Common.Query;
+using Akka.Persistence.Sql.Tests.PostgreSql;
+using Xunit;
+#if !DEBUG
+using Akka.Persistence.Sql.Tests.Common.Internal.Xunit;
+#endif
+
+namespace Akka.Persistence.Sql.Tests.Query.PostgreSql.Csv
+{
+#if !DEBUG
+    [SkipWindows]
+#endif
+    [Collection(nameof(PostgreSqlPersistenceSpec))]
+    public class PostgreSqlFromEndOffsetSpec : BaseFromEndOffsetSpec<PostgreSqlContainer>
+    {
+        public PostgreSqlFromEndOffsetSpec(ITestOutputHelper output, PostgreSqlContainer fixture)
+            : base(TagMode.Csv, output, nameof(PostgreSqlFromEndOffsetSpec), fixture) { }
+    }
+}

--- a/src/Akka.Persistence.Sql.Tests/Query/PostgreSql/TagTable/PostgreSqlFromEndOffsetSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests/Query/PostgreSql/TagTable/PostgreSqlFromEndOffsetSpec.cs
@@ -1,0 +1,27 @@
+// -----------------------------------------------------------------------
+//  <copyright file="PostgreSqlFromEndOffsetSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Persistence.Sql.Config;
+using Akka.Persistence.Sql.Tests.Common.Containers;
+using Akka.Persistence.Sql.Tests.Common.Query;
+using Akka.Persistence.Sql.Tests.PostgreSql;
+using Xunit;
+#if !DEBUG
+using Akka.Persistence.Sql.Tests.Common.Internal.Xunit;
+#endif
+
+namespace Akka.Persistence.Sql.Tests.Query.PostgreSql.TagTable
+{
+#if !DEBUG
+    [SkipWindows]
+#endif
+    [Collection(nameof(PostgreSqlPersistenceSpec))]
+    public class PostgreSqlFromEndOffsetSpec : BaseFromEndOffsetSpec<PostgreSqlContainer>
+    {
+        public PostgreSqlFromEndOffsetSpec(ITestOutputHelper output, PostgreSqlContainer fixture)
+            : base(TagMode.TagTable, output, nameof(PostgreSqlFromEndOffsetSpec), fixture) { }
+    }
+}

--- a/src/Akka.Persistence.Sql.Tests/Query/SqlServer/Csv/SqlServerFromEndOffsetSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests/Query/SqlServer/Csv/SqlServerFromEndOffsetSpec.cs
@@ -1,0 +1,27 @@
+// -----------------------------------------------------------------------
+//  <copyright file="SqlServerFromEndOffsetSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Persistence.Sql.Config;
+using Akka.Persistence.Sql.Tests.Common.Containers;
+using Akka.Persistence.Sql.Tests.Common.Query;
+using Akka.Persistence.Sql.Tests.SqlServer;
+using Xunit;
+#if !DEBUG
+using Akka.Persistence.Sql.Tests.Common.Internal.Xunit;
+#endif
+
+namespace Akka.Persistence.Sql.Tests.Query.SqlServer.Csv
+{
+#if !DEBUG
+    [SkipWindows]
+#endif
+    [Collection(nameof(SqlServerPersistenceSpec))]
+    public class SqlServerFromEndOffsetSpec : BaseFromEndOffsetSpec<SqlServerContainer>
+    {
+        public SqlServerFromEndOffsetSpec(ITestOutputHelper output, SqlServerContainer fixture)
+            : base(TagMode.Csv, output, nameof(SqlServerFromEndOffsetSpec), fixture) { }
+    }
+}

--- a/src/Akka.Persistence.Sql.Tests/Query/SqlServer/TagTable/SqlServerFromEndOffsetSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests/Query/SqlServer/TagTable/SqlServerFromEndOffsetSpec.cs
@@ -1,0 +1,27 @@
+// -----------------------------------------------------------------------
+//  <copyright file="SqlServerFromEndOffsetSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Persistence.Sql.Config;
+using Akka.Persistence.Sql.Tests.Common.Containers;
+using Akka.Persistence.Sql.Tests.Common.Query;
+using Akka.Persistence.Sql.Tests.SqlServer;
+using Xunit;
+#if !DEBUG
+using Akka.Persistence.Sql.Tests.Common.Internal.Xunit;
+#endif
+
+namespace Akka.Persistence.Sql.Tests.Query.SqlServer.TagTable
+{
+#if !DEBUG
+    [SkipWindows]
+#endif
+    [Collection(nameof(SqlServerPersistenceSpec))]
+    public class SqlServerFromEndOffsetSpec : BaseFromEndOffsetSpec<SqlServerContainer>
+    {
+        public SqlServerFromEndOffsetSpec(ITestOutputHelper output, SqlServerContainer fixture)
+            : base(TagMode.TagTable, output, nameof(SqlServerFromEndOffsetSpec), fixture) { }
+    }
+}

--- a/src/Akka.Persistence.Sql.Tests/Query/SqlServer2016/TagTable/SqlServer2016FromEndOffsetSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests/Query/SqlServer2016/TagTable/SqlServer2016FromEndOffsetSpec.cs
@@ -1,0 +1,27 @@
+// -----------------------------------------------------------------------
+//  <copyright file="SqlServer2016FromEndOffsetSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Persistence.Sql.Config;
+using Akka.Persistence.Sql.Tests.Common.Containers;
+using Akka.Persistence.Sql.Tests.Common.Query;
+using Akka.Persistence.Sql.Tests.SqlServer;
+using Xunit;
+#if !DEBUG
+using Akka.Persistence.Sql.Tests.Common.Internal.Xunit;
+#endif
+
+namespace Akka.Persistence.Sql.Tests.Query.SqlServer2016.TagTable
+{
+#if !DEBUG
+    [SkipWindows]
+#endif
+    [Collection(nameof(SqlServer2016PersistenceSpec))]
+    public class SqlServer2016FromEndOffsetSpec : BaseFromEndOffsetSpec<SqlServer2016Container>
+    {
+        public SqlServer2016FromEndOffsetSpec(ITestOutputHelper output, SqlServer2016Container fixture)
+            : base(TagMode.TagTable, output, nameof(SqlServer2016FromEndOffsetSpec), fixture) { }
+    }
+}

--- a/src/Akka.Persistence.Sql.Tests/Query/Sqlite/Csv/SqliteFromEndOffsetSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests/Query/Sqlite/Csv/SqliteFromEndOffsetSpec.cs
@@ -1,0 +1,21 @@
+// -----------------------------------------------------------------------
+//  <copyright file="SqliteFromEndOffsetSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Persistence.Sql.Config;
+using Akka.Persistence.Sql.Tests.Common.Containers;
+using Akka.Persistence.Sql.Tests.Common.Query;
+using Akka.Persistence.Sql.Tests.Sqlite;
+using Xunit;
+
+namespace Akka.Persistence.Sql.Tests.Query.Sqlite.Csv
+{
+    [Collection(nameof(SqlitePersistenceSpec))]
+    public class SqliteFromEndOffsetSpec : BaseFromEndOffsetSpec<SqliteContainer>
+    {
+        public SqliteFromEndOffsetSpec(ITestOutputHelper output, SqliteContainer fixture)
+            : base(TagMode.Csv, output, nameof(SqliteFromEndOffsetSpec), fixture) { }
+    }
+}

--- a/src/Akka.Persistence.Sql.Tests/Query/Sqlite/TagTable/SqliteFromEndOffsetSpec.cs
+++ b/src/Akka.Persistence.Sql.Tests/Query/Sqlite/TagTable/SqliteFromEndOffsetSpec.cs
@@ -1,0 +1,21 @@
+// -----------------------------------------------------------------------
+//  <copyright file="SqliteFromEndOffsetSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Persistence.Sql.Config;
+using Akka.Persistence.Sql.Tests.Common.Containers;
+using Akka.Persistence.Sql.Tests.Common.Query;
+using Akka.Persistence.Sql.Tests.Sqlite;
+using Xunit;
+
+namespace Akka.Persistence.Sql.Tests.Query.Sqlite.TagTable
+{
+    [Collection(nameof(SqlitePersistenceSpec))]
+    public class SqliteFromEndOffsetSpec : BaseFromEndOffsetSpec<SqliteContainer>
+    {
+        public SqliteFromEndOffsetSpec(ITestOutputHelper output, SqliteContainer fixture)
+            : base(TagMode.TagTable, output, nameof(SqliteFromEndOffsetSpec), fixture) { }
+    }
+}

--- a/src/Akka.Persistence.Sql/Query/Dao/BaseByteReadArrayJournalDao.cs
+++ b/src/Akka.Persistence.Sql/Query/Dao/BaseByteReadArrayJournalDao.cs
@@ -225,6 +225,58 @@ namespace Akka.Persistence.Sql.Query.Dao
                 });
         }
 
+        public async Task<long> FromEndStartOffsetAsync(string tag, int count)
+        {
+            if (count <= 0)
+                return 0;
+
+            var mode = _readJournalConfig.PluginConfig.TagMode;
+            var separator = _readJournalConfig.PluginConfig.TagSeparator;
+
+            // Find the Ordering of the Nth-from-last matching event by reading the top-N in descending order
+            // and taking the oldest of them. The query stays forward/exclusive (Ordering > start), so the
+            // exclusive start offset is that Ordering minus one.
+            var nthFromEnd = await ConnectionFactory.ExecuteQueryWithTransactionAsync(
+                _dbStateHolder,
+                async (connection, token) =>
+                {
+                    IQueryable<long> orderings;
+                    if (tag is null)
+                    {
+                        orderings = connection
+                            .GetTable<JournalRow>()
+                            .Where(r => !r.Deleted)
+                            .OrderByDescending(r => r.Ordering)
+                            .Select(r => r.Ordering);
+                    }
+                    else if (mode == TagMode.Csv)
+                    {
+                        var tagValue = $"{separator}{tag}{separator}";
+                        orderings = connection
+                            .GetTable<JournalRow>()
+                            .Where(r => r.Tags != null && r.Tags.Contains(tagValue) && !r.Deleted)
+                            .OrderByDescending(r => r.Ordering)
+                            .Select(r => r.Ordering);
+                    }
+                    else
+                    {
+                        orderings =
+                            from r in connection.GetTable<JournalRow>()
+                            from lp in connection.GetTable<JournalTagRow>()
+                                .Where(jtr => jtr.OrderingId == r.Ordering)
+                            where !r.Deleted && lp.TagValue == tag
+                            orderby r.Ordering descending
+                            select r.Ordering;
+                    }
+
+                    var list = await orderings.Skip(count - 1).Take(1).ToListAsync(token);
+                    return list.Count == 0 ? (long?)null : list[0];
+                });
+
+            // fewer than `count` matching events -> start from the beginning
+            return nthFromEnd.HasValue ? nthFromEnd.Value - 1 : 0;
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int MaxTake(long max)
             => max > int.MaxValue

--- a/src/Akka.Persistence.Sql/Query/IReadJournalDao.cs
+++ b/src/Akka.Persistence.Sql/Query/IReadJournalDao.cs
@@ -28,5 +28,12 @@ namespace Akka.Persistence.Sql.Query
             long limit);
 
         Task<long> MaxJournalSequenceAsync();
+
+        /// <summary>
+        /// Resolves a "from the end" (last <paramref name="count"/> events) query into a concrete exclusive
+        /// start offset, so the normal forward streaming path returns the last <paramref name="count"/> events.
+        /// Pass <paramref name="tag"/> = <c>null</c> to resolve against all events.
+        /// </summary>
+        Task<long> FromEndStartOffsetAsync(string tag, int count);
     }
 }

--- a/src/Akka.Persistence.Sql/Query/SqlReadJournal.cs
+++ b/src/Akka.Persistence.Sql/Query/SqlReadJournal.cs
@@ -114,24 +114,28 @@ namespace Akka.Persistence.Sql.Query
         public static string Identifier => "akka.persistence.query.journal.sql";
 
         public Source<EventEnvelope, NotUsed> AllEvents(Offset offset)
-            => Events(
-                offset is Sequence s
-                    ? s.Value
-                    : 0,
-                null);
+            => offset is FromEnd fe
+                ? ResolveFromEnd(null, fe.Count, start => Events(start, null))
+                : Events(
+                    offset is Sequence s
+                        ? s.Value
+                        : 0,
+                    null);
 
         public Source<EventEnvelope, NotUsed> CurrentAllEvents(Offset offset)
+            => offset is FromEnd fe
+                ? ResolveFromEnd(null, fe.Count, CurrentAllEventsFrom)
+                : CurrentAllEventsFrom(
+                    offset is Sequence s
+                        ? s.Value
+                        : 0);
+
+        private Source<EventEnvelope, NotUsed> CurrentAllEventsFrom(long offset)
             => AsyncSource<long>
                 .FromEnumerable(
                     state: _readJournalDao,
                     func: async input => new[] { await input.MaxJournalSequenceAsync() })
-                .ConcatMany(
-                    maxInDb =>
-                        Events(
-                            offset is Sequence s
-                                ? s.Value
-                                : 0,
-                            maxInDb));
+                .ConcatMany(maxInDb => Events(offset, maxInDb));
 
         public Source<EventEnvelope, NotUsed> CurrentEventsByPersistenceId(
             string persistenceId,
@@ -144,7 +148,9 @@ namespace Akka.Persistence.Sql.Query
                 refreshInterval: Option<(TimeSpan, IScheduler)>.None);
 
         public Source<EventEnvelope, NotUsed> CurrentEventsByTag(string tag, Offset offset)
-            => CurrentEventsByTag(tag, (offset as Sequence)?.Value ?? 0);
+            => offset is FromEnd fe
+                ? ResolveFromEnd(tag, fe.Count, start => CurrentEventsByTag(tag, start))
+                : CurrentEventsByTag(tag, (offset as Sequence)?.Value ?? 0);
 
         public Source<string, NotUsed> CurrentPersistenceIds()
             => _readJournalDao.AllPersistenceIdsSource(long.MaxValue);
@@ -161,12 +167,26 @@ namespace Akka.Persistence.Sql.Query
                     (_readJournalConfig.RefreshInterval, _system.Scheduler)));
 
         public Source<EventEnvelope, NotUsed> EventsByTag(string tag, Offset offset)
-            => EventsByTag(
-                tag,
-                offset is Sequence s
-                    ? s.Value
-                    : 0,
-                null);
+            => offset is FromEnd fe
+                ? ResolveFromEnd(tag, fe.Count, start => EventsByTag(tag, start, null))
+                : EventsByTag(
+                    tag,
+                    offset is Sequence s
+                        ? s.Value
+                        : 0,
+                    null);
+
+        // Resolves a FromEnd(N) offset into a concrete exclusive start offset, then defers to the normal
+        // forward-streaming query. Mirrors the existing async MaxJournalSequence resolution pattern.
+        private Source<EventEnvelope, NotUsed> ResolveFromEnd(
+            string tag,
+            int count,
+            Func<long, Source<EventEnvelope, NotUsed>> continuation)
+            => AsyncSource<long>
+                .FromEnumerable(
+                    state: new { dao = _readJournalDao, tag, count },
+                    func: async input => new[] { await input.dao.FromEndStartOffsetAsync(input.tag, input.count) })
+                .ConcatMany(continuation);
 
         public Source<string, NotUsed> PersistenceIds()
             => Source

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,10 +1,8 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <AkkaVersion>1.5.67</AkkaVersion>
+    <AkkaVersion>1.5.70-beta1</AkkaVersion>
     <AkkaHostingVersion>1.5.67</AkkaHostingVersion>
-    <!-- SPIKE ONLY: unreleased Akka core build carrying the FromEnd query offset (from ./local-spike feed) -->
-    <FromEndSpikeVersion>1.5.69-fromendspike</FromEndSpikeVersion>
     <FluentMigratorVersion>5.2.0</FluentMigratorVersion>
     <SqliteVersion>1.0.118</SqliteVersion>
     <MicrosoftSqliteVersion>8.0.7</MicrosoftSqliteVersion>
@@ -13,18 +11,18 @@
   </PropertyGroup>
   <!-- Akka dependencies -->
   <ItemGroup>
-    <PackageVersion Include="Akka" Version="$(FromEndSpikeVersion)" />
+    <PackageVersion Include="Akka" Version="$(AkkaVersion)" />
     <PackageVersion Include="Akka.Cluster.Hosting" Version="$(AkkaHostingVersion)" />
     <PackageVersion Include="Akka.Cluster.Sharding" Version="$(AkkaVersion)" />
     <PackageVersion Include="Akka.Hosting" Version="$(AkkaHostingVersion)" />
-    <PackageVersion Include="Akka.Persistence" Version="$(FromEndSpikeVersion)" />
+    <PackageVersion Include="Akka.Persistence" Version="$(AkkaVersion)" />
     <PackageVersion Include="Akka.Persistence.Hosting" Version="$(AkkaHostingVersion)" />
     <PackageVersion Include="Akka.Persistence.Sql.Compat.Common" Version="0.1.0" />
     <PackageVersion Include="Akka.Persistence.TCK" Version="$(AkkaVersion)" />
     <PackageVersion Include="Akka.Persistence.TestKit" Version="$(AkkaVersion)" />
-    <PackageVersion Include="Akka.Persistence.Query" Version="$(FromEndSpikeVersion)" />
+    <PackageVersion Include="Akka.Persistence.Query" Version="$(AkkaVersion)" />
     <PackageVersion Include="Akka.Serialization.Hyperion" Version="$(AkkaVersion)" />
-    <PackageVersion Include="Akka.Streams" Version="$(FromEndSpikeVersion)" />
+    <PackageVersion Include="Akka.Streams" Version="$(AkkaVersion)" />
     <PackageVersion Include="MathNet.Numerics" Version="5.0.0" />
   </ItemGroup>
   <!-- App dependencies -->

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -3,6 +3,8 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <AkkaVersion>1.5.67</AkkaVersion>
     <AkkaHostingVersion>1.5.67</AkkaHostingVersion>
+    <!-- SPIKE ONLY: unreleased Akka core build carrying the FromEnd query offset (from ./local-spike feed) -->
+    <FromEndSpikeVersion>1.5.69-fromendspike</FromEndSpikeVersion>
     <FluentMigratorVersion>5.2.0</FluentMigratorVersion>
     <SqliteVersion>1.0.118</SqliteVersion>
     <MicrosoftSqliteVersion>8.0.7</MicrosoftSqliteVersion>
@@ -11,18 +13,18 @@
   </PropertyGroup>
   <!-- Akka dependencies -->
   <ItemGroup>
-    <PackageVersion Include="Akka" Version="$(AkkaVersion)" />
+    <PackageVersion Include="Akka" Version="$(FromEndSpikeVersion)" />
     <PackageVersion Include="Akka.Cluster.Hosting" Version="$(AkkaHostingVersion)" />
     <PackageVersion Include="Akka.Cluster.Sharding" Version="$(AkkaVersion)" />
     <PackageVersion Include="Akka.Hosting" Version="$(AkkaHostingVersion)" />
-    <PackageVersion Include="Akka.Persistence" Version="$(AkkaVersion)" />
+    <PackageVersion Include="Akka.Persistence" Version="$(FromEndSpikeVersion)" />
     <PackageVersion Include="Akka.Persistence.Hosting" Version="$(AkkaHostingVersion)" />
     <PackageVersion Include="Akka.Persistence.Sql.Compat.Common" Version="0.1.0" />
     <PackageVersion Include="Akka.Persistence.TCK" Version="$(AkkaVersion)" />
     <PackageVersion Include="Akka.Persistence.TestKit" Version="$(AkkaVersion)" />
-    <PackageVersion Include="Akka.Persistence.Query" Version="$(AkkaVersion)" />
+    <PackageVersion Include="Akka.Persistence.Query" Version="$(FromEndSpikeVersion)" />
     <PackageVersion Include="Akka.Serialization.Hyperion" Version="$(AkkaVersion)" />
-    <PackageVersion Include="Akka.Streams" Version="$(AkkaVersion)" />
+    <PackageVersion Include="Akka.Streams" Version="$(FromEndSpikeVersion)" />
     <PackageVersion Include="MathNet.Numerics" Version="5.0.0" />
   </ItemGroup>
   <!-- App dependencies -->


### PR DESCRIPTION
> **Draft / spike — not mergeable as-is.** This validates the design for [akkadotnet/akka.net#8244](https://github.com/akkadotnet/akka.net/issues/8244) (a "from the end" / last-N query offset) against a real SQL backend. It depends on an **unreleased** Akka core build that carries the new `Offset.FromEnd` type, consumed here via a local NuGet feed (`NuGet.Config` + `Directory.Packages.props` spike wiring). **CI restore will fail** until that core change ships — that wiring is throwaway and must be reverted before this becomes a real PR.

## What this proves

`FromEnd(N)` resolves to a concrete exclusive start offset and then reuses the existing forward-streaming pipeline unchanged:

- `BaseByteReadArrayJournalDao.FromEndStartOffsetAsync` finds the Nth-from-last matching `Ordering` via `OrderByDescending(Ordering).Skip(N-1).Take(1)` and returns `that - 1` (exclusive start; `0` if fewer than N). Handles CSV mode, TagTable mode, and all-events (`tag == null`).
- `SqlReadJournal` handles `FromEnd` in `AllEvents`/`CurrentAllEvents`/`EventsByTag`/`CurrentEventsByTag` via a `ResolveFromEnd` helper (`CurrentAllEventsFrom` extracted to keep the non-FromEnd path identical).
- `MsSqliteFromEndSpec` validates last-N and N>total against SQLite (passes locally; also runs the inherited ByTag TCK suite green → spike core is binary-compatible).

## Known follow-ups before productionizing (from a max-effort review)

1. `ResolveFromEnd(null, …)` → `CS8625` under `-warnaserror`; make `tag` `string?`.
2. New member on the public `IReadJournalDao` is an API break — use a separate optional interface + feature-detect (DIM isn't viable on netstandard2.0).
3. Resolution + forward read are separate snapshots → Current* can return ≠ N under concurrent delete/write; resolve+read in one transaction and broaden the doc caveat.
4. `FromEnd(N)` counts journal rows, not post-adapter envelopes — document.
5. Share the tag-filter predicate with `EventsByTag` to avoid drift.

Replace the spike test with a dedicated `FromEndOffsetSpec` TCK subclass; drop the local-feed wiring.
