### PR TITLE
Bump version to 1.5.70

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-#### 1.5.70-beta1 June 24th 2026 ####
+#### 1.5.70 July 23rd 2026 ####
 
 **New Feature — FromEnd Query Offset**
 
@@ -17,7 +17,9 @@ var allEvents = ReadJournal
 ```
 
 * [Add FromEnd (last-N) query offset support](https://github.com/akkadotnet/Akka.Persistence.Sql/pull/589) - New `Offset.FromEnd(count)` query offset that resolves to the correct concrete start offset by looking up the max journal sequence. Implemented across all database providers (SQL Server, PostgreSQL, MySQL, SQLite).
-* [Bump Akka.NET to 1.5.70-beta1](https://github.com/akkadotnet/akka.net/releases/tag/1.5.70-beta1)
+* [Fix journal delete transaction retry scope](https://github.com/akkadotnet/Akka.Persistence.Sql/pull/592) - Move the configured retry policy outside the journal delete transaction so every retry uses a fresh connection and transaction. Prevents `Task.Delay` from throwing on negative delays and aborting the whole-transaction retry loop.
+* [Bump Akka.NET to 1.5.70](https://github.com/akkadotnet/akka.net/releases/tag/1.5.70)
+* [Bump Akka.Hosting to 1.5.70](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.70)
 
 #### 1.5.67 April 28th 2026 ####
 

--- a/src/Directory.Generated.props
+++ b/src/Directory.Generated.props
@@ -1,8 +1,25 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.5.60.1</VersionPrefix>
-    <PackageReleaseNotes>* [Bump Akka.NET to 1.5.60](https://github.com/akkadotnet/akka.net/releases/tag/1.5.60)
-* [Bump Akka.Hosting to 1.5.60](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.60)
-* [Fix linq2db assembly binding conflict](https://github.com/akkadotnet/Akka.Persistence.Sql/pull/572) - bumped `linq2db` from 5.4.1 to 5.4.1.9 to resolve assembly version mismatch that prevented projects from building when NuGet resolved the newer package version.</PackageReleaseNotes>
+    <VersionPrefix>1.5.70</VersionPrefix>
+    <PackageReleaseNotes>**New Feature — FromEnd Query Offset**
+
+Query the *last N events* by tag using a new `Offset.FromEnd(count)` offset type. Instead of streaming from a known forward offset, you specify how many recent events to return — useful for "get me the last 10 events tagged X" scenarios without knowing the current offset upfront.
+
+```csharp
+// Get the last 3 events tagged "green"
+var lastThree = ReadJournal
+    .CurrentEventsByTag("green", Offset.FromEnd(3))
+    .RunWith(Sink.Seq&lt;EventEnvelope&gt;(), materializer);
+
+// If fewer than 3 events exist, returns all of them
+var allEvents = ReadJournal
+    .CurrentEventsByTag("green", Offset.FromEnd(100))
+    .RunWith(Sink.Seq&lt;EventEnvelope&gt;(), materializer);
+```
+
+* [Add FromEnd (last-N) query offset support](https://github.com/akkadotnet/Akka.Persistence.Sql/pull/589) - New `Offset.FromEnd(count)` query offset that resolves to the correct concrete start offset by looking up the max journal sequence. Implemented across all database providers (SQL Server, PostgreSQL, MySQL, SQLite).
+* [Fix journal delete transaction retry scope](https://github.com/akkadotnet/Akka.Persistence.Sql/pull/592) - Move the configured retry policy outside the journal delete transaction so every retry uses a fresh connection and transaction. Prevents `Task.Delay` from throwing on negative delays and aborting the whole-transaction retry loop.
+* [Bump Akka.NET to 1.5.70](https://github.com/akkadotnet/akka.net/releases/tag/1.5.70)
+* [Bump Akka.Hosting to 1.5.70](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.70)</PackageReleaseNotes>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary

Release **1.5.70** for Akka.Persistence.Sql, incorporating the beta1 features plus post-beta fixes.

## Changes in 1.5.70

### New Feature — FromEnd Query Offset
- [Add FromEnd (last-N) query offset support](https://github.com/akkadotnet/Akka.Persistence.Sql/pull/589) - New `Offset.FromEnd(count)` query offset that resolves to the correct concrete start offset by looking up the max journal sequence. Implemented across all database providers (SQL Server, PostgreSQL, MySQL, SQLite).

### Bug Fixes
- [Fix journal delete transaction retry scope](https://github.com/akkadotnet/Akka.Persistence.Sql/pull/592) - Move the configured retry policy outside the journal delete transaction so every retry uses a fresh connection and transaction.

### Dependency Updates
- Bump Akka.NET to 1.5.70
- Bump Akka.Hosting to 1.5.70
