### PR TITLE
Release 1.5.70.1 with stable Akka dependencies

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+#### 1.5.70.1 July 29th 2026 ####
+
+**Dependency Correction**
+
+* Correct the prerelease Akka.NET package dependencies in `1.5.70` to stable `1.5.70`.
+* Upgrade Akka.Hosting package dependencies from `1.5.67` to stable `1.5.70`.
+
 #### 1.5.70 July 23rd 2026 ####
 
 **New Feature — FromEnd Query Offset**

--- a/src/Directory.Generated.props
+++ b/src/Directory.Generated.props
@@ -1,25 +1,9 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.5.70</VersionPrefix>
-    <PackageReleaseNotes>**New Feature — FromEnd Query Offset**
+    <VersionPrefix>1.5.70.1</VersionPrefix>
+    <PackageReleaseNotes>**Dependency Correction**
 
-Query the *last N events* by tag using a new `Offset.FromEnd(count)` offset type. Instead of streaming from a known forward offset, you specify how many recent events to return — useful for "get me the last 10 events tagged X" scenarios without knowing the current offset upfront.
-
-```csharp
-// Get the last 3 events tagged "green"
-var lastThree = ReadJournal
-    .CurrentEventsByTag("green", Offset.FromEnd(3))
-    .RunWith(Sink.Seq&lt;EventEnvelope&gt;(), materializer);
-
-// If fewer than 3 events exist, returns all of them
-var allEvents = ReadJournal
-    .CurrentEventsByTag("green", Offset.FromEnd(100))
-    .RunWith(Sink.Seq&lt;EventEnvelope&gt;(), materializer);
-```
-
-* [Add FromEnd (last-N) query offset support](https://github.com/akkadotnet/Akka.Persistence.Sql/pull/589) - New `Offset.FromEnd(count)` query offset that resolves to the correct concrete start offset by looking up the max journal sequence. Implemented across all database providers (SQL Server, PostgreSQL, MySQL, SQLite).
-* [Fix journal delete transaction retry scope](https://github.com/akkadotnet/Akka.Persistence.Sql/pull/592) - Move the configured retry policy outside the journal delete transaction so every retry uses a fresh connection and transaction. Prevents `Task.Delay` from throwing on negative delays and aborting the whole-transaction retry loop.
-* [Bump Akka.NET to 1.5.70](https://github.com/akkadotnet/akka.net/releases/tag/1.5.70)
-* [Bump Akka.Hosting to 1.5.70](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.70)</PackageReleaseNotes>
+* Correct the prerelease Akka.NET package dependencies in `1.5.70` to stable `1.5.70`.
+* Upgrade Akka.Hosting package dependencies from `1.5.67` to stable `1.5.70`.</PackageReleaseNotes>
   </PropertyGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <AkkaVersion>1.5.70-beta1</AkkaVersion>
-    <AkkaHostingVersion>1.5.67</AkkaHostingVersion>
+    <AkkaVersion>1.5.70</AkkaVersion>
+    <AkkaHostingVersion>1.5.70</AkkaHostingVersion>
     <FluentMigratorVersion>5.2.0</FluentMigratorVersion>
     <SqliteVersion>1.0.118</SqliteVersion>
     <MicrosoftSqliteVersion>8.0.7</MicrosoftSqliteVersion>


### PR DESCRIPTION
## Summary

- replace the Akka.NET 1.5.70-beta1 package references left in the 1.5.70 release with stable 1.5.70
- upgrade Akka.Hosting dependencies from 1.5.67 to 1.5.70
- version the dependency correction as 1.5.70.1 and update package release notes

The Offset.FromEnd implementation itself already shipped in 1.5.70; this PR only corrects its package dependency metadata.

## Validation

- Release solution build
- Akka.Persistence.Sql.Hosting.Tests: 40 passed
- FromEndOffsetSpec provider matrix: 110 passed
- packed Akka.Persistence.Sql 1.5.70.1 and Akka.Persistence.Sql.Hosting 1.5.70.1
- audited nuspec dependencies: stable Akka.NET 1.5.70, no beta references