### PR TITLE
Fix journal delete transaction retry scope

### DIFF
--- a/src/Akka.Persistence.Sql.Tests/SqlServer/SqlServerTransactionRetrySpec.cs
+++ b/src/Akka.Persistence.Sql.Tests/SqlServer/SqlServerTransactionRetrySpec.cs
@@ -28,9 +28,15 @@ using LinqToDB.Interceptors;
 using LinqToDB.Mapping;
 using Microsoft.Data.SqlClient;
 using Xunit;
+#if !DEBUG
+using Akka.Persistence.Sql.Tests.Common.Internal.Xunit;
+#endif
 
 namespace Akka.Persistence.Sql.Tests.SqlServer;
 
+#if !DEBUG
+[SkipWindows]
+#endif
 [Collection(nameof(SqlServerPersistenceSpec))]
 public sealed class SqlServerTransactionRetrySpec
 {

--- a/src/Akka.Persistence.Sql.Tests/SqlServer/SqlServerTransactionRetrySpec.cs
+++ b/src/Akka.Persistence.Sql.Tests/SqlServer/SqlServerTransactionRetrySpec.cs
@@ -1,0 +1,543 @@
+// -----------------------------------------------------------------------
+//  <copyright file="SqlServerTransactionRetrySpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Event;
+using Akka.Persistence.Sql.Config;
+using Akka.Persistence.Sql.Db;
+using Akka.Persistence.Sql.Extensions;
+using Akka.Persistence.Sql.Journal.Dao;
+using Akka.Persistence.Sql.Journal.Types;
+using Akka.Persistence.Sql.Tests.Common.Containers;
+using Akka.Streams;
+using FluentAssertions;
+using LinqToDB;
+using LinqToDB.Data.RetryPolicy;
+using LinqToDB.Interceptors;
+using LinqToDB.Mapping;
+using Microsoft.Data.SqlClient;
+using Xunit;
+
+namespace Akka.Persistence.Sql.Tests.SqlServer;
+
+[Collection(nameof(SqlServerPersistenceSpec))]
+public sealed class SqlServerTransactionRetrySpec
+{
+    private const int StressIterations = 10;
+    private readonly SqlServerContainer _fixture;
+
+    public SqlServerTransactionRetrySpec(SqlServerContainer fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task Public_transaction_handler_should_keep_its_configured_command_retry_policy()
+    {
+        var retryPolicy = new PassThroughRetryPolicy();
+        var config = WithRetryPolicy(CreateConfig(), retryPolicy);
+        var factory = new AkkaPersistenceDataConnectionFactory(config);
+        IRetryPolicy? handlerPolicy = null;
+
+        await factory.ExecuteWithTransactionAsync(
+            IsolationLevel.ReadCommitted,
+            CancellationToken.None,
+            (connection, _) =>
+            {
+                handlerPolicy = connection.DetachRetryPolicy();
+                return Task.CompletedTask;
+            });
+
+        handlerPolicy.Should().BeSameAs(retryPolicy);
+    }
+
+    [Fact]
+    public async Task Public_transaction_handler_should_execute_only_once()
+    {
+        var factory = new AkkaPersistenceDataConnectionFactory(CreateConfig());
+        var invocationCount = 0;
+
+        var action = () => factory.ExecuteWithTransactionAsync(
+            IsolationLevel.ReadCommitted,
+            CancellationToken.None,
+            (_, _) =>
+            {
+                Interlocked.Increment(ref invocationCount);
+                throw new TimeoutException("The public callback must not become implicitly replayable.");
+            });
+
+        await action.Should().ThrowAsync<TimeoutException>();
+        invocationCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Configured_retry_policy_should_own_complete_transaction_attempts()
+    {
+        var retryPolicy = new ReplayTwiceRetryPolicy();
+        var factory = new AkkaPersistenceDataConnectionFactory(WithRetryPolicy(CreateConfig(), retryPolicy));
+        var connections = new ConcurrentBag<AkkaDataConnection>();
+
+        await factory.ExecuteReplaySafeWithTransactionRetryAsync(
+            IsolationLevel.ReadCommitted,
+            CancellationToken.None,
+            (connection, _) =>
+            {
+                connections.Add(connection);
+                connection.DetachRetryPolicy().Should().BeNull(
+                    "command retry must be outside the transaction it may replace");
+                return Task.CompletedTask;
+            });
+
+        retryPolicy.VoidAsyncAttempts.Should().Be(2);
+        connections.Distinct(ReferenceEqualityComparer.Instance).Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task Connection_cleanup_failure_should_not_hide_the_retryable_operation_failure()
+    {
+        var retryPolicy = new RetryOncePolicy();
+        var options = CreateDataOptions(retryPolicy)
+            .UseInterceptor(new ThrowOnFirstClosingInterceptor());
+        var factory = new AkkaPersistenceDataConnectionFactory(
+            CreateConfig().WithDataOptions(options));
+        var invocationCount = 0;
+
+        await factory.ExecuteReplaySafeWithTransactionRetryAsync(
+            IsolationLevel.ReadCommitted,
+            CancellationToken.None,
+            (_, _) =>
+            {
+                if (Interlocked.Increment(ref invocationCount) == 1)
+                    throw new RetryableTestException();
+
+                return Task.CompletedTask;
+            });
+
+        retryPolicy.VoidAsyncAttempts.Should().Be(2);
+        retryPolicy.FirstException.Should().BeOfType<RetryableTestException>();
+        retryPolicy.FirstException!.Data.Values
+            .Cast<object>()
+            .Should().ContainSingle(value => value is ConnectionCleanupTestException);
+    }
+
+    [Fact]
+    public async Task Deadlock_victim_should_retry_entire_transaction_on_fresh_connection()
+    {
+        var config = CreateConfig();
+        var factory = new AkkaPersistenceDataConnectionFactory(config);
+
+        await using (var connection = factory.GetConnection())
+        {
+            await connection.CreateTableAsync<DeadlockRow>(TableOptions.None, null, CancellationToken.None);
+            await connection.GetTable<DeadlockRow>().InsertAsync(() => new DeadlockRow { Id = 1, Value = 0 });
+            await connection.GetTable<DeadlockRow>().InsertAsync(() => new DeadlockRow { Id = 2, Value = 0 });
+        }
+
+        for (var iteration = 0; iteration < StressIterations; iteration++)
+        {
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            var bothFirstRowsLocked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var firstLockCount = 0;
+            var invocationCount = 0;
+            var connections = new ConcurrentBag<AkkaDataConnection>();
+
+            Task Execute(int firstRowId, int secondRowId)
+                => factory.ExecuteReplaySafeWithTransactionRetryAsync(
+                    IsolationLevel.ReadCommitted,
+                    timeout.Token,
+                    async (connection, token) =>
+                    {
+                        connections.Add(connection);
+                        Interlocked.Increment(ref invocationCount);
+
+                        await LockRow(connection, firstRowId, token);
+                        if (Interlocked.Increment(ref firstLockCount) == 2)
+                            bothFirstRowsLocked.SetResult();
+
+                        await bothFirstRowsLocked.Task.WaitAsync(token);
+                        await LockRow(connection, secondRowId, token);
+                    });
+
+            await Task.WhenAll(
+                Execute(1, 2),
+                Execute(2, 1));
+
+            invocationCount.Should().Be(3, "the deadlock victim should rerun the complete transaction handler once");
+            connections.Distinct(ReferenceEqualityComparer.Instance).Should().HaveCount(3);
+        }
+
+        await using var verificationConnection = factory.GetConnection();
+        var rows = await verificationConnection.GetTable<DeadlockRow>()
+            .OrderBy(row => row.Id)
+            .ToArrayAsync();
+        rows.Select(row => row.Value).Should().Equal(StressIterations * 2, StressIterations * 2);
+    }
+
+    [Fact]
+    public async Task Journal_dao_delete_should_recover_from_deadlock_without_completed_transaction_failure()
+    {
+        const string journalTableName = "DaoTransactionRetryJournal";
+        const string metadataTableName = journalTableName + "Metadata";
+        var config = CreateConfig(journalTableName);
+        var factory = new AkkaPersistenceDataConnectionFactory(config);
+        var actorSystem = ActorSystem.Create("dao-transaction-retry-spec");
+
+        try
+        {
+            var dao = new ByteArrayJournalDao(
+                actorSystem.Scheduler.Advanced,
+                actorSystem.Materializer(),
+                factory,
+                config,
+                actorSystem.Serialization,
+                Logging.GetLogger(actorSystem, nameof(SqlServerTransactionRetrySpec)),
+                null,
+                CancellationToken.None);
+
+            await dao.InitializeTables(CancellationToken.None);
+            await CreateMetadataDeadlockTrigger(metadataTableName);
+
+            for (var iteration = 0; iteration < StressIterations; iteration++)
+            {
+                var firstPersistenceId = $"p-{iteration}-1";
+                var secondPersistenceId = $"p-{iteration}-2";
+                await SeedJournalRows(factory, firstPersistenceId, secondPersistenceId);
+
+                using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+                var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                async Task DeleteWhenStarted(string persistenceId)
+                {
+                    await start.Task.WaitAsync(timeout.Token);
+                    await dao.Delete(persistenceId, 2, timeout.Token);
+                }
+
+                var firstDelete = DeleteWhenStarted(firstPersistenceId);
+                var secondDelete = DeleteWhenStarted(secondPersistenceId);
+                start.SetResult();
+
+                await Task.WhenAll(firstDelete, secondDelete);
+            }
+
+            await using var verificationConnection = factory.GetConnection();
+            var remainingRows = await verificationConnection.GetTable<JournalRow>()
+                .OrderBy(row => row.PersistenceId)
+                .ThenBy(row => row.SequenceNumber)
+                .ToArrayAsync();
+
+            remainingRows.Should().HaveCount(StressIterations * 2)
+                .And.OnlyContain(row => row.SequenceNumber == 2 && row.Deleted);
+
+            var metadataRows = await verificationConnection.GetTable<JournalMetaData>()
+                .OrderBy(row => row.PersistenceId)
+                .ToArrayAsync();
+
+            metadataRows.Should().HaveCount(StressIterations * 2)
+                .And.OnlyContain(row => row.SequenceNumber == 2);
+
+            var tagRows = await verificationConnection.GetTable<JournalTagRow>()
+                .OrderBy(row => row.PersistenceId)
+                .ThenBy(row => row.SequenceNumber)
+                .ToArrayAsync();
+
+            tagRows.Should().HaveCount(StressIterations * 2)
+                .And.OnlyContain(row => row.SequenceNumber == 2);
+        }
+        finally
+        {
+            await actorSystem.Terminate();
+        }
+    }
+
+    [Fact]
+    public async Task Journal_dao_delete_should_remain_consistent_when_policy_replays_the_complete_transaction()
+    {
+        const string journalTableName = "DaoTransactionReplayJournal";
+        const string persistenceId = "replayed-delete";
+        var baseConfig = CreateConfig(journalTableName);
+        var baseFactory = new AkkaPersistenceDataConnectionFactory(baseConfig);
+        var actorSystem = ActorSystem.Create("dao-transaction-replay-spec");
+
+        try
+        {
+            var initializationDao = CreateDao(actorSystem, baseFactory, baseConfig);
+            await initializationDao.InitializeTables(CancellationToken.None);
+            await SeedJournalRows(baseFactory, persistenceId);
+
+            var retryPolicy = new ReplayTwiceRetryPolicy();
+            var policyFactoryCalls = 0;
+            var retryOptions = new DataOptions()
+                .UseConnectionString(_fixture.ProviderName, _fixture.ConnectionString);
+            retryOptions = retryOptions.WithOptions(retryOptions.RetryPolicyOptions with
+            {
+                Factory = _ => Interlocked.Increment(ref policyFactoryCalls) == 2
+                    ? retryPolicy
+                    : new PassThroughRetryPolicy(),
+            });
+            var retryConfig = baseConfig.WithDataOptions(retryOptions);
+            var retryFactory = new AkkaPersistenceDataConnectionFactory(retryConfig);
+            var retryDao = CreateDao(actorSystem, retryFactory, retryConfig);
+
+            await retryDao.Delete(persistenceId, 2, CancellationToken.None);
+
+            retryPolicy.VoidAsyncAttempts.Should().Be(2,
+                "the adversarial policy deliberately executes the complete transaction twice");
+
+            await using var verificationConnection = baseFactory.GetConnection();
+            var remainingRows = await verificationConnection.GetTable<JournalRow>()
+                .Where(row => row.PersistenceId == persistenceId)
+                .ToArrayAsync();
+            remainingRows.Should().ContainSingle(row => row.SequenceNumber == 2 && row.Deleted);
+
+            var metadataRows = await verificationConnection.GetTable<JournalMetaData>()
+                .Where(row => row.PersistenceId == persistenceId)
+                .ToArrayAsync();
+            metadataRows.Should().ContainSingle(row => row.SequenceNumber == 2);
+
+            var tagRows = await verificationConnection.GetTable<JournalTagRow>()
+                .Where(row => row.PersistenceId == persistenceId)
+                .ToArrayAsync();
+            tagRows.Should().ContainSingle(row => row.SequenceNumber == 2);
+        }
+        finally
+        {
+            await actorSystem.Terminate();
+        }
+    }
+
+    private JournalConfig CreateConfig(string journalTableName = "journal")
+    {
+        var config = ConfigurationFactory.ParseString(
+                $$"""
+                  akka.persistence.journal.sql {
+                    connection-string = "{{_fixture.ConnectionString}}"
+                    provider-name = "{{_fixture.ProviderName}}"
+                    delete-compatibility-mode = true
+                    tag-write-mode = TagTable
+                    default.journal {
+                      table-name = "{{journalTableName}}"
+                      use-writer-uuid-column = false
+                    }
+                    default.metadata.table-name = "{{journalTableName}}Metadata"
+                    default.tag.table-name = "{{journalTableName}}Tags"
+                  }
+                  """)
+            .WithFallback(SqlPersistence.DefaultConfiguration)
+            .GetConfig("akka.persistence.journal.sql");
+
+        return new JournalConfig(config);
+    }
+
+    private DataOptions CreateDataOptions(IRetryPolicy retryPolicy)
+        => new DataOptions()
+            .UseConnectionString(_fixture.ProviderName, _fixture.ConnectionString)
+            .UseRetryPolicy(retryPolicy);
+
+    private JournalConfig WithRetryPolicy(JournalConfig config, IRetryPolicy retryPolicy)
+        => config.WithDataOptions(CreateDataOptions(retryPolicy));
+
+    private static ByteArrayJournalDao CreateDao(
+        ActorSystem actorSystem,
+        AkkaPersistenceDataConnectionFactory factory,
+        JournalConfig config)
+        => new(
+            actorSystem.Scheduler.Advanced,
+            actorSystem.Materializer(),
+            factory,
+            config,
+            actorSystem.Serialization,
+            Logging.GetLogger(actorSystem, nameof(SqlServerTransactionRetrySpec)),
+            null,
+            CancellationToken.None);
+
+    private static async Task SeedJournalRows(
+        AkkaPersistenceDataConnectionFactory factory,
+        params string[] persistenceIds)
+    {
+        await using var connection = factory.GetConnection();
+        foreach (var persistenceId in persistenceIds)
+        {
+            for (var sequenceNumber = 1L; sequenceNumber <= 2; sequenceNumber++)
+            {
+                var orderingId = await connection.InsertWithInt64IdentityAsync(
+                    CreateJournalRow(persistenceId, sequenceNumber));
+
+                await connection.GetTable<JournalTagRow>().InsertAsync(
+                    () => new JournalTagRow
+                    {
+                        OrderingId = orderingId,
+                        PersistenceId = persistenceId,
+                        SequenceNumber = sequenceNumber,
+                        TagValue = "delete-retry",
+                    });
+            }
+        }
+    }
+
+    private static JournalRow CreateJournalRow(string persistenceId, long sequenceNumber)
+        => new()
+        {
+            PersistenceId = persistenceId,
+            SequenceNumber = sequenceNumber,
+            Timestamp = DateTime.UtcNow.Ticks,
+            Message = [1],
+            Manifest = string.Empty,
+            Tags = string.Empty,
+        };
+
+    private async Task CreateMetadataDeadlockTrigger(string metadataTableName)
+    {
+        await using var connection = new SqlConnection(_fixture.ConnectionString);
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText =
+            """
+              CREATE TABLE [DaoDeleteDeadlockControl]
+              (
+                  [Id] int NOT NULL PRIMARY KEY,
+                  [Value] int NOT NULL
+              );
+
+              INSERT INTO [DaoDeleteDeadlockControl] ([Id], [Value]) VALUES (1, 0), (2, 0);
+              """;
+        await command.ExecuteNonQueryAsync();
+
+        command.CommandText =
+            $$"""
+              CREATE TRIGGER [DaoMetadataDeadlockTrigger]
+              ON [{{metadataTableName}}]
+              AFTER INSERT, UPDATE
+              AS
+              BEGIN
+                  SET NOCOUNT ON;
+
+                  DECLARE @persistenceId nvarchar(255) =
+                      (SELECT TOP (1) [persistence_id] FROM inserted);
+                  DECLARE @firstId int = CASE WHEN RIGHT(@persistenceId, 1) = N'1' THEN 1 ELSE 2 END;
+                  DECLARE @secondId int = CASE WHEN @firstId = 1 THEN 2 ELSE 1 END;
+
+                  UPDATE [DaoDeleteDeadlockControl] WITH (ROWLOCK)
+                  SET [Value] = [Value] + 1
+                  WHERE [Id] = @firstId;
+
+                  WAITFOR DELAY '00:00:01';
+
+                  UPDATE [DaoDeleteDeadlockControl] WITH (ROWLOCK)
+                  SET [Value] = [Value] + 1
+                  WHERE [Id] = @secondId;
+              END;
+              """;
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private static Task<int> LockRow(
+        AkkaDataConnection connection,
+        int rowId,
+        CancellationToken cancellationToken)
+        => connection.GetTable<DeadlockRow>()
+            .Where(row => row.Id == rowId)
+            .Set(row => row.Value, row => row.Value + 1)
+            .UpdateAsync(cancellationToken);
+
+    [Table("TransactionRetryDeadlock")]
+    private sealed class DeadlockRow
+    {
+        [PrimaryKey]
+        public int Id { get; set; }
+
+        [Column]
+        public int Value { get; set; }
+    }
+
+    private class PassThroughRetryPolicy : IRetryPolicy
+    {
+        public int ResultAsyncAttempts { get; protected set; }
+        public int VoidAsyncAttempts { get; protected set; }
+
+        public TResult Execute<TResult>(Func<TResult> operation)
+            => operation();
+
+        public void Execute(Action operation)
+            => operation();
+
+        public virtual async Task<TResult> ExecuteAsync<TResult>(
+            Func<CancellationToken, Task<TResult>> operation,
+            CancellationToken cancellationToken = default)
+        {
+            ResultAsyncAttempts++;
+            return await operation(cancellationToken);
+        }
+
+        public virtual async Task ExecuteAsync(
+            Func<CancellationToken, Task> operation,
+            CancellationToken cancellationToken = default)
+        {
+            VoidAsyncAttempts++;
+            await operation(cancellationToken);
+        }
+    }
+
+    private sealed class ReplayTwiceRetryPolicy : PassThroughRetryPolicy
+    {
+        public override async Task ExecuteAsync(
+            Func<CancellationToken, Task> operation,
+            CancellationToken cancellationToken = default)
+        {
+            await base.ExecuteAsync(operation, cancellationToken);
+            await base.ExecuteAsync(operation, cancellationToken);
+        }
+    }
+
+    private sealed class RetryOncePolicy : PassThroughRetryPolicy
+    {
+        public Exception? FirstException { get; private set; }
+
+        public override async Task ExecuteAsync(
+            Func<CancellationToken, Task> operation,
+            CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                await base.ExecuteAsync(operation, cancellationToken);
+            }
+            catch (RetryableTestException exception)
+            {
+                FirstException = exception;
+                await base.ExecuteAsync(operation, cancellationToken);
+            }
+        }
+    }
+
+    private sealed class ThrowOnFirstClosingInterceptor : DataContextInterceptor
+    {
+        private int _closingCount;
+
+        public override Task OnClosingAsync(DataContextEventData eventData)
+        {
+            if (Interlocked.Increment(ref _closingCount) == 1)
+                throw new ConnectionCleanupTestException();
+
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RetryableTestException : Exception
+    {
+    }
+
+    private sealed class ConnectionCleanupTestException : Exception
+    {
+    }
+}

--- a/src/Akka.Persistence.Sql/Db/AkkaDataConnection.cs
+++ b/src/Akka.Persistence.Sql/Db/AkkaDataConnection.cs
@@ -14,6 +14,7 @@ using LinqToDB;
 using LinqToDB.Data;
 using LinqToDB.DataProvider;
 using LinqToDB.DataProvider.SqlServer;
+using LinqToDB.Data.RetryPolicy;
 using LinqToDB.SchemaProvider;
 
 namespace Akka.Persistence.Sql.Db
@@ -62,6 +63,13 @@ namespace Akka.Persistence.Sql.Db
 
         public AkkaDataConnection Clone()
             => new(_providerName, (DataConnection)_connection.Clone());
+
+        internal IRetryPolicy? DetachRetryPolicy()
+        {
+            var retryPolicy = _connection.RetryPolicy;
+            _connection.RetryPolicy = null;
+            return retryPolicy;
+        }
 
         public DatabaseSchema GetSchema()
             => _connection.DataProvider.GetSchemaProvider().GetSchema(_connection);

--- a/src/Akka.Persistence.Sql/Db/AkkaPersistenceDataConnectionFactory.cs
+++ b/src/Akka.Persistence.Sql/Db/AkkaPersistenceDataConnectionFactory.cs
@@ -10,6 +10,7 @@ using Akka.Persistence.Sql.Journal.Types;
 using Akka.Persistence.Sql.Snapshot;
 using LinqToDB;
 using LinqToDB.Data;
+using LinqToDB.Data.RetryPolicy;
 using LinqToDB.DataProvider.SqlServer;
 using LinqToDB.Mapping;
 
@@ -43,7 +44,7 @@ namespace Akka.Persistence.Sql.Db
             _useCloneDataConnection = config.UseCloneConnection;
 
             if (_opts.RetryPolicyOptions.RetryPolicy is null && _opts.RetryPolicyOptions.Factory is null && _opts.ConnectionOptions.ProviderName!.ToLowerInvariant().StartsWith("sqlserver"))
-                _opts = _opts.WithOptions( _opts.RetryPolicyOptions with { RetryPolicy = new SqlServerRetryPolicy() } );
+                _opts = _opts.WithOptions(_opts.RetryPolicyOptions with { Factory = _ => new SqlServerRetryPolicy() });
             
             _cloneConnection = new Lazy<AkkaDataConnection>(
                 () => new AkkaDataConnection(
@@ -403,5 +404,27 @@ namespace Akka.Persistence.Sql.Db
 
             return _cloneConnection.Value.Clone();
         }
+
+        internal bool HasRetryPolicy
+            => _opts.RetryPolicyOptions.RetryPolicy is not null ||
+               _opts.RetryPolicyOptions.Factory is not null;
+
+        internal AkkaDataConnection GetRetryScopeConnection(out IRetryPolicy? retryPolicy)
+        {
+            if (!HasRetryPolicy)
+            {
+                retryPolicy = null;
+                return GetConnection();
+            }
+
+            // Do not clone here. DataConnection.Clone copies the current retry-policy instance,
+            // while a replay-safe operation needs one independent policy to own all of its attempts.
+            var connection = new AkkaDataConnection(
+                _opts.ConnectionOptions.ProviderName!,
+                new DataConnection(_opts));
+            retryPolicy = connection.DetachRetryPolicy();
+            return connection;
+        }
+
     }
 }

--- a/src/Akka.Persistence.Sql/Db/AkkaPersistenceDataConnectionFactory.cs
+++ b/src/Akka.Persistence.Sql/Db/AkkaPersistenceDataConnectionFactory.cs
@@ -11,7 +11,6 @@ using Akka.Persistence.Sql.Snapshot;
 using LinqToDB;
 using LinqToDB.Data;
 using LinqToDB.Data.RetryPolicy;
-using LinqToDB.DataProvider.SqlServer;
 using LinqToDB.Mapping;
 
 namespace Akka.Persistence.Sql.Db
@@ -44,7 +43,7 @@ namespace Akka.Persistence.Sql.Db
             _useCloneDataConnection = config.UseCloneConnection;
 
             if (_opts.RetryPolicyOptions.RetryPolicy is null && _opts.RetryPolicyOptions.Factory is null && _opts.ConnectionOptions.ProviderName!.ToLowerInvariant().StartsWith("sqlserver"))
-                _opts = _opts.WithOptions(_opts.RetryPolicyOptions with { Factory = _ => new SqlServerRetryPolicy() });
+                _opts = _opts.WithOptions(_opts.RetryPolicyOptions with { Factory = _ => new AkkaSqlServerRetryPolicy() });
             
             _cloneConnection = new Lazy<AkkaDataConnection>(
                 () => new AkkaDataConnection(
@@ -409,22 +408,32 @@ namespace Akka.Persistence.Sql.Db
             => _opts.RetryPolicyOptions.RetryPolicy is not null ||
                _opts.RetryPolicyOptions.Factory is not null;
 
-        internal AkkaDataConnection GetRetryScopeConnection(out IRetryPolicy? retryPolicy)
+        /// <summary>
+        /// Materializes the configured retry policy. LinqToDB can only produce a policy through
+        /// RetryPolicyOptions (instance or factory) applied to a DataConnection, so we construct a
+        /// throwaway connection — never opened — and detach its policy.
+        /// </summary>
+        internal IRetryPolicy? TakeReplayRetryPolicy()
         {
-            if (!HasRetryPolicy)
-            {
-                retryPolicy = null;
-                return GetConnection();
-            }
-
             // Do not clone here. DataConnection.Clone copies the current retry-policy instance,
             // while a replay-safe operation needs one independent policy to own all of its attempts.
+            using var connection = new AkkaDataConnection(
+                _opts.ConnectionOptions.ProviderName!,
+                new DataConnection(_opts));
+            return connection.DetachRetryPolicy();
+        }
+
+        /// <summary>
+        /// Creates a fresh connection with no attached retry policy, so commands inside an explicit
+        /// transaction are never retried by LinqToDB against a doomed transaction.
+        /// </summary>
+        internal AkkaDataConnection GetConnectionWithoutRetryPolicy()
+        {
             var connection = new AkkaDataConnection(
                 _opts.ConnectionOptions.ProviderName!,
                 new DataConnection(_opts));
-            retryPolicy = connection.DetachRetryPolicy();
+            connection.DetachRetryPolicy();
             return connection;
         }
-
     }
 }

--- a/src/Akka.Persistence.Sql/Extensions/ConnectionFactoryExtensions.cs
+++ b/src/Akka.Persistence.Sql/Extensions/ConnectionFactoryExtensions.cs
@@ -18,6 +18,8 @@ namespace Akka.Persistence.Sql.Extensions
 {
     public static class ConnectionFactoryExtensions
     {
+        private const string CleanupExceptionDataKey = "Akka.Persistence.Sql.TransactionCleanupException";
+
         public static async Task ExecuteWithTransactionAsync(
             this AkkaPersistenceDataConnectionFactory factory,
             IsolationLevel level,
@@ -137,6 +139,142 @@ namespace Akka.Persistence.Sql.Extensions
                 }
 
                 throw;
+            }
+        }
+
+        /// <summary>
+        /// Executes a replay-safe operation with the configured retry policy outside the transaction
+        /// boundary. Every policy attempt owns a new connection and transaction.
+        /// </summary>
+        internal static async Task ExecuteReplaySafeWithTransactionRetryAsync(
+            this AkkaPersistenceDataConnectionFactory factory,
+            IsolationLevel level,
+            CancellationToken token,
+            Func<AkkaDataConnection, CancellationToken, Task> handler)
+        {
+            if (!factory.HasRetryPolicy)
+            {
+                await factory.ExecuteWithTransactionAsync(level, token, handler);
+                return;
+            }
+
+            AkkaDataConnection? firstConnection = factory.GetRetryScopeConnection(out var retryPolicy);
+
+            async Task ExecuteAttempt(CancellationToken cancellationToken)
+            {
+                var connection = Interlocked.Exchange(ref firstConnection, null)
+                    ?? factory.GetRetryScopeConnection(out _);
+                Exception? operationException = null;
+
+                try
+                {
+                    await ExecuteTransactionAttemptAsync(connection, level, cancellationToken, handler);
+                }
+                catch (Exception exception)
+                {
+                    operationException = exception;
+                    throw;
+                }
+                finally
+                {
+                    await DisposeConnectionAsync(connection, operationException);
+                }
+            }
+
+            Exception? retryException = null;
+            try
+            {
+                if (retryPolicy is null)
+                    await ExecuteAttempt(token);
+                else
+                    await retryPolicy.ExecuteAsync(ExecuteAttempt, token);
+            }
+            catch (Exception exception)
+            {
+                retryException = exception;
+                throw;
+            }
+            finally
+            {
+                var unusedConnection = Interlocked.Exchange(ref firstConnection, null);
+                if (unusedConnection is not null)
+                    await DisposeConnectionAsync(unusedConnection, retryException);
+            }
+        }
+
+        private static async Task ExecuteTransactionAttemptAsync(
+            AkkaDataConnection connection,
+            IsolationLevel level,
+            CancellationToken token,
+            Func<AkkaDataConnection, CancellationToken, Task> handler)
+        {
+            var tx = await connection.BeginTransactionAsync(level, token);
+
+            try
+            {
+                await handler(connection, token);
+                await tx.CommitAsync(token);
+            }
+            catch (Exception operationException)
+            {
+                try
+                {
+                    await tx.RollbackAsync(token);
+                }
+                catch (Exception rollbackException)
+                {
+                    // Cleanup failures must not hide the exception the configured policy uses to
+                    // decide whether to run a new transaction attempt.
+                    AttachCleanupException(operationException, rollbackException);
+                }
+
+                try
+                {
+                    await tx.DisposeAsync();
+                }
+                catch (Exception disposeException)
+                {
+                    AttachCleanupException(operationException, disposeException);
+                }
+
+                throw;
+            }
+
+            await tx.DisposeAsync();
+        }
+
+        private static async Task DisposeConnectionAsync(
+            AkkaDataConnection connection,
+            Exception? operationException)
+        {
+            try
+            {
+                await connection.DisposeAsync();
+            }
+            catch (Exception cleanupException) when (operationException is not null)
+            {
+                AttachCleanupException(operationException, cleanupException);
+            }
+        }
+
+        private static void AttachCleanupException(Exception operationException, Exception cleanupException)
+        {
+            try
+            {
+                if (operationException.Data[CleanupExceptionDataKey] is Exception previousCleanupException)
+                {
+                    operationException.Data[CleanupExceptionDataKey] = new AggregateException(
+                        previousCleanupException,
+                        cleanupException);
+                }
+                else
+                {
+                    operationException.Data[CleanupExceptionDataKey] = cleanupException;
+                }
+            }
+            catch
+            {
+                // Exception.Data can be read-only for custom exception implementations.
             }
         }
     }

--- a/src/Akka.Persistence.Sql/Extensions/ConnectionFactoryExtensions.cs
+++ b/src/Akka.Persistence.Sql/Extensions/ConnectionFactoryExtensions.cs
@@ -18,7 +18,15 @@ namespace Akka.Persistence.Sql.Extensions
 {
     public static class ConnectionFactoryExtensions
     {
-        private const string CleanupExceptionDataKey = "Akka.Persistence.Sql.TransactionCleanupException";
+        /// <summary>
+        /// <see cref="Exception.Data"/> key under which cleanup failures (transaction rollback/dispose,
+        /// connection dispose) encountered during a replay-safe transaction retry attempt are attached to
+        /// the primary operation exception. The value is either a single <see cref="Exception"/> or an
+        /// <see cref="AggregateException"/> when more than one cleanup failure was recorded. Cleanup
+        /// failures are never allowed to replace or mask the primary exception, since the configured retry
+        /// policy relies on that exception to decide whether to attempt another transaction.
+        /// </summary>
+        public const string CleanupExceptionDataKey = "Akka.Persistence.Sql.TransactionCleanupException";
 
         public static async Task ExecuteWithTransactionAsync(
             this AkkaPersistenceDataConnectionFactory factory,
@@ -150,7 +158,8 @@ namespace Akka.Persistence.Sql.Extensions
             this AkkaPersistenceDataConnectionFactory factory,
             IsolationLevel level,
             CancellationToken token,
-            Func<AkkaDataConnection, CancellationToken, Task> handler)
+            Func<AkkaDataConnection, CancellationToken, Task> handler,
+            ILoggingAdapter? logger = null)
         {
             if (!factory.HasRetryPolicy)
             {
@@ -158,17 +167,16 @@ namespace Akka.Persistence.Sql.Extensions
                 return;
             }
 
-            AkkaDataConnection? firstConnection = factory.GetRetryScopeConnection(out var retryPolicy);
+            var retryPolicy = factory.TakeReplayRetryPolicy();
 
             async Task ExecuteAttempt(CancellationToken cancellationToken)
             {
-                var connection = Interlocked.Exchange(ref firstConnection, null)
-                    ?? factory.GetRetryScopeConnection(out _);
+                var connection = factory.GetConnectionWithoutRetryPolicy();
                 Exception? operationException = null;
 
                 try
                 {
-                    await ExecuteTransactionAttemptAsync(connection, level, cancellationToken, handler);
+                    await ExecuteTransactionAttemptAsync(connection, level, cancellationToken, handler, logger);
                 }
                 catch (Exception exception)
                 {
@@ -177,36 +185,22 @@ namespace Akka.Persistence.Sql.Extensions
                 }
                 finally
                 {
-                    await DisposeConnectionAsync(connection, operationException);
+                    await DisposeConnectionAsync(connection, operationException, logger);
                 }
             }
 
-            Exception? retryException = null;
-            try
-            {
-                if (retryPolicy is null)
-                    await ExecuteAttempt(token);
-                else
-                    await retryPolicy.ExecuteAsync(ExecuteAttempt, token);
-            }
-            catch (Exception exception)
-            {
-                retryException = exception;
-                throw;
-            }
-            finally
-            {
-                var unusedConnection = Interlocked.Exchange(ref firstConnection, null);
-                if (unusedConnection is not null)
-                    await DisposeConnectionAsync(unusedConnection, retryException);
-            }
+            if (retryPolicy is null)
+                await ExecuteAttempt(token);
+            else
+                await retryPolicy.ExecuteAsync(ExecuteAttempt, token);
         }
 
         private static async Task ExecuteTransactionAttemptAsync(
             AkkaDataConnection connection,
             IsolationLevel level,
             CancellationToken token,
-            Func<AkkaDataConnection, CancellationToken, Task> handler)
+            Func<AkkaDataConnection, CancellationToken, Task> handler,
+            ILoggingAdapter? logger)
         {
             var tx = await connection.BeginTransactionAsync(level, token);
 
@@ -226,6 +220,9 @@ namespace Akka.Persistence.Sql.Extensions
                     // Cleanup failures must not hide the exception the configured policy uses to
                     // decide whether to run a new transaction attempt.
                     AttachCleanupException(operationException, rollbackException);
+                    logger?.Warning(
+                        rollbackException,
+                        "Transaction cleanup failed after a journal operation error; the original operation exception is preserved and remains the primary error.");
                 }
 
                 try
@@ -235,6 +232,9 @@ namespace Akka.Persistence.Sql.Extensions
                 catch (Exception disposeException)
                 {
                     AttachCleanupException(operationException, disposeException);
+                    logger?.Warning(
+                        disposeException,
+                        "Transaction cleanup failed after a journal operation error; the original operation exception is preserved and remains the primary error.");
                 }
 
                 throw;
@@ -245,7 +245,8 @@ namespace Akka.Persistence.Sql.Extensions
 
         private static async Task DisposeConnectionAsync(
             AkkaDataConnection connection,
-            Exception? operationException)
+            Exception? operationException,
+            ILoggingAdapter? logger)
         {
             try
             {
@@ -254,6 +255,9 @@ namespace Akka.Persistence.Sql.Extensions
             catch (Exception cleanupException) when (operationException is not null)
             {
                 AttachCleanupException(operationException, cleanupException);
+                logger?.Warning(
+                    cleanupException,
+                    "Transaction cleanup failed after a journal operation error; the original operation exception is preserved and remains the primary error.");
             }
         }
 

--- a/src/Akka.Persistence.Sql/Journal/Dao/BaseByteArrayJournalDao.cs
+++ b/src/Akka.Persistence.Sql/Journal/Dao/BaseByteArrayJournalDao.cs
@@ -184,7 +184,8 @@ namespace Akka.Persistence.Sql.Journal.Dao
                                     r.PersistenceId == persistenceId)
                             .DeleteAsync(token);
                     }
-                });
+                },
+                Logger);
         }
 
         public async Task<Done> Update(string persistenceId, long sequenceNr, object payload)

--- a/src/Akka.Persistence.Sql/Journal/Dao/BaseByteArrayJournalDao.cs
+++ b/src/Akka.Persistence.Sql/Journal/Dao/BaseByteArrayJournalDao.cs
@@ -126,7 +126,7 @@ namespace Akka.Persistence.Sql.Journal.Dao
             if (maxMarkedDeletion is 0)
                 return;
             
-            await ConnectionFactory.ExecuteWithTransactionAsync(
+            await ConnectionFactory.ExecuteReplaySafeWithTransactionRetryAsync(
                 WriteIsolationLevel,
                 cts.Token,
                 async (connection, token) =>


### PR DESCRIPTION
## Summary

- move the configured LinqToDB retry policy outside the journal delete transaction
- give every retry attempt a fresh connection and transaction
- detach command-level retry inside each attempt so a failed transaction is never reused
- preserve public transaction callback behavior and the exact no-policy path
- preserve the primary operation failure when rollback, transaction disposal, or connection disposal also fails
- limit replay behavior to the audited, idempotent journal delete operation

## Why this is safe

Journal deletion performs transactional and idempotent database work: it marks the boundary row deleted, removes earlier journal rows, upserts compatibility metadata, and removes earlier metadata and tag rows. Replaying the complete operation converges on the same state, including after an ambiguous successful commit.

Retry classification, retry limits, delay, and cancellation remain owned by the configured retry policy. This change adds no provider-specific error classifier or custom retry loop.

## Verification

- delete transaction regression suite: 7/7 passed twice
- forced SQL Server conflict during late metadata work: 10 concurrent delete pairs per run
- adversarial committed-transaction replay leaves journal, metadata, and tag state consistent
- connection cleanup failure cannot mask the retryable operation exception
- all provider end-to-end specifications: 10/10 passed
- main functional suite: 971 passed, 11 intentional skips, 0 failed
- hosting suite: 40/40 passed
- full solution build: succeeded with 0 errors

The full-solution test command also exposed unrelated repository infrastructure issues: the common test library has no runnable apphost, the compatibility SQL Server fixture did not become ready within its timeout, and the benchmark project loads a legacy SQLite plugin missing the current persistence API. These fail before exercising this change.

Fixes #591